### PR TITLE
BACKLOG-15221 Fixing issue that logical statement should not use disp…

### DIFF
--- a/src/javascript/ContentManager/ContentRoute/ContentLayout/ContentListTable/ContentListTable.jsx
+++ b/src/javascript/ContentManager/ContentRoute/ContentLayout/ContentListTable/ContentListTable.jsx
@@ -293,10 +293,10 @@ export class ContentListTable extends React.Component {
 
     getMediaIcon(node) {
         let {classes} = this.props;
-        switch (node.primaryNodeType.displayName) {
-            case 'Folder':
+        switch (node.primaryNodeType.name) {
+            case 'jnt:folder':
                 return <Folder className={classes.icon}/>;
-            case 'File':
+            case 'jnt:file':
                 if (node.mixinTypes.length !== 0 && !_.isEmpty(node.mixinTypes.filter(mixin => mixin.name === 'jmix:image'))) {
                     return <ImageIcon className={classes.icon}/>;
                 }


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-15221

## Description

Simple PR here to fix the logical statement to not look at displayName as that is not language agnostic.
Using the 'name' will be the correct approach.
Back porting to 7.3
