### PR TITLE
BACKLOG-12826 adapt the size of the dropdown menu so it fits long elements

### DIFF
--- a/src/javascript/JContent/actions/searchAction/SearchDialog/BasicSearch/BasicSearch.scss
+++ b/src/javascript/JContent/actions/searchAction/SearchDialog/BasicSearch/BasicSearch.scss
@@ -12,4 +12,8 @@
 
 .dropdown {
     border: 1px solid #e0e6ea;
+
+    > menu {
+        max-width: 500px !important;
+    }
 }


### PR DESCRIPTION
## JIRA
https://jira.jahia.org/browse/BACKLOG-12826

## Description
adapt the size of the dropdown menu so it fits long elements
