### PR TITLE
Fixed version for the next release in the 1_x 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     </parent>
     <artifactId>content-media-manager</artifactId>
     <name>Content and Media Manager</name>
-    <version>1.6.1-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (Content and Media Manager) for running on a Digital Experience Manager server.</description>
 


### PR DESCRIPTION
This was set to 1.6.1 by mistake, it should have been 1.7.0