### PR TITLE
BACKLOG-12802: Remove unactive languages from language switcher

### DIFF
--- a/src/javascript/JContent/AppLayout/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.jsx
+++ b/src/javascript/JContent/AppLayout/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.jsx
@@ -42,9 +42,9 @@ export const LanguageSwitcher = ({
             className={styles.languageSwitcher}
             label={lang}
             value={lang}
-            data={siteInfo.languages.map(l => ({label: l.language, value: l.language}))}
+            data={siteInfo.languages.filter(l => l.activeInEdit).map(l => ({label: l.language, value: l.language}))}
             onChange={(e, item) => {
-                onSelectLanguageHandler(item.label);
+                onSelectLanguageHandler(item.value);
                 return true;
             }}
         />


### PR DESCRIPTION
Languages that are not active for edition should not be selectable from the language switcher.

https://jira.jahia.org/browse/BACKLOG-12802