### PR TITLE
Optimize the CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
       - run:
           name: Maven call
           command: |
-          if [[ "${CIRCLE_BRANCH}" == "<< parameters.branch_to_deploy >>" ]]
+          if [[ "${CIRCLE_BRANCH}" == "<< parameters.branch_to_deploy >>" ]];
           then
             mvn -s .circleci/.circleci.settings.xml clean install deploy
           else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,12 @@ commands:
       - run:
           name: Maven call
           command: |
-          if [[ "${CIRCLE_BRANCH}" == "<< parameters.branch_to_deploy >>" ]];
-          then
-            mvn -s .circleci/.circleci.settings.xml clean install deploy
-          else
-            mvn -s .circleci/.circleci.settings.xml clean install
-          fi
+            if [[ "${CIRCLE_BRANCH}" == "<< parameters.branch_to_deploy >>" ]];
+            then
+              mvn -s .circleci/.circleci.settings.xml clean install deploy
+            else
+              mvn -s .circleci/.circleci.settings.xml clean install
+            fi
 
 jobs:
   install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
       - checkout
       - run_pre_mvn_tasks
       - run_maven:
-        deploy_at_the_end: false
+          deploy_at_the_end: false
       - run_post_mvn_tasks
       
   install_and_deploy:
@@ -84,7 +84,7 @@ jobs:
       - checkout
       - run_pre_mvn_tasks
       - run_maven:
-        deploy_at_the_end: true
+          deploy_at_the_end: true
       - run_post_mvn_tasks
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,24 +14,35 @@ references:
     attach_workspace:
       at: .
 
-jobs:
-  install:
-    <<: *workdir
-
-    docker: # run the steps with Docker
-      - image: circleci/openjdk:8-jdk-stretch
-   
-    resource_class: large
-
+commands:
+  run_pre_mvn_tasks:
+    description:
     steps:
-      - checkout
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "pom.xml" }}
             # fallback to using the latest cache if no exact match is found
             - v2-dependencies-
-      - run: mvn -s .circleci/.circleci.settings.xml clean install
+  run_maven:
+    description:
+    parameters:
+        deploy_at_the_end:
+          type: boolean
+          default: false
+    steps:
       # Built module is stored in: /home/circleci/source/repo/repo/api/target/jcontent-2.0.0-SNAPSHOT.jar
+      - when:
+          condition: << parameters.deploy_at_the_end >>
+          steps:
+            - run: mvn -s .circleci/.circleci.settings.xml clean install deploy
+      - unless:
+          condition: << parameters.deploy_at_the_end >>
+          steps:
+            - run: mvn -s .circleci/.circleci.settings.xml clean install
+
+  run_post_mvn_tasks:
+    description:
+    steps:
       - save_cache:
           paths:
             - ~/.m2
@@ -44,15 +55,37 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts/
       - *persist-workspace
-  deploy:
+
+jobs:
+  install:
     <<: *workdir
 
     docker: # run the steps with Docker
       - image: circleci/openjdk:8-jdk-stretch
-    
+   
+    resource_class: large
+
     steps:
-      - *attach-workspace
-      - run: mvn -s .circleci/.circleci.settings.xml deploy
+      - checkout
+      - run_pre_mvn_tasks
+      - run_maven:
+        deploy_at_the_end: false
+      - run_post_mvn_tasks
+      
+  install_and_deploy:
+    <<: *workdir
+
+    docker: # run the steps with Docker
+      - image: circleci/openjdk:8-jdk-stretch
+   
+    resource_class: large
+
+    steps:
+      - checkout
+      - run_pre_mvn_tasks
+      - run_maven:
+        deploy_at_the_end: true
+      - run_post_mvn_tasks
 
 workflows:
   version: 2
@@ -60,10 +93,11 @@ workflows:
     jobs:
       - install:
           context: QA_ENVIRONMENT
-      - deploy:
+          filters:
+            branches:
+              ignore: master
+      - install_and_deploy:
           context: QA_ENVIRONMENT
-          requires:
-            - install
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,34 +15,41 @@ references:
       at: .
 
 commands:
-  run_pre_mvn_tasks:
+  run_maven:
     description:
+    parameters:
+        branch_to_deploy:
+          type: string
+          default: "master"
     steps:
+      # Built module is stored in: /home/circleci/source/repo/repo/api/target/jcontent-2.0.0-SNAPSHOT.jar
+      - run:
+          name: Maven call
+          command: |
+          if [[ "${CIRCLE_BRANCH}" == "<< parameters.branch_to_deploy >>" ]]
+          then
+            mvn -s .circleci/.circleci.settings.xml clean install deploy
+          else
+            mvn -s .circleci/.circleci.settings.xml clean install
+          fi
+
+jobs:
+  install:
+    <<: *workdir
+
+    docker: # run the steps with Docker
+      - image: circleci/openjdk:8-jdk-stretch
+   
+    resource_class: large
+
+    steps:
+      - checkout
       - restore_cache:
           keys:
             - v2-dependencies-{{ checksum "pom.xml" }}
             # fallback to using the latest cache if no exact match is found
             - v2-dependencies-
-  run_maven:
-    description:
-    parameters:
-        deploy_at_the_end:
-          type: boolean
-          default: false
-    steps:
-      # Built module is stored in: /home/circleci/source/repo/repo/api/target/jcontent-2.0.0-SNAPSHOT.jar
-      - when:
-          condition: << parameters.deploy_at_the_end >>
-          steps:
-            - run: mvn -s .circleci/.circleci.settings.xml clean install deploy
-      - unless:
-          condition: << parameters.deploy_at_the_end >>
-          steps:
-            - run: mvn -s .circleci/.circleci.settings.xml clean install
-
-  run_post_mvn_tasks:
-    description:
-    steps:
+      - run_maven
       - save_cache:
           paths:
             - ~/.m2
@@ -56,48 +63,9 @@ commands:
           path: /tmp/artifacts/
       - *persist-workspace
 
-jobs:
-  install:
-    <<: *workdir
-
-    docker: # run the steps with Docker
-      - image: circleci/openjdk:8-jdk-stretch
-   
-    resource_class: large
-
-    steps:
-      - checkout
-      - run_pre_mvn_tasks
-      - run_maven:
-          deploy_at_the_end: false
-      - run_post_mvn_tasks
-      
-  install_and_deploy:
-    <<: *workdir
-
-    docker: # run the steps with Docker
-      - image: circleci/openjdk:8-jdk-stretch
-   
-    resource_class: large
-
-    steps:
-      - checkout
-      - run_pre_mvn_tasks
-      - run_maven:
-          deploy_at_the_end: true
-      - run_post_mvn_tasks
-
 workflows:
   version: 2
   build:
     jobs:
       - install:
           context: QA_ENVIRONMENT
-          filters:
-            branches:
-              ignore: master
-      - install_and_deploy:
-          context: QA_ENVIRONMENT
-          filters:
-            branches:
-              only: master


### PR DESCRIPTION
where the parameter allow to add (or not) the deploy step at the end

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12842

## Description

As the "mvn deploy" is also running the "install" tasks, having 2 different jobs do not optimize the execution on master. So the idea here is to use a command with a parameter giving the possibility to add the "deploy" step at the end. Note that I had 2 create 2 jobs using almost the same structure because I did not find how to use the branch as a parameter in a workflow job
