### PR TITLE
BACKLOG-12332: Fix CSS formatting

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.scss
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.scss
@@ -1,8 +1,8 @@
 .contentStatuses {
-  display: inline-flex;
-  flex-direction: row;
+    display: inline-flex;
+    flex-direction: row;
 
-  & > *:not(:first-child) {
-    margin-left: var(--spacing-nano);
-  }
+    & > *:not(:first-child) {
+        margin-left: var(--spacing-nano);
+    }
 }


### PR DESCRIPTION
Unexpected formatting breaks the build since stylelint has been added in between.