### PR TITLE
BACKLOG-12332: Fix incorrect usage of UI language instead of site one

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.container.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.container.jsx
@@ -16,7 +16,7 @@ const ContentStatusesContainer = () => {
     const {data, error} = useQuery(GetContentStatuses, {
         variables: {
             path: path,
-            language: uilang
+            language: language
         }
     });
 


### PR DESCRIPTION
UI language was used as an argument to GetContentStatuses query instead of site language.

https://jira.jahia.org/browse/BACKLOG-12332