### PR TITLE
QA-13567 use the sortBy introduced to sort the useTreeEntries results.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@apollo/react-hooks": "^3.1.5",
     "@babel/polyfill": "^7.0.0",
-    "@jahia/data-helper": "^1.0.0",
+    "@jahia/data-helper": "^1.0.1",
     "@jahia/design-system-kit": "^1.1.2",
     "@jahia/icons": "^1.1.1",
     "@jahia/moonstone": "^1.0.0",

--- a/src/javascript/JContent/ContentTree/ContentTree.constants.js
+++ b/src/javascript/JContent/ContentTree/ContentTree.constants.js
@@ -1,0 +1,4 @@
+export const SORT_CONTENT_TREE_BY_NAME_ASC = {
+    fieldName: 'name',
+    sortType: 'ASC'
+};

--- a/src/javascript/JContent/ContentTree/ContentTree.jsx
+++ b/src/javascript/JContent/ContentTree/ContentTree.jsx
@@ -18,7 +18,7 @@ export const ContentTree = ({lang, siteKey, path, openPaths, setPath, openPath, 
         openPaths.push(rootPath);
     }
 
-    const json = {
+    const useTreeEntriesOptionsJson = {
         fragments: [PickerItemsFragment.mixinTypes, PickerItemsFragment.primaryNodeType, PickerItemsFragment.isPublished, lockInfo, displayName],
         rootPaths: [rootPath],
         openPaths: openPaths,
@@ -31,10 +31,10 @@ export const ContentTree = ({lang, siteKey, path, openPaths, setPath, openPath, 
 
     // For pages portion want to skip the sortBy
     if (item.key !== 'pages') {
-        json.sortBy = SORT_CONTENT_TREE_BY_NAME_ASC;
+        useTreeEntriesOptionsJson.sortBy = SORT_CONTENT_TREE_BY_NAME_ASC;
     }
 
-    const {treeEntries, refetch} = useTreeEntries(json);
+    const {treeEntries, refetch} = useTreeEntries(useTreeEntriesOptionsJson);
 
     let switchPath;
     // If path is root one but root is hidden, then select its first child

--- a/src/javascript/JContent/ContentTree/ContentTree.jsx
+++ b/src/javascript/JContent/ContentTree/ContentTree.jsx
@@ -9,6 +9,7 @@ import {TreeView} from '@jahia/moonstone';
 import {ContextualMenu} from '@jahia/ui-extender';
 import {convertPathsToTree} from './ContentTree.utils';
 import {refetchTypes, setRefetcher, unsetRefetcher} from '../JContent.refetches';
+import {SORT_CONTENT_TREE_BY_NAME_ASC} from './ContentTree.constants';
 
 export const ContentTree = ({lang, siteKey, path, openPaths, setPath, openPath, closePath, item}) => {
     const rootPath = '/sites/' + siteKey + item.config.rootPath;
@@ -17,7 +18,7 @@ export const ContentTree = ({lang, siteKey, path, openPaths, setPath, openPath, 
         openPaths.push(rootPath);
     }
 
-    const {treeEntries, refetch} = useTreeEntries({
+    const json = {
         fragments: [PickerItemsFragment.mixinTypes, PickerItemsFragment.primaryNodeType, PickerItemsFragment.isPublished, lockInfo, displayName],
         rootPaths: [rootPath],
         openPaths: openPaths,
@@ -26,7 +27,14 @@ export const ContentTree = ({lang, siteKey, path, openPaths, setPath, openPath, 
         selectableTypes: item.config.selectableTypes,
         queryVariables: {language: lang},
         hideRoot: item.config.hideRoot
-    });
+    };
+
+    // For pages portion want to skip the sortBy
+    if (item.key !== 'pages') {
+        json.sortBy = SORT_CONTENT_TREE_BY_NAME_ASC;
+    }
+
+    const {treeEntries, refetch} = useTreeEntries(json);
 
     let switchPath;
     // If path is root one but root is hidden, then select its first child

--- a/yarn.lock
+++ b/yarn.lock
@@ -1019,10 +1019,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
   integrity sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==
 
-"@jahia/data-helper@^1.0.0":
-  version "1.0.0"
-  resolved "https://npm.jahia.com/@jahia%2fdata-helper/-/data-helper-1.0.0.tgz#3b4938e8023a3878d503e3b8b3297f3c42c92f84"
-  integrity sha512-Wm2hYXx6Y8aqRPZgFJtsbSBWz1EcgO2n0ix0h/2KvpHlHHQOWgPJU02/bZVbEUaS/RG3fLppt7DAQV97GV88CQ==
+"@jahia/data-helper@^1.0.1":
+  version "1.0.1"
+  resolved "https://npm.jahia.com/@jahia%2fdata-helper/-/data-helper-1.0.1.tgz#fe96bd0b6e84f19620083d9384fc4f0bb02d6259"
+  integrity sha512-qXB97RGpB+Y6D8muvMec0kdQuo3N6hpCYq7taWzJyzqR9qhTWfvof5Y/LEPpUcm5cafRj2FXIsSSXPcUzeWTDQ==
   dependencies:
     apollo-cache "^1.3.4"
     apollo-client "^2.6.8"


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/QA-13567

## Description

Using the sort by to get the sorted results

Example:
`query test($path: String!, $sorter: InputFieldSorterInput) {
    jcr {
      nodeByPath(path: $path) {
        children(fieldSorter: $sorter) {
          nodes {
            name
          }
        }
      }
    }
}`

`{
  "path":"/sites/digitall/files",
  "sorter":{ "fieldName": "name", "sortType": "ASC"}
}`