### PR TITLE
BACKLOG-13978: Add PreviewSize component to display image dimensions and size in preview

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PreviewComponent.container.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PreviewComponent.container.jsx
@@ -19,11 +19,16 @@ export const PreviewComponentContainer = ({previewMode, previewSelection, previe
         workspace: previewMode
     });
 
+    // Trigger manual refetch only on language change
     useEffect(() => {
         if (!loading && !error) {
             refetch();
         }
-    });
+    }, [language]);
+
+    if (!loading && Object.keys(data || {}).length === 0) {
+        refetch();
+    }
 
     if (error) {
         console.error('Error when fetching data: ', error);
@@ -32,7 +37,7 @@ export const PreviewComponentContainer = ({previewMode, previewSelection, previe
         return null;
     }
 
-    if (loading || Object.keys(data).length === 0) {
+    if (loading || Object.keys(data || {}).length === 0) {
         return <ProgressOverlay/>;
     }
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewDrawer.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewDrawer.jsx
@@ -11,6 +11,7 @@ import {CM_DRAWER_STATES} from '../../../JContent.redux';
 import {compose} from '~/utils';
 import PublicationStatus from './PublicationStatus';
 import {cmSetPreviewMode, cmSetPreviewState} from '../../../preview.redux';
+import PreviewSize from './PreviewSize';
 
 const styles = theme => ({
     leftButtons: {
@@ -94,6 +95,9 @@ const PreviewDrawer = ({previewMode, previewState, setPreviewMode, t, closePrevi
                 <CardContent data-cm-role="preview-name" className={classes.leftGutter}>
                     <Typography gutterBottom noWrap variant="gamma">
                         {previewSelection.displayName ? previewSelection.displayName : previewSelection.name}
+                    </Typography>
+                    <Typography gutterBottom noWrap variant="iota">
+                        <PreviewSize node={previewSelection}/>
                     </Typography>
                     <PublicationStatus previewSelection={previewSelection}/>
                 </CardContent>

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewDrawer.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewDrawer.jsx
@@ -97,7 +97,7 @@ const PreviewDrawer = ({previewMode, previewState, setPreviewMode, t, closePrevi
                         {previewSelection.displayName ? previewSelection.displayName : previewSelection.name}
                     </Typography>
                     <Typography gutterBottom noWrap variant="iota">
-                        <PreviewSize node={previewSelection}/>
+                        <PreviewSize node={previewSelection} previewMode={effectiveMode}/>
                     </Typography>
                     <PublicationStatus previewSelection={previewSelection}/>
                 </CardContent>

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewSize/PreviewSize.container.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewSize/PreviewSize.container.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import {previewSizeQuery} from './PreviewSize.gql-queries';
+import {useQuery} from 'react-apollo';
+import PropTypes from 'prop-types';
+import PreviewSize from './PreviewSize';
+
+const useMetadataPreview = variables => {
+    return useQuery(previewSizeQuery, {
+        variables,
+        fetchPolicy: 'cache-first'
+    });
+};
+
+export const PreviewSizeContainer = ({node, previewMode}) => {
+    const {data, loading} = useMetadataPreview({
+        workspace: previewMode?.toUpperCase(),
+        path: node.path
+    });
+    if (!loading) {
+        node = data?.jcr?.nodeByPath || {};
+    }
+
+    return (<PreviewSize node={node}/>);
+};
+
+PreviewSizeContainer.propTypes = {
+    node: PropTypes.object.isRequired,
+    previewMode: PropTypes.string.isRequired
+};
+
+export default PreviewSizeContainer;

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewSize/PreviewSize.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewSize/PreviewSize.gql-queries.js
@@ -1,0 +1,25 @@
+import gql from 'graphql-tag';
+
+const previewSizeQuery = gql`query getImageMetadata($workspace: Workspace!, $path: String!) {
+    jcr(workspace: $workspace) {
+        nodeByPath(path: $path) {
+            id: uuid
+            path
+            width: property(name:"j:width") {
+                value
+            }
+            height: property(name: "j:height") {
+              value
+            }
+            children(typesFilter: {types: ["jnt:resource"]}, names:["jcr:content"]) {
+                nodes {
+                    data: property(name: "jcr:data") {
+                        size
+                    }
+                }
+            }
+        }
+    }
+}`;
+
+export {previewSizeQuery};

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewSize/PreviewSize.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewSize/PreviewSize.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import bytes from 'bytes';
+import PropTypes from 'prop-types';
+
+const PreviewSize = ({node}) => {
+    const width = node?.width?.value;
+    const height = node?.height?.value;
+
+    const nodes = node?.children?.nodes || [];
+    const size = (nodes.length > 0) ? nodes[0]?.data?.size : 0;
+
+    return (
+        <>
+            { (width && height) ?
+                `${width} x ${height} - ${bytes(size, {unitSeparator: ' '})}` : '' }
+        </>
+    );
+};
+
+PreviewSize.propTypes = {
+    node: PropTypes.object.isRequired
+};
+
+export default PreviewSize;

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewSize/PreviewSize.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewSize/PreviewSize.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import bytes from 'bytes';
 import PropTypes from 'prop-types';
 
-const PreviewSize = ({node}) => {
+const PreviewSize = ({node = {}}) => {
     const width = node?.width?.value;
     const height = node?.height?.value;
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewSize/PreviewSize.test.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewSize/PreviewSize.test.jsx
@@ -25,7 +25,7 @@ describe('PreviewSize', () => {
     });
 
     it('should render empty text with no node', () => {
-        let mockNode;
+        let mockNode = {};
         const wrapper = shallow(<PreviewSize node={mockNode}/>);
         expect(wrapper.text()).toBe('');
     });

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewSize/PreviewSize.test.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewSize/PreviewSize.test.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PreviewSize from './PreviewSize';
+import {shallow} from '@jahia/test-framework';
+
+describe('PreviewSize', () => {
+    it('should show dimension and size', () => {
+        const mockNode = getMockNode();
+        const wrapper = shallow(<PreviewSize node={mockNode}/>);
+        expect(wrapper.text()).toContain('100');
+        expect(wrapper.text()).toContain('30 x 20');
+    });
+
+    it('should render empty text with no width', () => {
+        let mockNode = getMockNode();
+        mockNode.width = null;
+        const wrapper = shallow(<PreviewSize node={mockNode}/>);
+        expect(wrapper.text()).toBe('');
+    });
+
+    it('should render empty text with no height', () => {
+        let mockNode = getMockNode();
+        mockNode.height = null;
+        const wrapper = shallow(<PreviewSize node={mockNode}/>);
+        expect(wrapper.text()).toBe('');
+    });
+
+    it('should render empty text with no node', () => {
+        let mockNode;
+        const wrapper = shallow(<PreviewSize node={mockNode}/>);
+        expect(wrapper.text()).toBe('');
+    });
+
+    it('should show the unit', () => {
+        let mockNode = getMockNode();
+        mockNode.children.nodes[0].data.size = 36585;
+        const wrapper = shallow(<PreviewSize node={mockNode}/>);
+        expect(wrapper.text()).toContain('35.73 KB');
+    });
+});
+
+function getMockNode() {
+    return {
+        width: {value: 30},
+        height: {value: 20},
+        children: {
+            nodes: [
+                {data: {size: 100}}
+            ]
+        }
+    };
+}

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewSize/index.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewSize/index.js
@@ -1,3 +1,3 @@
-import PreviewSize from './PreviewSize';
+import PreviewSize from './PreviewSize.container';
 
 export default PreviewSize;

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewSize/index.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PreviewSize/index.js
@@ -1,0 +1,3 @@
+import PreviewSize from './PreviewSize';
+
+export default PreviewSize;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-13978

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Added new component to pull metadata of file nodes to retrieve image dimensions and file size depending on specified workspace (live or edit) on the preview toggle and display to the user.

Change notes: even if not related to the story, I found I had to make some modifications to _PreviewComponent.container.jsx_ that is causing some GraphQL issues when pulling data for PreviewSize component.


## Tests

The following are included in this PR
- [x] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
