### PR TITLE
QA-12760: use context.id to differentiate upload actions

### DIFF
--- a/src/javascript/JContent/actions/fileUploadAction.jsx
+++ b/src/javascript/JContent/actions/fileUploadAction.jsx
@@ -22,7 +22,7 @@ const Upload = ({context, inputRef}) => {
 
     return (
         <input ref={inputRef}
-               id={'file-upload-input-' + context.key}
+               id={'file-upload-input-' + context.id}
                type="file"
                multiple={context.uploadType !== 'replaceWith'}
                context-path={context.path}
@@ -64,8 +64,11 @@ export const FileUploadActionComponent = ({context, render: Render, loading: Loa
     );
 
     useEffect(() => {
-        componentRenderer.render('upload-' + context.key, Upload, {context, inputRef});
-    });
+        componentRenderer.render('upload-' + context.id, Upload, {context, inputRef});
+        return () => {
+            componentRenderer.destroy('upload-' + context.id);
+        };
+    }, [context.id, context.path, context.uploadType, componentRenderer]);
 
     if (res.loading) {
         return (Loading && <Loading context={context}/>) || false;


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-12760

## Description

use context.id to differentiate upload actions, define useEffect dependencies


## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
