### PR TITLE
BACKLOG-12803 : Use cache invalidation instead of redux refetch path.…

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx
@@ -16,7 +16,7 @@ import {
 } from '../../eventHandlerRegistry';
 import {useTranslation} from 'react-i18next';
 import {connect} from 'react-redux';
-import {cmClosePaths, cmGoto, cmOpenPaths, cmRemovePathsToRefetch} from '../../JContent.redux';
+import {cmClosePaths, cmGoto, cmOpenPaths} from '../../JContent.redux';
 import JContentConstants from '../../JContent.constants';
 import {getNewNodePath, isDescendantOrSelf} from '../../JContent.utils';
 import {cmRemoveSelection, cmSwitchSelection} from './contentSelection.redux';
@@ -56,8 +56,6 @@ export const ContentLayoutContainer = ({
     removeSelection,
     switchSelection,
     setPreviewSelection,
-    pathsToRefetch,
-    removePathsToRefetch,
     setPath,
     filesMode,
     previewState,
@@ -67,11 +65,6 @@ export const ContentLayoutContainer = ({
     const client = useApolloClient();
 
     let fetchPolicy = sort.orderBy === 'displayName' ? 'network-only' : 'cache-first';
-    // If the path to display is part of the paths to refetch then refetch
-    if (!_.isEmpty(pathsToRefetch) && pathsToRefetch.indexOf(path) !== -1) {
-        removePathsToRefetch([path]);
-        fetchPolicy = 'network-only';
-    }
 
     const queryHandler = contentQueryHandlerByMode(mode);
     const layoutQuery = queryHandler.getQuery();
@@ -274,7 +267,6 @@ const mapStateToProps = state => ({
     pagination: state.jcontent.pagination,
     sort: state.jcontent.sort,
     openedPaths: state.jcontent.openPaths,
-    pathsToRefetch: state.jcontent.pathsToRefetch,
     selection: state.jcontent.selection
 });
 
@@ -283,7 +275,6 @@ const mapDispatchToProps = dispatch => ({
     setPreviewSelection: previewSelection => dispatch(cmSetPreviewSelection(previewSelection)),
     openPaths: paths => dispatch(cmOpenPaths(paths)),
     closePaths: paths => dispatch(cmClosePaths(paths)),
-    removePathsToRefetch: paths => dispatch(cmRemovePathsToRefetch(paths)),
     removeSelection: path => dispatch(cmRemoveSelection(path)),
     switchSelection: path => dispatch(cmSwitchSelection(path))
 });
@@ -297,9 +288,7 @@ ContentLayoutContainer.propTypes = {
     pagination: PropTypes.object.isRequired,
     params: PropTypes.object.isRequired,
     path: PropTypes.string.isRequired,
-    pathsToRefetch: PropTypes.array.isRequired,
     previewSelection: PropTypes.string,
-    removePathsToRefetch: PropTypes.func.isRequired,
     setPath: PropTypes.func.isRequired,
     setPreviewSelection: PropTypes.func.isRequired,
     siteKey: PropTypes.string.isRequired,

--- a/src/javascript/JContent/JContent.app-root.js
+++ b/src/javascript/JContent/JContent.app-root.js
@@ -1,6 +1,6 @@
 import {DSProvider} from '@jahia/design-system-kit';
 import {ComponentRendererProvider, DxContext, NotificationProvider} from '@jahia/react-material';
-import PushEventHandler from './PushEventHandler';
+import {PushEventHandler} from './PushEventHandler';
 import {ComponentRendererProvider as NewComponentRendererProvider} from '@jahia/ui-extender';
 import React from 'react';
 import {triggerRefetchAll} from './JContent.refetches';

--- a/src/javascript/JContent/JContent.redux.js
+++ b/src/javascript/JContent/JContent.redux.js
@@ -125,16 +125,10 @@ export const jContentRedux = registry => {
         [cmClosePaths]: (state, action) => _.difference(state, action.payload)
     }, _.dropRight(extractPaths(currentValueFromUrl.site, currentValueFromUrl.path, currentValueFromUrl.mode), 1));
 
-    const pathsToRefetchReducer = handleActions({
-        [cmAddPathsToRefetch]: (state, action) => _.union(state, action.payload),
-        [cmRemovePathsToRefetch]: (state, action) => _.difference(state, action.payload)
-    }, []);
-
     registry.add('redux-reducer', 'mode', {targets: ['jcontent'], reducer: modeReducer});
     registry.add('redux-reducer', 'path', {targets: ['jcontent'], reducer: pathReducer});
     registry.add('redux-reducer', 'params', {targets: ['jcontent'], reducer: paramsReducer});
     registry.add('redux-reducer', 'openPaths', {targets: ['jcontent'], reducer: openPathsReducer});
-    registry.add('redux-reducer', 'pathsToRefetch', {targets: ['jcontent'], reducer: pathsToRefetchReducer});
 
     let currentValue;
     let getSyncListener = store => () => {

--- a/src/javascript/JContent/PushEventHandler/index.js
+++ b/src/javascript/JContent/PushEventHandler/index.js
@@ -1,3 +1,1 @@
-import PushEventHandler from './PushEventHandler';
-
-export default PushEventHandler;
+export * from './PushEventHandler';

--- a/src/javascript/JContent/actions/copyPaste/pasteAction.jsx
+++ b/src/javascript/JContent/actions/copyPaste/pasteAction.jsx
@@ -4,7 +4,7 @@ import {triggerRefetchAll} from '../../JContent.refetches';
 import {copypasteClear} from './copyPaste.redux';
 import {withNotifications} from '@jahia/react-material';
 import {getNewNodePath, isDescendantOrSelf} from '../../JContent.utils';
-import {cmAddPathsToRefetch, cmClosePaths, cmGoto, cmOpenPaths} from '../../JContent.redux';
+import {cmClosePaths, cmGoto, cmOpenPaths} from '../../JContent.redux';
 import {cmSetPreviewSelection} from '../../preview.redux';
 import copyPasteConstants from './copyPaste.constants';
 import {setLocalStorage} from './localStorageHandler';
@@ -120,7 +120,8 @@ export const PasteActionComponent = withNotifications()(({context, render: Rende
                     notificationContext.notify(t('jcontent:label.contentManager.copyPaste.success'), ['closeButton']);
 
                     // Let's make sure the content table will be refreshed when displayed
-                    dispatch(cmAddPathsToRefetch([context.path, ...nodes.map(nodeToPaste => nodeToPaste.path.substring(0, nodeToPaste.path.lastIndexOf('/')))]));
+                    client.cache.flushNodeEntryByPath(context.path);
+                    nodes.map(nodeToPaste => nodeToPaste.path.substring(0, nodeToPaste.path.lastIndexOf('/'))).forEach(p => client.cache.flushNodeEntryByPath(p));
 
                     // If it's a move we need to update the list of opened path with the new paths, update the tree path and update the preview selection
                     let pastedNodes = _.merge(nodes, datas.map(({data}) => ({newPath: data.jcr.pasteNode.node.path})));

--- a/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.container.jsx
+++ b/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.container.jsx
@@ -55,7 +55,6 @@ const CreateFolderDialogContainer = ({path, contentType, onExit}) => {
     });
 
     useEffect(() => {
-        console.log('updating', data);
         if (data && data.jcr && data.jcr.nodeByPath) {
             updateChildNodes(data.jcr.nodeByPath.children.nodes);
         }

--- a/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.gql-queries.js
+++ b/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.gql-queries.js
@@ -2,12 +2,12 @@ import gql from 'graphql-tag';
 import {PredefinedFragments} from '@jahia/data-helper';
 
 const CreateFolderQuery = gql`
-    query FolderQuery($path:String!, $typesFilter: InputNodeTypesInput!) {
+    query FolderQuery($path:String!) {
         jcr {
             nodeByPath(path: $path) {
                 id: uuid
                 name
-                children(typesFilter: $typesFilter) {
+                children {
                     nodes {
                         name
                         ...NodeCacheRequiredFields


### PR DESCRIPTION
… Fixed cache after folder creation

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12803 

## Description

Remove all redux related "pathsToRefetch". Instead use simple cache invalidation, which forces refetch (in all languages). Updated pasteAction  accordingly, and also update PushEventHandler to flush cache in case of publication/workflow job.

Fix cache in create folder action, use refetchAll / cache invalidation to properly invalidate cache when a new folder is created. Also fix the query that check if a node (any node) already exist with the same name.

