### PR TITLE
BACKLOG-12332: Fix status tooltip of contents marked for deletion

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.gql-queries.js
@@ -42,6 +42,14 @@ export const GetContentStatuses = gql`
                 wipLangs: property(name: "j:workInProgressLanguages") {
                     values
                 }
+                ancestors(fieldFilter: {filters: {fieldName: "deleted", evaluation: NOT_EMPTY}}) {
+                    deleted:property(name: "j:deletionDate") {
+                        value
+                    }
+                    deletedBy: property(name: "j:deletionUser") {
+                        value
+                    }
+                }
             }
         }
     }

--- a/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.jsx
@@ -4,7 +4,7 @@ import {useTranslation} from 'react-i18next';
 
 import JContentConstants from '../../JContent.constants';
 import {isMarkedForDeletion, isWorkInProgress} from '../../JContent.utils';
-import {tooltip} from './ContentStatuses.utils';
+import {getTooltip} from './ContentStatuses.utils';
 import styles from './ContentStatuses.scss';
 import Status from './Status';
 
@@ -37,7 +37,7 @@ const ContentStatuses = ({node, isDisabled, language, uilang}) => {
     }
 
     const renderStatus = type => (
-        <Status type={type} isDisabled={isDisabled} tooltip={tooltip(type, node, uilang, t)}/>
+        <Status type={type} isDisabled={isDisabled} tooltip={getTooltip(node, type, t, uilang)}/>
     );
     return (
         <div className={styles.contentStatuses}>
@@ -86,6 +86,14 @@ ContentStatuses.propTypes = {
         }),
         wipLangs: PropTypes.shape({
             values: PropTypes.arrayOf(PropTypes.string)
+        }),
+        ancestors: PropTypes.shape({
+            deleted: PropTypes.shape({
+                value: PropTypes.string
+            }),
+            deletedBy: PropTypes.shape({
+                value: PropTypes.string
+            })
         })
     }).isRequired,
     language: PropTypes.string.isRequired,

--- a/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.test.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.test.jsx
@@ -17,7 +17,7 @@ describe('ContentStatuses', () => {
         expect(wrapper.find('Status')).toHaveLength(1);
     });
 
-    it('should only render a \'Not Published\' status when content is unpublished', () => {
+    it('should render a \'Not Published\' status when unpublished', () => {
         const node = {
             aggregatedPublicationInfo: {
                 publicationStatus: 'UNPUBLISHED'
@@ -29,7 +29,7 @@ describe('ContentStatuses', () => {
         expect(wrapper.find('Status')).toHaveLength(1);
     });
 
-    it('should only render a \'Published\' status', () => {
+    it('should only render a \'Published\' status when published', () => {
         const node = {
             aggregatedPublicationInfo: {
                 publicationStatus: 'PUBLISHED'
@@ -42,7 +42,7 @@ describe('ContentStatuses', () => {
         expect(wrapper.find('Status')).toHaveLength(1);
     });
 
-    it('should render a \'Locked\' status', () => {
+    it('should render a \'Locked\' status when locked', () => {
         const node = {
             lockOwner: {
                 value: 'me'
@@ -56,7 +56,7 @@ describe('ContentStatuses', () => {
         expect(wrapper.find('Status')).toHaveLength(2);
     });
 
-    it('should render a \'Marked for deletion\' status', () => {
+    it('should render a \'Marked for deletion\' status when deleted', () => {
         const node = {
             mixinTypes: [{
                 name: 'jmix:markedForDeletion'
@@ -70,7 +70,7 @@ describe('ContentStatuses', () => {
         expect(wrapper.find('Status')).toHaveLength(2);
     });
 
-    it('should render a \'Modified\' status', () => {
+    it('should render a \'Modified\' status when modified', () => {
         const node = {
             aggregatedPublicationInfo: {
                 publicationStatus: 'MODIFIED'
@@ -84,7 +84,7 @@ describe('ContentStatuses', () => {
         expect(wrapper.find('Status')).toHaveLength(2);
     });
 
-    it('should render a \'New\' status', () => {
+    it('should render a \'New\' status when never published', () => {
         const node = {
             aggregatedPublicationInfo: {
                 publicationStatus: 'NOT_PUBLISHED'
@@ -112,7 +112,7 @@ describe('ContentStatuses', () => {
         expect(wrapper.find('Status')).toHaveLength(2);
     });
 
-    it('should render a \'Work in progress\' status', () => {
+    it('should render a \'Work in progress\' status when is work in progress in all languages', () => {
         const node = {
             wipStatus: {value: 'ALL_CONTENT'}
         };
@@ -124,7 +124,7 @@ describe('ContentStatuses', () => {
         expect(wrapper.find('Status')).toHaveLength(2);
     });
 
-    it('should also render a \'Work in progress\' status', () => {
+    it('should render a \'Work in progress\' status when is work in progress in current language', () => {
         const node = {
             wipStatus: {value: 'LANGUAGES'},
             wipLangs: {values: ['fr']}
@@ -137,7 +137,7 @@ describe('ContentStatuses', () => {
         expect(wrapper.find('Status')).toHaveLength(2);
     });
 
-    it('should not render a \'Work in progress\' status', () => {
+    it('should not render a \'Work in progress\' status when is work in progress in another language', () => {
         const node = {
             wipStatus: {value: 'LANGUAGES'},
             wipLangs: {values: ['fr', 'gr']}


### PR DESCRIPTION
* Tooltip text of Marked for deletion status for child contents of a deleted one were missing deletion date and user name
* Also fixed incorrect tooltip text from Warning status when publication status is 'mandatoryLanguageValid'
* Rewrote method used to compute status tooltips

https://jira.jahia.org/browse/BACKLOG-12332