### PR TITLE
BACKLOG-13138: Fix selection not always being clear when path is updated

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/contentSelection.redux.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/contentSelection.redux.js
@@ -1,6 +1,6 @@
 import {cmSetPage, cmSetPageSize} from './pagination.redux';
 import {cmSetSort} from './sort.redux';
-import {cmSetPath} from '../../JContent.redux';
+import {cmSetPath, cmSetModePathParams} from '../../JContent.redux';
 import {createAction, handleActions} from 'redux-actions';
 import {cmSetPreviewSelection} from '../../preview.redux';
 
@@ -35,6 +35,7 @@ export const contentSelectionRedux = registry => {
         [cmSwitchSelection]: (state, action) => (state.indexOf(action.payload) === -1) ? [...state, action.payload] : state.filter(path => action.payload !== path),
         [cmClearSelection]: () => ([]),
         [cmSetPath]: () => ([]),
+        [cmSetModePathParams]: () => ([]),
         [cmSetSort]: () => ([]),
         [cmSetPage]: () => ([]),
         [cmSetPageSize]: () => ([])


### PR DESCRIPTION
The recently introduced cmSetModePathParams action was not handled.
The issue was only noticeable when using Thumbnail or Detail View in medias section, because List View comes with some specific code to clear the selection.

https://jira.jahia.org/browse/BACKLOG-13138