### PR TITLE
BACKLOG-15824: permissions on jcontent accordions

### DIFF
--- a/src/javascript/JContent.register.jsx
+++ b/src/javascript/JContent.register.jsx
@@ -40,7 +40,7 @@ export default function () {
             path: `/sites/${site}`,
             language: language
         }, {
-            requiredPermission: ['pagesAccordionAccess', 'contentFolderAccordionAccess', 'mediaAccordionAccess', 'additionalAccordionAccess', 'formAccordionAccess']
+            requiredSitePermission: [JContentConstants.accordionPermissions.pagesAccordionAccess, JContentConstants.accordionPermissions.contentFolderAccordionAccess, JContentConstants.accordionPermissions.mediaAccordionAccess, JContentConstants.accordionPermissions.additionalAccordionAccess, JContentConstants.accordionPermissions.formAccordionAccess]
         });
 
         if (permissions.loading) {
@@ -49,15 +49,15 @@ export default function () {
 
         let defaultMode = JContentConstants.mode.PAGES;
 
-        if (!permissions.node.pagesAccordionAccess && !permissions.node.contentFolderAccordionAccess && !permissions.node.mediaAccordionAccess && !permissions.node.formAccordionAccess && !permissions.node.additionalAccordionAccess) {
+        if (!permissions.node.site.pagesAccordionAccess && !permissions.node.site.contentFolderAccordionAccess && !permissions.node.site.mediaAccordionAccess && !permissions.node.site.formAccordionAccess && !permissions.node.site.additionalAccordionAccess) {
             defaultMode = '';
-        } else if (!permissions.node.pagesAccordionAccess && !permissions.node.contentFolderAccordionAccess && !permissions.node.mediaAccordionAccess && !permissions.node.formAccordionAccess) {
+        } else if (!permissions.node.site.pagesAccordionAccess && !permissions.node.site.contentFolderAccordionAccess && !permissions.node.site.mediaAccordionAccess && !permissions.node.site.formAccordionAccess) {
             defaultMode = JContentConstants.mode.APPS;
-        } else if (!permissions.node.pagesAccordionAccess && !permissions.node.contentFolderAccordionAccess && !permissions.node.mediaAccordionAccess) {
+        } else if (!permissions.node.site.pagesAccordionAccess && !permissions.node.site.contentFolderAccordionAccess && !permissions.node.site.mediaAccordionAccess) {
             defaultMode = JContentConstants.mode.FORMS;
-        } else if (!permissions.node.pagesAccordionAccess && !permissions.node.contentFolderAccordionAccess) {
+        } else if (!permissions.node.site.pagesAccordionAccess && !permissions.node.site.contentFolderAccordionAccess) {
             defaultMode = JContentConstants.mode.MEDIA;
-        } else if (!permissions.node.pagesAccordionAccess) {
+        } else if (!permissions.node.site.pagesAccordionAccess) {
             defaultMode = JContentConstants.mode.CONTENT_FOLDERS;
         }
 

--- a/src/javascript/JContent.register.jsx
+++ b/src/javascript/JContent.register.jsx
@@ -49,8 +49,9 @@ export default function () {
 
         let defaultMode = JContentConstants.mode.PAGES;
 
-        // FIXME if no permission what is the display
-        if (!permissions.node.pagesAccordionAccess && !permissions.node.contentFolderAccordionAccess && !permissions.node.mediaAccordionAccess && !permissions.node.formAccordionAccess) {
+        if (!permissions.node.pagesAccordionAccess && !permissions.node.contentFolderAccordionAccess && !permissions.node.mediaAccordionAccess && !permissions.node.formAccordionAccess && !permissions.node.additionalAccordionAccess) {
+            defaultMode = '';
+        } else if (!permissions.node.pagesAccordionAccess && !permissions.node.contentFolderAccordionAccess && !permissions.node.mediaAccordionAccess && !permissions.node.formAccordionAccess) {
             defaultMode = JContentConstants.mode.APPS;
         } else if (!permissions.node.pagesAccordionAccess && !permissions.node.contentFolderAccordionAccess && !permissions.node.mediaAccordionAccess) {
             defaultMode = JContentConstants.mode.FORMS;

--- a/src/javascript/JContent.register.jsx
+++ b/src/javascript/JContent.register.jsx
@@ -40,7 +40,7 @@ export default function () {
             path: `/sites/${site}`,
             language: language
         }, {
-            requiredPermission: ['pagesAccordionAccess', 'contentFolderAccordionAccess', 'mediaAccordionAccess', 'additionalAccordionAccess']
+            requiredPermission: ['pagesAccordionAccess', 'contentFolderAccordionAccess', 'mediaAccordionAccess', 'additionalAccordionAccess', 'formAccordionAccess']
         });
 
         if (permissions.loading) {
@@ -50,8 +50,10 @@ export default function () {
         let defaultMode = JContentConstants.mode.PAGES;
 
         // FIXME if no permission what is the display
-        if (!permissions.node.pagesAccordionAccess && !permissions.node.contentFolderAccordionAccess && !permissions.node.mediaAccordionAccess) {
+        if (!permissions.node.pagesAccordionAccess && !permissions.node.contentFolderAccordionAccess && !permissions.node.mediaAccordionAccess && !permissions.node.formAccordionAccess) {
             defaultMode = JContentConstants.mode.APPS;
+        } else if (!permissions.node.pagesAccordionAccess && !permissions.node.contentFolderAccordionAccess && !permissions.node.mediaAccordionAccess) {
+            defaultMode = JContentConstants.mode.FORMS;
         } else if (!permissions.node.pagesAccordionAccess && !permissions.node.contentFolderAccordionAccess) {
             defaultMode = JContentConstants.mode.MEDIA;
         } else if (!permissions.node.pagesAccordionAccess) {

--- a/src/javascript/JContent.register.jsx
+++ b/src/javascript/JContent.register.jsx
@@ -47,18 +47,18 @@ export default function () {
             return 'Loading...';
         }
 
-        let defaultMode = JContentConstants.mode.PAGES;
+        let defaultMode = '';
 
-        if (!permissions.node.site.pagesAccordionAccess && !permissions.node.site.contentFolderAccordionAccess && !permissions.node.site.mediaAccordionAccess && !permissions.node.site.formAccordionAccess && !permissions.node.site.additionalAccordionAccess) {
-            defaultMode = '';
-        } else if (!permissions.node.site.pagesAccordionAccess && !permissions.node.site.contentFolderAccordionAccess && !permissions.node.site.mediaAccordionAccess && !permissions.node.site.formAccordionAccess) {
-            defaultMode = JContentConstants.mode.APPS;
-        } else if (!permissions.node.site.pagesAccordionAccess && !permissions.node.site.contentFolderAccordionAccess && !permissions.node.site.mediaAccordionAccess) {
-            defaultMode = JContentConstants.mode.FORMS;
-        } else if (!permissions.node.site.pagesAccordionAccess && !permissions.node.site.contentFolderAccordionAccess) {
-            defaultMode = JContentConstants.mode.MEDIA;
-        } else if (!permissions.node.site.pagesAccordionAccess) {
+        if (permissions.node.site.pagesAccordionAccess) {
+            defaultMode = JContentConstants.mode.PAGES;
+        } else if (permissions.node.site.contentFolderAccordionAccess) {
             defaultMode = JContentConstants.mode.CONTENT_FOLDERS;
+        } else if (permissions.node.site.mediaAccordionAccess) {
+            defaultMode = JContentConstants.mode.MEDIA;
+        } else if (permissions.node.site.formAccordionAccess) {
+            defaultMode = JContentConstants.mode.FORMS;
+        } else if (permissions.node.site.additionalAccordionAccess) {
+            defaultMode = JContentConstants.mode.APPS;
         }
 
         return (

--- a/src/javascript/JContent.register.jsx
+++ b/src/javascript/JContent.register.jsx
@@ -20,6 +20,7 @@ import JContentConstants from './JContent/JContent.constants';
 import {useDispatch, useSelector} from 'react-redux';
 import {useApolloClient} from 'react-apollo';
 import {initClipboardWatcher} from './JContent/actions/copyPaste/localStorageHandler';
+import {useNodeChecks} from '@jahia/data-helper';
 
 export default function () {
     const CmmNavItem = () => {
@@ -34,6 +35,29 @@ export default function () {
             mode: state.jcontent.mode,
             params: state.jcontent.params
         }));
+
+        const permissions = useNodeChecks({
+            path: `/sites/${site}`,
+            language: language
+        }, {
+            requiredPermission: ['pagesAccordionAccess', 'contentFolderAccordionAccess', 'mediaAccordionAccess', 'additionalAccordionAccess']
+        });
+
+        if (permissions.loading) {
+            return 'Loading...';
+        }
+
+        let defaultMode = JContentConstants.mode.PAGES;
+
+        // FIXME if no permission what is the display
+        if (!permissions.node.pagesAccordionAccess && !permissions.node.contentFolderAccordionAccess && !permissions.node.mediaAccordionAccess) {
+            defaultMode = JContentConstants.mode.APPS;
+        } else if (!permissions.node.pagesAccordionAccess && !permissions.node.contentFolderAccordionAccess) {
+            defaultMode = JContentConstants.mode.MEDIA;
+        } else if (!permissions.node.pagesAccordionAccess) {
+            defaultMode = JContentConstants.mode.CONTENT_FOLDERS;
+        }
+
         return (
             <PrimaryNavItem key="/jcontent"
                             role="jcontent-menu-item"
@@ -41,7 +65,7 @@ export default function () {
                             label={t('label.name')}
                             icon={<Collections/>}
                             onClick={() => {
-                                history.push(buildUrl(site, language, mode || JContentConstants.mode.PAGES, path, params));
+                                history.push(buildUrl(site, language, mode || defaultMode, path, params));
                                 initClipboardWatcher(dispatch, client);
                             }}/>
         );

--- a/src/javascript/JContent/ContentNavigation/ContentNavigation.container.jsx
+++ b/src/javascript/JContent/ContentNavigation/ContentNavigation.container.jsx
@@ -15,7 +15,7 @@ const ContentNavigationContainer = ({mode, siteKey, handleNavigation}) => {
         path: `/sites/${currentState.site}`,
         language: currentState.language
     }, {
-        requiredPermission: ['pagesAccordionAccess', 'contentFolderAccordionAccess', 'mediaAccordionAccess', 'additionalAccordionAccess']
+        requiredPermission: ['pagesAccordionAccess', 'contentFolderAccordionAccess', 'mediaAccordionAccess', 'additionalAccordionAccess', 'formAccordionAccess']
     });
 
     if (permissions.loading) {

--- a/src/javascript/JContent/ContentNavigation/ContentNavigation.container.jsx
+++ b/src/javascript/JContent/ContentNavigation/ContentNavigation.container.jsx
@@ -4,9 +4,28 @@ import {cmGoto} from '../JContent.redux';
 import ContentNavigation from './ContentNavigation';
 import PropTypes from 'prop-types';
 import {registry} from '@jahia/ui-extender';
+import {useSelector} from 'react-redux';
+import {useNodeChecks} from '@jahia/data-helper';
 
 const ContentNavigationContainer = ({mode, siteKey, handleNavigation}) => {
     let accordionItems = registry.find({type: 'accordionItem', target: 'jcontent'});
+
+    const currentState = useSelector(state => ({site: state.site, language: state.language}));
+    const permissions = useNodeChecks({
+        path: `/sites/${currentState.site}`,
+        language: currentState.language
+    }, {
+        requiredPermission: ['pagesAccordionAccess', 'contentFolderAccordionAccess', 'mediaAccordionAccess', 'additionalAccordionAccess']
+    });
+
+    if (permissions.loading) {
+        return 'Loading...';
+    }
+
+    accordionItems = accordionItems.filter(accordionItem =>
+        Object.prototype.hasOwnProperty.call(permissions.node, accordionItem.requiredPermission) && permissions.node[accordionItem.requiredPermission]
+    );
+
     return <ContentNavigation accordionItems={accordionItems} mode={mode} siteKey={siteKey} handleNavigation={handleNavigation}/>;
 };
 

--- a/src/javascript/JContent/ContentNavigation/ContentNavigation.container.jsx
+++ b/src/javascript/JContent/ContentNavigation/ContentNavigation.container.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import {registry} from '@jahia/ui-extender';
 import {useSelector} from 'react-redux';
 import {useNodeChecks} from '@jahia/data-helper';
+import JContentConstants from '../JContent.constants';
 
 const ContentNavigationContainer = ({mode, siteKey, handleNavigation}) => {
     let accordionItems = registry.find({type: 'accordionItem', target: 'jcontent'});
@@ -15,7 +16,7 @@ const ContentNavigationContainer = ({mode, siteKey, handleNavigation}) => {
         path: `/sites/${currentState.site}`,
         language: currentState.language
     }, {
-        requiredPermission: ['pagesAccordionAccess', 'contentFolderAccordionAccess', 'mediaAccordionAccess', 'additionalAccordionAccess', 'formAccordionAccess']
+        requiredSitePermission: [JContentConstants.accordionPermissions.pagesAccordionAccess, JContentConstants.accordionPermissions.contentFolderAccordionAccess, JContentConstants.accordionPermissions.mediaAccordionAccess, JContentConstants.accordionPermissions.additionalAccordionAccess, JContentConstants.accordionPermissions.formAccordionAccess]
     });
 
     if (permissions.loading) {
@@ -23,7 +24,7 @@ const ContentNavigationContainer = ({mode, siteKey, handleNavigation}) => {
     }
 
     accordionItems = accordionItems.filter(accordionItem =>
-        Object.prototype.hasOwnProperty.call(permissions.node, accordionItem.requiredPermission) && permissions.node[accordionItem.requiredPermission]
+        Object.prototype.hasOwnProperty.call(permissions.node.site, accordionItem.requiredSitePermission) && permissions.node.site[accordionItem.requiredSitePermission]
     );
 
     return <ContentNavigation accordionItems={accordionItems} mode={mode} siteKey={siteKey} handleNavigation={handleNavigation}/>;

--- a/src/javascript/JContent/JContent.accordion-items.jsx
+++ b/src/javascript/JContent/JContent.accordion-items.jsx
@@ -53,7 +53,7 @@ export const jContentAccordionItems = registry => {
         icon: <File/>,
         label: 'label.contentManager.navigation.pages',
         defaultPath: siteKey => '/sites/' + siteKey,
-        RequiredPermission: 'pagesAccordionAccess',
+        requiredPermission: 'pagesAccordionAccess',
         config: {
             hideRoot: true,
             rootPath: '',
@@ -70,7 +70,7 @@ export const jContentAccordionItems = registry => {
         icon: <FolderSpecial/>,
         label: 'label.contentManager.navigation.contentFolders',
         defaultPath: siteKey => '/sites/' + siteKey + '/contents',
-        RequiredPermission: 'contentFolderAccordionAccess',
+        requiredPermission: 'contentFolderAccordionAccess',
         config: {
             rootPath: '/contents',
             selectableTypes: ['jmix:cmContentTreeDisplayable', 'jmix:visibleInContentTree', 'jnt:contentFolder'],
@@ -86,7 +86,7 @@ export const jContentAccordionItems = registry => {
         icon: <Collections/>,
         label: 'label.contentManager.navigation.media',
         defaultPath: siteKey => '/sites/' + siteKey + '/files',
-        RequiredPermission: 'mediaAccordionAccess',
+        requiredPermission: 'mediaAccordionAccess',
         config: {
             rootPath: '/files',
             selectableTypes: ['jnt:folder'],
@@ -103,6 +103,6 @@ export const jContentAccordionItems = registry => {
         label: 'label.contentManager.navigation.apps.title',
         appsTarget: 'jcontent',
         isEnabled: siteKey => siteKey !== 'systemsite',
-        RequiredPermission: 'additionalAccordionAccess'
+        requiredPermission: 'additionalAccordionAccess'
     });
 };

--- a/src/javascript/JContent/JContent.accordion-items.jsx
+++ b/src/javascript/JContent/JContent.accordion-items.jsx
@@ -4,6 +4,7 @@ import ContentTree from './ContentTree';
 import ContentRoute from './ContentRoute';
 import AdditionalAppsTree from './AdditionalAppsTree';
 import AdditionalAppsRoute from './AdditionalAppsRoute';
+import JContentConstants from './JContent.constants';
 
 export const jContentAccordionItems = registry => {
     const getPath = (site, pathElements, registryItem) => {
@@ -53,7 +54,7 @@ export const jContentAccordionItems = registry => {
         icon: <File/>,
         label: 'label.contentManager.navigation.pages',
         defaultPath: siteKey => '/sites/' + siteKey,
-        requiredPermission: 'pagesAccordionAccess',
+        requiredSitePermission: JContentConstants.accordionPermissions.pagesAccordionAccess,
         config: {
             hideRoot: true,
             rootPath: '',
@@ -70,7 +71,7 @@ export const jContentAccordionItems = registry => {
         icon: <FolderSpecial/>,
         label: 'label.contentManager.navigation.contentFolders',
         defaultPath: siteKey => '/sites/' + siteKey + '/contents',
-        requiredPermission: 'contentFolderAccordionAccess',
+        requiredSitePermission: JContentConstants.accordionPermissions.contentFolderAccordionAccess,
         config: {
             rootPath: '/contents',
             selectableTypes: ['jmix:cmContentTreeDisplayable', 'jmix:visibleInContentTree', 'jnt:contentFolder'],
@@ -86,7 +87,7 @@ export const jContentAccordionItems = registry => {
         icon: <Collections/>,
         label: 'label.contentManager.navigation.media',
         defaultPath: siteKey => '/sites/' + siteKey + '/files',
-        requiredPermission: 'mediaAccordionAccess',
+        requiredSitePermission: JContentConstants.accordionPermissions.mediaAccordionAccess,
         config: {
             rootPath: '/files',
             selectableTypes: ['jnt:folder'],
@@ -103,6 +104,6 @@ export const jContentAccordionItems = registry => {
         label: 'label.contentManager.navigation.apps.title',
         appsTarget: 'jcontent',
         isEnabled: siteKey => siteKey !== 'systemsite',
-        requiredPermission: 'additionalAccordionAccess'
+        requiredSitePermission: JContentConstants.accordionPermissions.additionalAccordionAccess
     });
 };

--- a/src/javascript/JContent/JContent.accordion-items.jsx
+++ b/src/javascript/JContent/JContent.accordion-items.jsx
@@ -53,6 +53,7 @@ export const jContentAccordionItems = registry => {
         icon: <File/>,
         label: 'label.contentManager.navigation.pages',
         defaultPath: siteKey => '/sites/' + siteKey,
+        RequiredPermission: 'pagesAccordionAccess',
         config: {
             hideRoot: true,
             rootPath: '',
@@ -69,6 +70,7 @@ export const jContentAccordionItems = registry => {
         icon: <FolderSpecial/>,
         label: 'label.contentManager.navigation.contentFolders',
         defaultPath: siteKey => '/sites/' + siteKey + '/contents',
+        RequiredPermission: 'contentFolderAccordionAccess',
         config: {
             rootPath: '/contents',
             selectableTypes: ['jmix:cmContentTreeDisplayable', 'jmix:visibleInContentTree', 'jnt:contentFolder'],
@@ -84,6 +86,7 @@ export const jContentAccordionItems = registry => {
         icon: <Collections/>,
         label: 'label.contentManager.navigation.media',
         defaultPath: siteKey => '/sites/' + siteKey + '/files',
+        RequiredPermission: 'mediaAccordionAccess',
         config: {
             rootPath: '/files',
             selectableTypes: ['jnt:folder'],
@@ -99,6 +102,7 @@ export const jContentAccordionItems = registry => {
         icon: <Grain/>,
         label: 'label.contentManager.navigation.apps.title',
         appsTarget: 'jcontent',
-        isEnabled: siteKey => siteKey !== 'systemsite'
+        isEnabled: siteKey => siteKey !== 'systemsite',
+        RequiredPermission: 'additionalAccordionAccess'
     });
 };

--- a/src/javascript/JContent/JContent.constants.js
+++ b/src/javascript/JContent/JContent.constants.js
@@ -26,6 +26,13 @@ const JContentConstants = {
     },
     localStorageKeys: {
         filesSelectorMode: 'jcontent_files_selector_mode'
+    },
+    accordionPermissions: {
+        pagesAccordionAccess: 'pagesAccordionAccess',
+        contentFolderAccordionAccess: 'contentFolderAccordionAccess',
+        mediaAccordionAccess: 'mediaAccordionAccess',
+        additionalAccordionAccess: 'additionalAccordionAccess',
+        formAccordionAccess: 'formAccordionAccess'
     }
 };
 

--- a/src/javascript/JContent/JContent.constants.js
+++ b/src/javascript/JContent/JContent.constants.js
@@ -15,6 +15,7 @@ const JContentConstants = {
         CONTENT_FOLDERS: 'content-folders',
         PAGES: 'pages',
         MEDIA: 'media',
+        FORMS: 'forms',
         APPS: 'apps',
         SEARCH: 'search',
         SQL2SEARCH: 'sql2Search',

--- a/src/javascript/JContent/JContent.constants.js
+++ b/src/javascript/JContent/JContent.constants.js
@@ -15,6 +15,7 @@ const JContentConstants = {
         CONTENT_FOLDERS: 'content-folders',
         PAGES: 'pages',
         MEDIA: 'media',
+        APPS: 'apps',
         SEARCH: 'search',
         SQL2SEARCH: 'sql2Search',
         LIST: 'list',

--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -36,5 +36,11 @@
             <openImageEditorAction jcr:primaryType="jnt:permission"/>
             <downloadAction jcr:primaryType="jnt:permission"/>
         </jContentActions>
+        <jContentAccordions jcr:primaryType="jnt:permission">
+            <pagesAccordionAccess jcr:primaryType="jnt:permission"/>
+            <contentFolderAccordionAccess jcr:primaryType="jnt:permission"/>
+            <mediaAccordionAccess jcr:primaryType="jnt:permission"/>
+            <additionalAccordionAccess jcr:primaryType="jnt:permission"/>
+        </jContentAccordions>
     </jContent>
 </permissions>

--- a/src/main/resources/resources/jcontent_en.properties
+++ b/src/main/resources/resources/jcontent_en.properties
@@ -1,1 +1,5 @@
 label.jContent=jContent
+label.permission.additionalAccordionAccess.description=Display the "Additional" accordion in jContent. Note that additional permission may apply on each of the entries of the accordion.
+label.permission.contentFolderAccordionAccess.description=Display the "Content folders" accordion in jContent
+label.permission.mediaAccordionAccess.description=Display the "Media" accordion in jContent
+label.permission.pagesAccordionAccess.description=Display the "Pages" accordion in jContent

--- a/src/main/resources/resources/jcontent_fr.properties
+++ b/src/main/resources/resources/jcontent_fr.properties
@@ -1,0 +1,5 @@
+label.permission.additionalAccordionAccess.description=Affiche l'accordéon "Extensions" dans jContent. Des permissions additionnelles \
+  peuvent s'appliquer pour chaque entrée de cet accordéon.
+label.permission.contentFolderAccordionAccess.description=Affiche l'accordéon "Dossiers de contenu" dans jContent
+label.permission.mediaAccordionAccess.description=Affiche l'accordéon "Média" dans jContent
+label.permission.pagesAccordionAccess.description=Affiche l'accordéon "Pages" dans jContent


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-15824

## Description

Initial display of accordions based on permissions.
Then if permission is missing then on click on the jContent button default to the proper URL.

- [x] In-case of no permission what is the display (confirmed to show at /<lang> blank page)
- [x] Custom permission not really dynamic in a sense (confirmed)