### PR TITLE
[BACKLOG-12842] Add commands to install a specific version of Node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,21 @@ references:
     attach_workspace:
       at: .
 
+commands:
+  warmup_on_machine:
+    description: "Update or install specific version of libraries"
+    steps:
+      - run:
+          name: Update Node.js and npm
+          command: |
+            curl -sSL "https://nodejs.org/dist/v12.16.1/node-v12.16.1-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v12.16.1-linux-x64/bin/node
+            curl https://www.npmjs.com/install.sh | sudo bash
+      - run:
+          name: Check current version of node
+          command: |
+            node -v
+            npm -v
+
 jobs:
   install:
     <<: *workdir
@@ -23,6 +38,7 @@ jobs:
 
     steps:
       - checkout
+      - warmup_on_machine
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "pom.xml" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,8 @@ jobs:
 
     docker: # run the steps with Docker
       - image: circleci/openjdk:8-jdk-stretch
+      
+    resource_class: large
 
     steps:
       - checkout


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12842

## Description
The last runs have shown that the Node version installed on the openjdk8 docker image of CircleCI was not the right one