### PR TITLE
BACKLOG-15625 issue with z-index on page composer add in return of uuid.

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/Upload/Upload.redux.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/Upload/Upload.redux.js
@@ -100,6 +100,10 @@ export const fileuploadRedux = registry => {
                     mimeType: file.type,
                     fileHandle: file
                 }
+            }).then(data => {
+                return ({
+                    uuid: data?.data?.jcr?.mutateNode?.uuid
+                });
             });
         }
     });
@@ -114,6 +118,10 @@ export const fileuploadRedux = registry => {
                     path: path,
                     mimeType: file.type
                 }
+            }).then(data => {
+                return ({
+                    uuid: data?.data?.jcr?.addNode?.uuid
+                });
             });
         }
     });

--- a/src/javascript/JContent/ContentRoute/ContentLayout/Upload/UploadItem/EditButton.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/Upload/UploadItem/EditButton.jsx
@@ -1,25 +1,39 @@
 import React from 'react';
 import {uploadStatuses} from '../Upload.constants';
-import {DisplayActions} from '@jahia/ui-extender';
-import {ButtonRenderer} from '~/utils/getButtonRenderer';
 import {OpenInNew} from '@jahia/moonstone/dist/icons';
+import {Button} from '@jahia/moonstone';
 import PropTypes from 'prop-types';
+import {useSelector} from 'react-redux';
 import {isImageFile} from '../../ContentLayout.utils';
 
