### PR TITLE
BACKLOG-13979: fix card image size and colour 7.3 back porting

### DIFF
--- a/src/javascript/ContentManager/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.jsx
+++ b/src/javascript/ContentManager/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.jsx
@@ -66,10 +66,14 @@ const styles = theme => ({
     detailedCover: {
         minWidth: 200,
         maxWidth: 200,
-        minHeight: 200
+        minHeight: 200,
+        backgroundSize: 'contain',
+        backgroundColor: '#DADADA'
     },
     thumbCover: {
-        height: 150
+        height: 150,
+        backgroundSize: 'contain',
+        backgroundColor: '#DADADA'
     },
     thumbCoverDetailed: {
         height: 200


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-13979

## Description

Very simple CSS change to the FileCard to display the background image as "contain" instead of "cover" as the size of the image is always greater than height 200px width 200px (due to the image we are using)
Very simple CSS addition to colour the background colour to #DADADA as per the Figma documentation.
Additional requirement from @fpral to make the thumbnail view to have the same display as well.