### PR TITLE
BACKLOG-13071, BACKLOG-13081: remove 'new' badge, and do not display …

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.jsx
@@ -15,7 +15,6 @@ const ContentStatuses = ({node, isDisabled, language, uilang}) => {
         locked: node.lockOwner,
         markedForDeletion: isMarkedForDeletion(node),
         modified: false,
-        new: false,
         published: false,
         warning: false,
         workInProgress: isWorkInProgress(node, language)
@@ -25,8 +24,9 @@ const ContentStatuses = ({node, isDisabled, language, uilang}) => {
         const {publicationStatus} = node.aggregatedPublicationInfo;
         if (publicationStatus === JContentConstants.availablePublicationStatuses.MODIFIED) {
             statuses.modified = true;
+            statuses.published = true;
         } else if (publicationStatus === JContentConstants.availablePublicationStatuses.NOT_PUBLISHED) {
-            statuses.new = true;
+            statuses.published = false;
         } else if (publicationStatus === JContentConstants.availablePublicationStatuses.PUBLISHED) {
             statuses.published = true;
         } else if (publicationStatus === JContentConstants.availablePublicationStatuses.UNPUBLISHED) {
@@ -41,7 +41,6 @@ const ContentStatuses = ({node, isDisabled, language, uilang}) => {
     );
     return (
         <div className={styles.contentStatuses}>
-            {statuses.new && renderStatus('new')}
             {statuses.modified && renderStatus('modified')}
             {statuses.markedForDeletion && renderStatus('markedForDeletion')}
             {statuses.workInProgress && renderStatus('workInProgress')}

--- a/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.test.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.test.jsx
@@ -80,21 +80,7 @@ describe('ContentStatuses', () => {
         const expectedTooltip = 'translated_label.contentManager.publicationStatus.modified';
 
         expect(wrapper.containsMatchingElement(<Status type="modified" tooltip={expectedTooltip}/>)).toBeTruthy();
-        expect(wrapper.containsMatchingElement(<Status type="notPublished"/>)).toBeTruthy();
-        expect(wrapper.find('Status')).toHaveLength(2);
-    });
-
-    it('should render a \'New\' status when never published', () => {
-        const node = {
-            aggregatedPublicationInfo: {
-                publicationStatus: 'NOT_PUBLISHED'
-            }
-        };
-        const wrapper = shallow(<ContentStatuses {...defaultProps} node={node}/>);
-        const expectedTooltip = 'translated_label.contentManager.publicationStatus.notPublished';
-
-        expect(wrapper.containsMatchingElement(<Status type="new" tooltip={expectedTooltip}/>)).toBeTruthy();
-        expect(wrapper.containsMatchingElement(<Status type="notPublished"/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<Status type="published"/>)).toBeTruthy();
         expect(wrapper.find('Status')).toHaveLength(2);
     });
 

--- a/src/javascript/JContent/ContentRoute/ContentStatuses/Status.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/Status.jsx
@@ -17,10 +17,6 @@ const config = {
         color: 'default',
         icon: <File/>
     },
-    new: {
-        color: 'success',
-        icon: <File/>
-    },
     notPublished: {
         color: 'warning',
         icon: <NoCloud/>

--- a/src/javascript/JContent/ContentRoute/ContentStatuses/Status.test.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/Status.test.jsx
@@ -32,15 +32,6 @@ describe('Status', () => {
         expect(wrapper.props().icon).toStrictEqual(<File/>);
     });
 
-    it('should be \'New\'', () => {
-        const wrapper = shallow(<Status type="new"/>);
-
-        expect(wrapper.find('Chip').exists()).toBeTruthy();
-        expect(wrapper.props().label).toBe('translated_label.contentManager.contentStatus.new');
-        expect(wrapper.props().color).toBe('success');
-        expect(wrapper.props().icon).toStrictEqual(<File/>);
-    });
-
     it('should be \'Not published\'', () => {
         const wrapper = shallow(<Status type="notPublished"/>);
 


### PR DESCRIPTION
new display rules:
- content modified but exist in live: do not display: 'not published' badge
- content is new: do not display 'new' badge but only 'not published'