### PR TITLE
BACKLOG-12908: Add selector attribute to header's title

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentTitle/ContentTitle.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentTitle/ContentTitle.jsx
@@ -14,7 +14,7 @@ const ContentTitle = () => {
     const {loading, node} = useNodeInfo({path: path, language: language}, {getDisplayName: true});
 
     return (
-        <div className={classnames(styles.root, 'alignCenter')}>
+        <div className={classnames(styles.root, 'alignCenter')} data-sel-role="title">
             <Typography variant="title" style={{opacity: loading ? 0 : 1}}>
                 {(!loading && node && node.displayName) || 'Loading ...'}
             </Typography>


### PR DESCRIPTION
Added attribute to be able to locate header's title from Selenium tests.

## JIRA
https://jira.jahia.org/browse/BACKLOG-12908