### PR TITLE
BACKLOG-12964 : make the separator invisible when there is no actions…

### DIFF
--- a/src/javascript/JContent/ContentRoute/ToolBar/ToolBar.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/ToolBar.jsx
@@ -36,7 +36,7 @@ export const ToolBar = () => {
                 </Typography>
                 <div className={styles.spacer}/>
                 <Button icon={<Cancel/>} variant="ghost" size="small" onClick={() => dispatch(cmClearSelection())}/>
-                <div>
+                <div className="flexRow">
                     <Separator variant="vertical" invisible="onlyChild"/>
                     <DisplayActions
                         target="selectedContentActions"

--- a/src/javascript/JContent/ContentRoute/ToolBar/ToolBar.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/ToolBar.jsx
@@ -36,14 +36,16 @@ export const ToolBar = () => {
                 </Typography>
                 <div className={styles.spacer}/>
                 <Button icon={<Cancel/>} variant="ghost" size="small" onClick={() => dispatch(cmClearSelection())}/>
-                <Separator variant="vertical"/>
-                <DisplayActions
-                    target="selectedContentActions"
-                    context={{paths: selection}}
-                    filter={action => action.key !== 'deletePermanently' && action.key.indexOf('publish') === -1}
-                    render={getButtonRenderer({size: 'small', variant: 'ghost'})}
-                />
-                <Separator variant="vertical"/>
+                <div>
+                    <Separator variant="vertical" invisible="onlyChild"/>
+                    <DisplayActions
+                        target="selectedContentActions"
+                        context={{paths: selection}}
+                        filter={action => action.key !== 'deletePermanently' && action.key.indexOf('publish') === -1}
+                        render={getButtonRenderer({size: 'small', variant: 'ghost'})}
+                    />
+                </div>
+                <Separator variant="vertical" invisible="onlyChild"/>
                 <ButtonGroup size="small" variant="outlined" color="accent">
                     <DisplayAction actionKey="publish" context={{paths: selection}} render={ButtonRendererMultiple}/>
                     <DisplayAction actionKey="publishDeletion" context={{paths: selection}} render={ButtonRendererShortLabel}/>

--- a/src/javascript/JContent/ContentRoute/ToolBar/ToolBar.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/ToolBar.jsx
@@ -48,10 +48,10 @@ export const ToolBar = () => {
                 <Separator variant="vertical" invisible="onlyChild"/>
                 <ButtonGroup size="small" variant="outlined" color="accent">
                     <DisplayAction actionKey="publish" context={{paths: selection}} render={ButtonRendererMultiple}/>
-                    <DisplayAction actionKey="publishDeletion" context={{paths: selection}} render={ButtonRendererShortLabel}/>
-                    <DisplayAction actionKey="deletePermanently" context={{paths: selection}} render={ButtonRendererShortLabel}/>
                     <DisplayAction actionKey="publishMenu" context={{paths: selection, menuUseElementAnchor: true}} render={ButtonRendererNoLabel}/>
                 </ButtonGroup>
+                <DisplayAction actionKey="publishDeletion" context={{paths: selection}} render={ButtonRendererShortLabel}/>
+                <DisplayAction actionKey="deletePermanently" context={{paths: selection}} render={ButtonRendererShortLabel}/>
             </React.Fragment>}
         </div>
     );

--- a/src/javascript/JContent/ContentRoute/ToolBar/Toolbar.test.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/Toolbar.test.jsx
@@ -45,7 +45,7 @@ describe('Toolbar', () => {
         expect(toolbar.find('Typography').prop('children')).toContain('itemsSelected');
         expect(toolbar.find('Button').prop('icon').type('SvgCancel')).toBeDefined();
         expect(toolbar.find('Typography').prop('data-cm-selection-size')).toBe(1);
-        expect(toolbar.find('ButtonGroup').children()).toHaveLength(4);
+        expect(toolbar.find('ButtonGroup').children()).toHaveLength(2);
     });
 
     it('should render multiple selection actions for 2 items', () => {
@@ -57,6 +57,6 @@ describe('Toolbar', () => {
         expect(toolbar.find('Typography').prop('children')).toContain('itemsSelected');
         expect(toolbar.find('Button').prop('icon').type('SvgCancel')).toBeDefined();
         expect(toolbar.find('Typography').prop('data-cm-selection-size')).toBe(2);
-        expect(toolbar.find('ButtonGroup').children()).toHaveLength(4);
+        expect(toolbar.find('ButtonGroup').children()).toHaveLength(2);
     });
 });


### PR DESCRIPTION
… in the middle of the bar

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12964

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
