### PR TITLE
BACKLOG-13979: fixing card file image size and colour.

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.jsx
@@ -47,7 +47,9 @@ const styles = theme => ({
     detailedCover: {
         minWidth: 200,
         maxWidth: 200,
-        minHeight: 200
+        minHeight: 200,
+        backgroundSize: 'contain',
+        backgroundColor: '#DADADA'
     },
     thumbCoverDetailed: {
         height: 200


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-13979

## Description

Very simple CSS change to the FileCard to display the background image as "contain" instead of "cover" as the size of the image is always greater than height 200px width 200px (due to the image we are using)
Very simple CSS addition to colour the background colour to #DADADA as per the Figma documentation.  

