### PR TITLE
BACKLOG-13685: Deploy on system site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <tag>HEAD</tag>
     </scm>
     <properties>
+        <jahia-deploy-on-site>system</jahia-deploy-on-site>
         <jahia-module-type>system</jahia-module-type>
         <yarn.arguments>build:production</yarn.arguments>
         <jahia-module-signature>MC0CFAbKQT3IlbJv8G0cymF8Anxm8AZGAhUAlHIpwcqE7wKziV2hVo/ahwkGWmg=</jahia-module-signature>


### PR DESCRIPTION
Previous commit removed the Jahia-Deploy-On-Site entry from the MANIFEST because this module was unnecessary deployed on all sites. In order to function properly though, it must at least be deployed on system site.

https://jira.jahia.org/browse/BACKLOG-13685