### PR TITLE
BACKLOG-13122: Prevent header to be resized when breadcrumb is empty

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentBreadcrumb/ContentType/ContentType.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentBreadcrumb/ContentType/ContentType.jsx
@@ -2,10 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {Chip} from '@jahia/moonstone';
 
+import styles from './ContentType.scss';
 import {getNodeTypeIcon} from '../ContentBreadcrumb.utils';
 
 const ContentType = ({name, displayName}) => (
-    <Chip color="accent" label={displayName || name} icon={getNodeTypeIcon(name)}/>
+    <div className={styles.contentType}>
+        <Chip color="accent" label={displayName || name} icon={getNodeTypeIcon(name)}/>
+    </div>
 );
 
 ContentType.propTypes = {

--- a/src/javascript/JContent/ContentRoute/ContentBreadcrumb/ContentType/ContentType.scss
+++ b/src/javascript/JContent/ContentRoute/ContentBreadcrumb/ContentType/ContentType.scss
@@ -1,0 +1,3 @@
+.contentType {
+    padding: 1px 0;
+}

--- a/src/javascript/JContent/ContentRoute/ContentBreadcrumb/ContentType/ContentType.test.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentBreadcrumb/ContentType/ContentType.test.jsx
@@ -8,7 +8,7 @@ import {getNodeTypeIcon} from '../ContentBreadcrumb.utils';
 describe('ContentType', () => {
     it('should render one Chip', () => {
         const wrapper = shallow(<ContentType name="foo" displayName="bar"/>);
-        expect(wrapper.matchesElement(
+        expect(wrapper.containsMatchingElement(
             <Chip color="accent" label="bar" icon={getNodeTypeIcon('bar')}/>
         )).toBeTruthy();
     });


### PR DESCRIPTION
When the breadcrumb does not display any ancestor (ie. it only display the type of the current node) then the header height is reduced by 2 pixels. This changes does fix this issue by adding 1px top and bottom margin around the content type, so that its height matches the one of buttons used for displaying ancestors.

https://jira.jahia.org/browse/BACKLOG-13122
