### PR TITLE
BACKLOG-12877 : Fixed initial loading of additional accordion, fixed …

### DIFF
--- a/src/javascript/JContent/AdditionalAppsTree/AdditionalAppsTree.jsx
+++ b/src/javascript/JContent/AdditionalAppsTree/AdditionalAppsTree.jsx
@@ -1,26 +1,44 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {TreeView} from '@jahia/moonstone';
 import {useDispatch, useSelector} from 'react-redux';
 import {cmGoto} from '../JContent.redux';
 import {useAdminRouteTreeStructure} from '@jahia/ui-extender';
-import {useHistory} from 'react-router';
 import {useNodeInfo} from '@jahia/data-helper';
 import {useTranslation} from 'react-i18next';
 import PropTypes from 'prop-types';
 
 export const AdditionalAppsTree = ({item, target}) => {
-    const site = useSelector(state => state.site);
+    const {site, path} = useSelector(state => ({site: state.site, path: state.jcontent.path}));
     const dispatch = useDispatch();
     const {t} = useTranslation();
-    const history = useHistory();
 
-    let selected = history.location.pathname.split('/').pop();
+    const selected = path.substr(1);
 
-    const {tree, defaultOpenedItems, allPermissions} = useAdminRouteTreeStructure(target, selected);
+    const {tree, routes, defaultOpenedItems, allPermissions} = useAdminRouteTreeStructure(target, selected);
 
-    const {node, loading, error} = useNodeInfo({path: '/sites/' + site}, {getPermissions: allPermissions, getSiteInstalledModules: true});
+    const {node, loading, error} = useNodeInfo({path: '/sites/' + site}, {
+        getPermissions: allPermissions,
+        getSiteInstalledModules: true
+    });
 
-    if (loading || error) {
+    let switchSelection;
+    if (!loading && !error && selected === '') {
+        const firstItem = routes.find(route => route.isSelectable &&
+            (route.requiredPermission === undefined || node[route.requiredPermission] !== false) &&
+            (route.requireModuleInstalledOnSite === undefined || node.site.installedModulesWithAllDependencies.indexOf(route.requireModuleInstalledOnSite) > -1)
+        );
+        if (firstItem) {
+            switchSelection = firstItem.key;
+        }
+    }
+
+    useEffect(() => {
+        if (switchSelection) {
+            dispatch(cmGoto({path: '/' + switchSelection}));
+        }
+    }, [dispatch, switchSelection]);
+
+    if (loading || error || switchSelection) {
         return false;
     }
 
@@ -35,17 +53,20 @@ export const AdditionalAppsTree = ({item, target}) => {
         }))
         .getData();
 
