### PR TITLE
BACKLOG-11453 : fix parentfolder.zip naming when selecting only one i…

### DIFF
--- a/src/javascript/ContentManager/actions/zipUnzip/zipAction.jsx
+++ b/src/javascript/ContentManager/actions/zipUnzip/zipAction.jsx
@@ -11,7 +11,7 @@ export default composeActions(requirementsAction, withNotificationContextAction,
         context.initRequirements({});
     },
     onClick: context => {
-        let name = context.node ? context.node.name : context.nodes[0].parent.name;
+        let name = context.node ? context.node.name : (context.nodes.length > 1 ? context.nodes[0].parent.name : context.nodes[0].name);
         let nameWithoutExtension = removeFileExtension(name);
         let paths = context.node ? [context.node.path] : context.paths;
         let uuid = context.node ? context.node.uuid : context.nodes[0].uuid;


### PR DESCRIPTION
…tem to zip

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-11453

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
fixed bug
