### PR TITLE
BACKLOG-12965: Fix publishAction not re-rendered once data is loaded

### DIFF
--- a/src/javascript/JContent/ContentRoute/ToolBar/ToolBar.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/ToolBar.jsx
@@ -24,10 +24,13 @@ export const ToolBar = () => {
         selection: state.jcontent.selection
     }));
 
-    const {nodes} = useNodeInfo({paths: selection}, {getIsNodeTypes: ['jnt:page', 'jnt:contentFolder', 'jnt:folder']});
+    const {nodes, loading} = useNodeInfo({paths: selection}, {getIsNodeTypes: ['jnt:page', 'jnt:contentFolder', 'jnt:folder']});
 
-    const canPublish = nodes && nodes.map(n => n['jnt:page'] || !(n['jnt:contentFolder'] || n['jnt:folder'])).reduce((v, a) => v && a, true);
-    const publishAction = canPublish ? 'publish' : 'publishAll';
+    let publishAction;
+    if (!loading) {
+        const canPublish = nodes && nodes.map(n => n['jnt:page'] || !(n['jnt:contentFolder'] || n['jnt:folder'])).reduce((v, a) => v && a, true);
+        publishAction = canPublish ? 'publish' : 'publishAll';
+    }
 
     return (
         <div className={`flexRow ${styles.root}`}>
@@ -54,7 +57,7 @@ export const ToolBar = () => {
                 </div>
                 <Separator variant="vertical" invisible="onlyChild"/>
                 <ButtonGroup size="default" variant="outlined" color="accent">
-                    <DisplayAction actionKey={publishAction} context={{paths: selection}} render={ButtonRendererShortLabel}/>
+                    {publishAction && <DisplayAction actionKey={publishAction} context={{paths: selection}} render={ButtonRendererShortLabel}/>}
                     <DisplayAction actionKey="publishMenu" context={{paths: selection, menuUseElementAnchor: true}} render={ButtonRendererNoLabel}/>
                 </ButtonGroup>
                 <DisplayAction actionKey="publishDeletion" context={{paths: selection}} render={ButtonRendererShortLabel}/>


### PR DESCRIPTION
Only render publish action once data loading has completed.

Previous fix ([63100abdb9710d7b898557db0e835c791c2b0503](https://github.com/Jahia/jcontent/commit/63100abdb9710d7b898557db0e835c791c2b0503)) to enforce the rendering of the toolbar when data is still loading, did introduce a regression. The publish action button rendered during loading is not re-rendered once loading has completed. Thus correct rendering of the action only occurs if required data was correct on first rendering.

https://jira.jahia.org/browse/BACKLOG-12965