### PR TITLE
BACKLOG-12332: Don't show a 'Warning' chip when a content is UNPUBLISHED

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.jsx
@@ -29,6 +29,8 @@ const ContentStatuses = ({node, isDisabled, language, uilang}) => {
             statuses.new = true;
         } else if (publicationStatus === JContentConstants.availablePublicationStatuses.PUBLISHED) {
             statuses.published = true;
+        } else if (publicationStatus === JContentConstants.availablePublicationStatuses.UNPUBLISHED) {
+            statuses.published = false;
         } else if (publicationStatus && publicationStatus !== JContentConstants.availablePublicationStatuses.MARKED_FOR_DELETION) {
             statuses.warning = true;
         }

--- a/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.test.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.test.jsx
@@ -17,6 +17,18 @@ describe('ContentStatuses', () => {
         expect(wrapper.find('Status')).toHaveLength(1);
     });
 
+    it('should only render a \'Not Published\' status when content is unpublished', () => {
+        const node = {
+            aggregatedPublicationInfo: {
+                publicationStatus: 'UNPUBLISHED'
+            }
+        };
+        const wrapper = shallow(<ContentStatuses {...defaultProps} node={node}/>);
+
+        expect(wrapper.containsMatchingElement(<Status type="notPublished"/>)).toBeTruthy();
+        expect(wrapper.find('Status')).toHaveLength(1);
+    });
+
     it('should only render a \'Published\' status', () => {
         const node = {
             aggregatedPublicationInfo: {


### PR DESCRIPTION
UNPUBLISHED status should only trigger the rendering of 'Not Published' chip.

https://jira.jahia.org/browse/BACKLOG-12332