### PR TITLE
BACKLOG-12725 : initClipboardWatcher was not called anymore

### DIFF
--- a/src/javascript/JContent.register.jsx
+++ b/src/javascript/JContent.register.jsx
@@ -18,11 +18,15 @@ import {paginationRedux} from './JContent/ContentRoute/ContentLayout/pagination.
 import {sortRedux} from './JContent/ContentRoute/ContentLayout/sort.redux';
 import {contentSelectionRedux} from './JContent/ContentRoute/ContentLayout/contentSelection.redux';
 import JContentConstants from './JContent/JContent.constants';
-import {useSelector} from 'react-redux';
+import {useSelector, useDispatch} from 'react-redux';
+import {useApolloClient} from 'react-apollo';
+import {initClipboardWatcher} from './JContent/actions/copyPaste/localStorageHandler';
 
 const CmmNavItem = () => {
     const history = useHistory();
     const {t} = useTranslation('jcontent');
+    const client = useApolloClient();
+    const dispatch = useDispatch();
     const {site, language, path, mode, params} = useSelector(state => ({
         language: state.language,
         site: state.site,
@@ -36,7 +40,10 @@ const CmmNavItem = () => {
                         isSelected={history.location.pathname.startsWith('/jcontent') && history.location.pathname.split('/').length > 3}
                         label={t('label.name')}
                         icon={<Collections/>}
-                        onClick={() => history.push(buildUrl(site, language, mode || JContentConstants.mode.PAGES, path, params))}/>
+                        onClick={() => {
+                            history.push(buildUrl(site, language, mode || JContentConstants.mode.PAGES, path, params));
+                            initClipboardWatcher(dispatch, client);
+                        }}/>
     );
 };
 

--- a/src/javascript/JContent/actions/copyPaste/localStorageHandler.js
+++ b/src/javascript/JContent/actions/copyPaste/localStorageHandler.js
@@ -25,7 +25,7 @@ const getGWTNode = n => {
 
 let currentValue = '';
 
-const initClipboardWatcher = (store, client) => {
+const initClipboardWatcher = (dispatch, client) => {
     setInterval(() => {
         let previousValue = currentValue;
         currentValue = localStorage.getItem('jahia-clipboard');
@@ -43,9 +43,9 @@ const initClipboardWatcher = (store, client) => {
                 const nodesWithData = data.jcr.nodesById;
 
                 if (cb.type === copyPasteConstants.CUT) {
-                    store.dispatch(copypasteCut(nodesWithData));
+                    dispatch(copypasteCut(nodesWithData));
                 } else {
-                    store.dispatch(copypasteCopy(nodesWithData));
+                    dispatch(copypasteCopy(nodesWithData));
                 }
             });
         }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12725

## Description
initClipboardWatcher was not called anymore, now it's called when opening jContent to watch clipboard if there is any copy action called from pageComposer
<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
