### PR TITLE
BACKLOG-12336 : raise parent version and check the new permission of …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>7.3.1.0</version>
+        <version>7.3.5.0-SNAPSHOT</version>
         <relativePath />
     </parent>
     <artifactId>content-media-manager</artifactId>

--- a/src/javascript/ContentManager/actions/clearAllLocksAction.jsx
+++ b/src/javascript/ContentManager/actions/clearAllLocksAction.jsx
@@ -9,9 +9,8 @@ export default composeActions(requirementsAction, withDxContextAction, {
     init: context => {
         context.initRequirements({
             getLockInfo: true,
-            requiredPermission: 'jcr:lockManagement',
-            enabled: context => context.node.pipe(map(node => node.lockTypes !== null && !_.includes(node.lockTypes.values, ' deletion :deletion') &&
-                context.dxContext.userName === 'root'))
+            requiredPermission: 'clearLock',
+            enabled: context => context.node.pipe(map(node => node.lockTypes !== null && !_.includes(node.lockTypes.values, ' deletion :deletion')))
         });
     },
     onClick: context => {


### PR DESCRIPTION
…clearAllLocks

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12336

## Description

As suggested by François, we need to raise the parent version of CMM 1.5.0-SN to benefit from the new changes in the core (new permission for clearAllLocks action)
<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
