### PR TITLE
BACKLOG-15053: Fix missing error message when a node cannot be found

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx
@@ -200,9 +200,12 @@ export const ContentLayoutContainer = ({
         };
     });
 
-    if (error) {
-        const message = t('jcontent:label.contentManager.error.queryingContent', {details: (error.message ? error.message : '')});
-        console.error(message);
+    if (error || (!loading && !data?.jcr?.nodeByPath)) {
+        if (error) {
+            const message = t('jcontent:label.contentManager.error.queryingContent', {details: (error.message ? error.message : '')});
+            console.error(message);
+        }
+
         return (
             <ContentLayout contentNotFound
                            mode={mode}

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.gql-queries.js
@@ -157,7 +157,7 @@ class ContentQueryHandler {
     }
 
     getResultsPath(data) {
-        return data && data.jcr && data.jcr.nodeByPath.descendants;
+        return data && data.jcr && data.jcr.nodeByPath && data.jcr.nodeByPath.descendants;
     }
 }
 
@@ -223,7 +223,7 @@ class FilesQueryHandler {
     }
 
     getResultsPath(data) {
-        return data && data.jcr && data.jcr.nodeByPath.children;
+        return data && data.jcr && data.jcr.nodeByPath && data.jcr.nodeByPath.children;
     }
 }
 


### PR DESCRIPTION
## JIRA
https://jira.jahia.org/browse/BACKLOG-15053

## Description
This is a specific workaround to a wider issue with the Apollo client.
A re-render is triggered but query errors are not longer present with the query result in Apollo cache.