+const showEditButton = ({uuid, status}) => {
+    if (uuid !== null && status === uploadStatuses.UPLOADED) {
+        return true;
+    }
+
+    return false;
+};
+
 const EditButton = props => {
-    const {status, file, t, path} = props;
+    const {status, file, t, uuid} = props;
+
+    const {language} = useSelector(state => ({language: state.language}));
+    const windowLocationPathNames = window.location.pathname.split('/');
+    const location = (windowLocationPathNames.length > 1) ? `/${windowLocationPathNames[1]}` : '';
+    const url = `${location}/content-editor/${language}/edit/${uuid}`;
 
     if (isImageFile(file.name)) {
-        if (status === uploadStatuses.UPLOADED) {
+        if (showEditButton({uuid, status})) {
             return (
-                <DisplayActions
-                    target="contentActions"
-                    filter={value => value.key === 'edit'}
-                    path={`${path}/${file.name}`}
-                    render={ButtonRenderer}
-                    buttonLabel={t('jcontent:label.contentManager.fileUpload.edit')}
-                    buttonIcon={<OpenInNew/>}
-                    buttonProps={{variant: 'ghost', size: 'big', isReversed: true}}
+                <Button
+                    isReversed
+                    label={t('jcontent:label.contentManager.fileUpload.edit')}
+                    icon={<OpenInNew/>}
+                    variant="ghost"
+                    size="big"
+                    onClick={() => {
+                        window.open(url, '_blank');
+                    }}
                 />
             );
         }
@@ -30,9 +44,9 @@ const EditButton = props => {
 
 EditButton.propTypes = {
     status: PropTypes.string,
+    uuid: PropTypes.string,
     file: PropTypes.object.isRequired,
-    t: PropTypes.func.isRequired,
-    path: PropTypes.string.isRequired
+    t: PropTypes.func.isRequired
 };
 
 export default EditButton;

--- a/src/javascript/JContent/ContentRoute/ContentLayout/Upload/UploadItem/EditButton.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/Upload/UploadItem/EditButton.jsx
@@ -6,14 +6,6 @@ import PropTypes from 'prop-types';
 import {useSelector} from 'react-redux';
 import {isImageFile} from '../../ContentLayout.utils';
 
-const showEditButton = ({uuid, status}) => {
-    if (uuid !== null && status === uploadStatuses.UPLOADED) {
-        return true;
-    }
-
-    return false;
-};
-
 const EditButton = props => {
     const {status, file, t, uuid} = props;
 
@@ -22,21 +14,19 @@ const EditButton = props => {
     const location = (windowLocationPathNames.length > 1) ? `/${windowLocationPathNames[1]}` : '';
     const url = `${location}/content-editor/${language}/edit/${uuid}`;
 
-    if (isImageFile(file.name)) {
-        if (showEditButton({uuid, status})) {
-            return (
-                <Button
-                    isReversed
-                    label={t('jcontent:label.contentManager.fileUpload.edit')}
-                    icon={<OpenInNew/>}
-                    variant="ghost"
-                    size="big"
-                    onClick={() => {
-                        window.open(url, '_blank');
-                    }}
-                />
-            );
-        }
+    if (isImageFile(file.name) && uuid !== null && status === uploadStatuses.UPLOADED) {
+        return (
+            <Button
+                isReversed
+                label={t('jcontent:label.contentManager.fileUpload.edit')}
+                icon={<OpenInNew/>}
+                variant="ghost"
+                size="big"
+                onClick={() => {
+                    window.open(url, '_blank');
+                }}
+            />
+        );
     }
 
     return null; // If not uploaded yet or has error no need to display the edit button

--- a/src/javascript/JContent/ContentRoute/ContentLayout/Upload/UploadItem/UploadItem.gql-mutations.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/Upload/UploadItem/UploadItem.gql-mutations.js
@@ -10,8 +10,8 @@ const uploadFile = gql`mutation uploadFile($nameInJCR: String!, $path: String!, 
                 contentType: mutateProperty(name: "jcr:mimeType") {
                     setValue(value: $mimeType)
                 }
-
             }
+            uuid
         }
     }
 }`;
@@ -27,6 +27,7 @@ const updateFileContent = gql`mutation updateFileContent($path: String!, $mimeTy
                     setValue(value: $mimeType)
                 }
             }
+            uuid
         }
     }
 }`;

--- a/src/javascript/JContent/ContentRoute/ContentLayout/Upload/UploadItem/UploadItem.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/Upload/UploadItem/UploadItem.jsx
@@ -59,7 +59,8 @@ export class UploadItem extends React.Component {
         this.state = {
             userChosenName: null,
             anchorEl: null,
-            component: null
+            component: null,
+            uuid: null
         };
 
         this.doUploadAndStatusUpdate = this.doUploadAndStatusUpdate.bind(this);
@@ -95,10 +96,10 @@ export class UploadItem extends React.Component {
                     })}
                     doUploadAndStatusUpdate={this.doUploadAndStatusUpdate}
                 />
-                <div className={classes.grow}/>
+                <div className={classes.grow} doUploadAndStatusUpdate={this.doUploadAndStatusUpdate}/>
                 <Status {...this.props}/>
                 {this.state.component}
-                <EditButton {...this.props}/>
+                <EditButton {...this.props} uuid={this.state.uuid}/>
                 <Dialog open={this.state.anchorEl !== null}>
                     <DialogTitle>
                         {t('jcontent:label.contentManager.fileUpload.dialogRenameTitle')}
@@ -141,9 +142,13 @@ export class UploadItem extends React.Component {
             setTimeout(() => {
                 this.props.uploadFile(upload);
                 this.props.updateUploadsStatus();
-                const component = uploadReturnObj.component;
+                const {component, uuid} = uploadReturnObj;
                 if (typeof component !== 'undefined' && component !== null && React.isValidElement(component)) {
                     this.setState({component: component});
+                }
+
+                if (typeof uuid !== 'undefined' && uuid !== null) {
+                    this.setState({uuid: uuid});
                 }
             }, UPLOAD_DELAY);
         }).catch(e => {


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-15625

## Description

Issue with "page composer" as it has display issue with z-index in comparison with jcontent.
Business requested that the "edit" onclick to open in a new tab instead.

The reason I am not using the existing code is the action is tightly bind with redux action.
Plus do not want to affect existing "edit" functionalities.