### PR TITLE
BACKLOG-12716: Update buttons size to default in action bar

### DIFF
--- a/src/javascript/JContent/ContentRoute/ToolBar/BrowseControlBar/BrowseControlBar.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/BrowseControlBar/BrowseControlBar.jsx
@@ -24,7 +24,7 @@ const styles = theme => ({
     }
 });
 
-const ButtonRenderer = getButtonRenderer({size: 'small', variant: 'ghost'});
+const ButtonRenderer = getButtonRenderer({size: 'default', variant: 'ghost'});
 
 export class BrowseControlBar extends React.Component {
     isRootNode() {
@@ -52,7 +52,7 @@ export class BrowseControlBar extends React.Component {
                 <React.Fragment>
                     <DisplayActions target="headerPrimaryActions" context={{path: path}} render={ButtonRenderer}/>
                     <Button variant="ghost"
-                            size="small"
+                            size="default"
                             label={t('jcontent:label.contentManager.refresh')}
                             icon={<Reload/>}
                             data-cm-role="content-list-refresh-button"

--- a/src/javascript/utils/getButtonRenderer.jsx
+++ b/src/javascript/utils/getButtonRenderer.jsx
@@ -17,7 +17,7 @@ export const getButtonRenderer = ({labelStyle, ...props} = {}) => {
         return (context.isVisible !== false &&
             <Button data-sel-role={context.key}
                     label={t(label, context.buttonLabelParams)}
-                    icon={context.buttonIcon && context.buttonIcon}
+                    icon={context.buttonIcon}
                     disabled={context.enabled === false || context.disabled}
                     onClick={e => {
                         e.stopPropagation();

--- a/src/javascript/utils/getButtonRenderer.jsx
+++ b/src/javascript/utils/getButtonRenderer.jsx
@@ -1,6 +1,5 @@
 import {useTranslation} from 'react-i18next';
 import {Button} from '@jahia/moonstone';
-import {toIconComponent} from '@jahia/react-material';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -18,7 +17,7 @@ export const getButtonRenderer = ({labelStyle, ...props} = {}) => {
         return (context.isVisible !== false &&
             <Button data-sel-role={context.key}
                     label={t(label, context.buttonLabelParams)}
-                    icon={context.buttonIcon && toIconComponent(context.buttonIcon)}
+                    icon={context.buttonIcon && context.buttonIcon}
                     disabled={context.enabled === false || context.disabled}
                     onClick={e => {
                         e.stopPropagation();


### PR DESCRIPTION
Also removed unnecessary call to react-material's toIconComponent from getButtonRenderer.jsx

https://jira.jahia.org/browse/BACKLOG-12716