### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in the repository.
+# Unless a later match takes precedence,
+# they will be requested for review when someone opens a pull request.
+*    @tdraier @cedricmoitrier @Yousria @DameniMilo


### PR DESCRIPTION
## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

This file identifies the owners of this repository. They will be automatically assigned as reviewers on PR (but not required) targeting the master branch. Note that I've followed the Github documentation (https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners)
