### PR TITLE
BACKLOG-12530: Fix non visible node selected in Navigation/TreeView

### DIFF
--- a/src/javascript/JContent/ContentTree/ContentTree.jsx
+++ b/src/javascript/JContent/ContentTree/ContentTree.jsx
@@ -27,6 +27,14 @@ export const ContentTree = ({lang, siteKey, path, openPaths, setPath, openPath, 
         hideRoot: item.config.hideRoot
     });
 
+    // If path is root one but root is hidden, then select its first child
+    if (((path === rootPath) || (path === rootPath + '/')) && item.config.hideRoot && treeEntries.length > 0) {
+        const first = treeEntries[0];
+        first.selected = true;
+        path = first.path;
+        setPath(path);
+    }
+
     let contextualMenu = React.createRef();
 
     return (


### PR DESCRIPTION
Root node of pages is hidden, thus when no specific page is selected then there is no visible selected element in the tree view and the header display information about the hidden parent (ie. the site).

From now on, when the root element is selected and this root is not visible, then selection will be forced to its first child (if any) instead.

https://jira.jahia.org/browse/BACKLOG-12530