### PR TITLE
BACKLOG-12388 : skip the root node and have 1st level node displayed …

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTrees/ContentTree/ContentTree.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTrees/ContentTree/ContentTree.jsx
@@ -5,6 +5,7 @@ import {PredefinedFragments} from '@jahia/apollo-dx';
 import {TreeView} from '@jahia/moonstone';
 import gql from 'graphql-tag';
 import {registry} from '@jahia/ui-extender';
+import {File} from '@jahia/moonstone/dist/icons';
 
 const PickerItemsFragment = {
     mixinTypes: {
@@ -41,7 +42,7 @@ const PickerItemsFragment = {
 
 function getIcon(mode) {
     let registryItem = registry.find({type: 'accordionItem', target: 'jcontent', key: mode});
-    const Icon = registryItem[0].icon;
+    const Icon = registry[0] ? registryItem[0].icon : <File/>;
     return <Icon.type {...Icon.props} size="small"/>;
 }
 
@@ -68,15 +69,6 @@ function convertPathsToTree(pickerEntries, mode) {
         return tree;
     }
 
-    let rootElement = {
-        id: pickerEntries[0].path,
-        label: pickerEntries[0].node.displayName,
-        hasChildren: pickerEntries[0].hasChildren,
-        parent: getParentPath(pickerEntries[0].path),
-        iconStart: getIcon(mode),
-        children: []
-    };
-    tree.push(rootElement);
     for (let i = 1; i < pickerEntries.length; i++) {
         let parentPath = getParentPath(pickerEntries[i].path);
         let element = {
@@ -90,6 +82,8 @@ function convertPathsToTree(pickerEntries, mode) {
         let parent = findInTree(tree, parentPath);
         if (parent !== undefined) {
             parent.children.push(element);
+        } else if (!findInTree(tree, element.id)) {
+            tree.push(element);
         }
     }
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTrees/ContentTrees.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTrees/ContentTrees.jsx
@@ -47,6 +47,7 @@ export class ContentTrees extends React.Component {
                     <div className={classes.list}>
                         {
                             _.map(contentTreeConfigs, contentTreeConfig => {
+                                openPaths.push(path);
                                 return (
                                     <ContentTree key={contentTreeConfig.key}
                                                  container={this.container}


### PR DESCRIPTION
…on the tree

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12388

## Description

skip the root node, but needed to explicitly open the 1st level node after the site, because the picker would not provide all paths and we'll have empty tree when we first browse to a mode without any path
<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
