### PR TITLE
BACKLOG-12739 - Fixed a mismatch between german translation and the actual button name

### DIFF
--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -41,7 +41,7 @@
         "selectMessage": "Datei von meinem Computer wählen",
         "uploadingActionMessage": "Es gibt Fehler, die Ihre Aufmerksamkeit benötigen",
         "or": "oder",
-        "dropMessage": "Datei mit Drag & Drop hier einfügen oder den Button \"Inhalt hinzufügen\" verwenden",
+        "dropMessage": "Datei mit Drag & Drop hier einfügen oder den Button \"Datei(en) hochladen\" verwenden",
         "queued": "In Warteschlange",
         "errorMessage": "Es gab Probleme beim Hochladen einiger Dateien",
         "importErrorMessage": "Während des Imports ist ein Fehler aufgetreten. <0>Erfahren Sie mehr zu Export und Import hier</0>",


### PR DESCRIPTION
Updated the translation since the button was called differently.