-    if (tree && tree.length !== 0) {
+    if (selected && tree && tree.length !== 0) {
         return (
             <TreeView isReversed
                       data={data}
                       selectedItems={[selected]}
                       defaultOpenedItems={defaultOpenedItems}
-                      onClickItem={app => app.isSelectable ? dispatch(cmGoto({mode: item.key, path: '/' + app.id})) : false}/>
+                      onClickItem={app => app.isSelectable ? dispatch(cmGoto({
+                          mode: item.key,
+                          path: '/' + app.id
+                      })) : false}/>
         );
     }
 
-    return null;
+    return false;
 };
 
 AdditionalAppsTree.propTypes = {

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx
@@ -23,7 +23,7 @@ import {cmRemoveSelection, cmSwitchSelection} from './contentSelection.redux';
 import {setModificationHook} from './ContentLayout.utils';
 import {cmSetPreviewSelection} from '../../preview.redux';
 import ContentLayout from './ContentLayout';
-import {setRefetcher, refetchTypes, unsetRefetcher} from '../../JContent.refetches';
+import {refetchTypes, setRefetcher, unsetRefetcher} from '../../JContent.refetches';
 
 const contentQueryHandlerByMode = mode => {
     switch (mode) {
@@ -183,6 +183,17 @@ export const ContentLayoutContainer = ({
     };
 
     useEffect(() => {
+        if (data && data.jcr && data.jcr.nodeByPath) {
+            // When new results have been loaded, use them for rendering.
+            let nodeTypeName = data.jcr.nodeByPath.primaryNodeType.name;
+            let isSub = nodeTypeName !== 'jnt:page' && nodeTypeName !== 'jnt:contentFolder' && nodeTypeName !== 'jnt:virtualsite';
+            if (!isSub && params.sub && params.sub === true) {
+                setPath(path, {sub: false});
+            } else if (isSub && (!params.sub || params.sub === false)) {
+                setPath(path, {sub: true});
+            }
+        }
+
         setRefetcher(refetchTypes.CONTENT_DATA, {
             query: layoutQuery,
             queryParams: layoutQueryParams,
@@ -220,17 +231,6 @@ export const ContentLayoutContainer = ({
     if (loading) {
         // While loading new results, render current ones loaded during previous render invocation (if any).
     } else {
-        if (data.jcr && data.jcr.nodeByPath) {
-            // When new results have been loaded, use them for rendering.
-            let nodeTypeName = data.jcr.nodeByPath.primaryNodeType.name;
-            let isSub = nodeTypeName !== 'jnt:page' && nodeTypeName !== 'jnt:contentFolder' && nodeTypeName !== 'jnt:virtualsite';
-            if (!isSub && params.sub && params.sub === true) {
-                setPath(path, {sub: false});
-            } else if (isSub && (!params.sub || params.sub === false)) {
-                setPath(path, {sub: true});
-            }
-        }
-
         currentResult = queryHandler.getResultsPath(data);
     }
 

--- a/src/javascript/JContent/ContentTree/ContentTree.jsx
+++ b/src/javascript/JContent/ContentTree/ContentTree.jsx
@@ -8,7 +8,7 @@ import {PickerItemsFragment} from './ContentTree.gql-fragments';
 import {TreeView} from '@jahia/moonstone';
 import {ContextualMenu} from '@jahia/ui-extender';
 import {convertPathsToTree} from './ContentTree.utils';
-import {setRefetcher, refetchTypes, unsetRefetcher} from '../JContent.refetches';
+import {refetchTypes, setRefetcher, unsetRefetcher} from '../JContent.refetches';
 
 export const ContentTree = ({lang, siteKey, path, openPaths, setPath, openPath, closePath, item}) => {
     const rootPath = '/sites/' + siteKey + item.config.rootPath;
@@ -28,6 +28,20 @@ export const ContentTree = ({lang, siteKey, path, openPaths, setPath, openPath, 
         hideRoot: item.config.hideRoot
     });
 
+    let switchPath;
+    // If path is root one but root is hidden, then select its first child
+    if (((path === rootPath) || (path === rootPath + '/')) && item.config.hideRoot && treeEntries.length > 0) {
+        const first = treeEntries[0];
+        first.selected = true;
+        switchPath = first.path;
+    }
+
+    useEffect(() => {
+        if (switchPath) {
+            setPath(switchPath);
+        }
+    }, [setPath, switchPath]);
+
     useEffect(() => {
         setRefetcher(refetchTypes.CONTENT_TREE, {
             refetch: refetch
@@ -36,14 +50,6 @@ export const ContentTree = ({lang, siteKey, path, openPaths, setPath, openPath, 
             unsetRefetcher(refetchTypes.CONTENT_TREE);
         };
     });
-
-    // If path is root one but root is hidden, then select its first child
-    if (((path === rootPath) || (path === rootPath + '/')) && item.config.hideRoot && treeEntries.length > 0) {
-        const first = treeEntries[0];
-        first.selected = true;
-        path = first.path;
-        setPath(path);
-    }
 
     let contextualMenu = React.createRef();
 

--- a/src/javascript/JContent/JContent.accordion-items.jsx
+++ b/src/javascript/JContent/JContent.accordion-items.jsx
@@ -84,10 +84,7 @@ export const jContentAccordionItems = registry => {
         targets: ['jcontent:80'],
         icon: <Setting/>,
         label: 'label.contentManager.navigation.apps',
-        defaultPath: () => {
-            const availableRoutes = registry.find({type: 'adminRoute', target: 'jcontent'});
-            return '/' + availableRoutes[0].key;
-        },
+        defaultPath: () => '/',
         render: v => <AdditionalAppsTree target="jcontent" item={v.item}/>,
         routeRender: v => <AdditionalAppsRoute target="jcontent" match={v.match}/>,
         config: {

--- a/src/javascript/JContent/JContent.jsx
+++ b/src/javascript/JContent/JContent.jsx
@@ -4,10 +4,12 @@ import {LayoutModule} from '@jahia/moonstone';
 import ContentNavigation from './ContentNavigation';
 import {Route, Switch} from 'react-router';
 import {ProgressPaper} from '@jahia/design-system-kit';
+import {useSelector} from 'react-redux';
 
 export const JContent = () => {
     const routes = registry.find({type: 'route', target: 'jcontent'});
-    const accordionItems = registry.find({type: 'accordionItem', target: 'jcontent'});
+    const mode = useSelector(state => state.jcontent.mode);
+    const item = registry.get('accordionItem', mode);
 
     return (
         <LayoutModule
@@ -22,13 +24,13 @@ export const JContent = () => {
                                    component={r.component}
                             />
                         ))}
-                        {accordionItems.map(item => (
+                        {item && (
                             <Route key={item.key}
                                    path={'/jcontent/:siteKey/:lang/' + item.key}
                                    render={item.routeRender}
                                    component={item.routeComponent}
                             />
-                        ))}
+                        )}
                     </Switch>
                 </Suspense>
             }


### PR DESCRIPTION
…loading and warning issue

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12877

## Description

- Fixed initial opening of additional tab : takes the first available item, depending on permissions
- Removed state update during render in tree and contentlayout, use effects
- Added a single redux action for changing path/mode/params at the same time to avoid back&forth with the listener leading to inconsistent states
- Removed routes that are not in the current mode, as the url is updated after the mode/path in redux , which lead component trying to render in another mode and executing queries with invalid parameters

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
