### PR TITLE
BACKLOG-13165: Removed redux listener, use reducers

### DIFF
--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.jsx
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.jsx
@@ -5,9 +5,9 @@ import {useTranslation} from 'react-i18next';
 import {connect} from 'react-redux';
 import {ProgressOverlay, withNotifications} from '@jahia/react-material';
 import {useSiteInfo} from '@jahia/data-helper';
-import {registry} from '@jahia/ui-extender';
 import {Dropdown} from '@jahia/moonstone';
 import styles from './LanguageSwitcher.scss';
+import {cmGoto} from '../../../JContent.redux';
 
 export const LanguageSwitcher = ({
     notificationContext,
@@ -21,8 +21,6 @@ export const LanguageSwitcher = ({
     const onSelectLanguageHandler = lang => {
         console.debug(`%c  Switching language to: ${lang}`, 'color: #6B5CA5');
         onSelectLanguage(lang);
-        // Switch edit mode linker language
-        window.authoringApi.switchLanguage(lang);
     };
 
     if (error) {
@@ -58,7 +56,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
     onSelectLanguage: lang => {
-        dispatch(registry.get('redux-reducer', 'language').actions.setLanguage(lang));
+        dispatch(cmGoto({language: lang}));
     }
 });
 

--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SiteSwitcher.jsx
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SiteSwitcher.jsx
@@ -80,7 +80,6 @@ class SiteSwitcher extends React.Component {
     onSelectSite(siteNode, currentLang) {
         let newLang = this.getTargetSiteLanguageForSwitch(siteNode, currentLang);
         this.props.selectSite(siteNode, newLang);
-        window.authoringApi.switchSite(siteNode.name, newLang);
     }
 
     render() {

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentListTable/ContentListTable.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentListTable/ContentListTable.jsx
@@ -11,7 +11,7 @@ import * as _ from 'lodash';
 import {useTranslation} from 'react-i18next';
 import PublicationStatus from '../PublicationStatus';
 import dayjs from 'dayjs';
-import {CM_DRAWER_STATES, cmGoto, cmOpenPaths, cmSetMode} from '../../../JContent.redux';
+import {CM_DRAWER_STATES, cmGoto, cmOpenPaths} from '../../../JContent.redux';
 import {
     allowDoubleClickNavigation,
     extractPaths,
@@ -648,7 +648,7 @@ const mapDispatchToProps = dispatch => ({
         dispatch(cmOpenPaths(extractPaths(siteKey, path, mode)));
         dispatch(cmGoto({path, params}));
     },
-    setMode: mode => dispatch(cmSetMode(mode)),
+    setMode: mode => dispatch(cmGoto({mode})),
     setCurrentPage: page => dispatch(cmSetPage(page)),
     setPageSize: pageSize => dispatch(cmSetPageSize(pageSize)),
     setSort: state => dispatch(cmSetSort(state)),

--- a/src/javascript/JContent/ContentRoute/ContentLayout/contentSelection.redux.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/contentSelection.redux.js
@@ -1,6 +1,5 @@
 import {cmSetPage, cmSetPageSize} from './pagination.redux';
 import {cmSetSort} from './sort.redux';
-import {cmSetPath, cmSetModePathParams} from '../../JContent.redux';
 import {createAction, handleActions} from 'redux-actions';
 import {cmSetPreviewSelection} from '../../preview.redux';
 
@@ -34,8 +33,6 @@ export const contentSelectionRedux = registry => {
         [cmRemoveSelection]: (state, action) => state.filter(path => toArray(action.payload).indexOf(path) === -1),
         [cmSwitchSelection]: (state, action) => (state.indexOf(action.payload) === -1) ? [...state, action.payload] : state.filter(path => action.payload !== path),
         [cmClearSelection]: () => ([]),
-        [cmSetPath]: () => ([]),
-        [cmSetModePathParams]: () => ([]),
         [cmSetSort]: () => ([]),
         [cmSetPage]: () => ([]),
         [cmSetPageSize]: () => ([])

--- a/src/javascript/JContent/ContentRoute/ContentLayout/pagination.redux.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/pagination.redux.js
@@ -1,4 +1,3 @@
-import {cmSetPath} from '../../JContent.redux';
 import {createActions, handleActions} from 'redux-actions';
 
 export const {cmSetPage, cmSetPageSize} = createActions('CM_SET_PAGE', 'CM_SET_PAGE_SIZE');
@@ -6,7 +5,7 @@ export const paginationRedux = registry => {
     const paginationReducer = handleActions({
         [cmSetPage]: (state, action) => ({...state, currentPage: action.payload}),
         [cmSetPageSize]: (state, action) => ({...state, pageSize: action.payload}),
-        [cmSetPath]: state => ({...state, currentPage: 0})
+        '@@router/LOCATION_CHANGE': state => ({...state, currentPage: 0})
     }, {currentPage: 0, pageSize: 25});
 
     registry.add('redux-reducer', 'pagination', {targets: ['jcontent'], reducer: paginationReducer});


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-13165

## Description

Remove listener on redux, update instead reducers so that they react on url change. Removed the actions to update path/mode/params manually, should always go through an url update by using the cmGoto action. The cmGoto actions now build and push the new url , updating all states at once.

Also removed the calls to authoringApi when switching site and language, since this is done in a listener in jahia-ui-root.
