### PR TITLE
BACKLOG-12719: Update icon size

### DIFF
--- a/src/javascript/JContent/ContentRoute/ToolBar/FileModeSelector/FileModeSelector.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/FileModeSelector/FileModeSelector.jsx
@@ -75,7 +75,7 @@ export const FileModeSelector = () => {
                     aria-selected={select === v}
                     color={select === v ? 'accent' : 'default'}
                     title={t('jcontent:label.contentManager.filesGrid.' + v)}
-                    size="big"
+                    size="default"
                     variant="ghost"
                     icon={icons[v]}
                     onClick={() => handleChange(v)}


### PR DESCRIPTION
The icon size now matches the one use for the buttons located on the left side of the header.

https://jira.jahia.org/browse/BACKLOG-12719