### PR TITLE
BACKLOG-15789: Add page permission check on edit/export in jcontent

### DIFF
--- a/src/javascript/JContent/ContentRoute/MainActionBar/MainActionBar.jsx
+++ b/src/javascript/JContent/ContentRoute/MainActionBar/MainActionBar.jsx
@@ -16,6 +16,7 @@ export const MainActionBar = () => {
     }
 
     const publishAction = node['jnt:folder'] || node['jnt:contentFolder'] ? 'publishAll' : 'publish';
+    const editActionKey = node['jnt:page'] ? 'editPage' : 'edit';
     const disabled = selection && selection.length > 0;
 
     return (
@@ -23,7 +24,7 @@ export const MainActionBar = () => {
             <DisplayAction actionKey="search" path={path} disabled={disabled} render={ButtonRenderer} buttonProps={{variant: 'ghost', size: 'big', 'data-sel-role': 'open-search-dialog'}}/>
             <Separator variant="vertical" invisible="firstOrLastChild" className={styles.showSeparator}/>
             <DisplayAction actionKey="pageComposer" path={path} disabled={disabled} render={ButtonRenderer} buttonProps={{variant: 'ghost', size: 'big', color: 'accent', className: styles.item}}/>
-            <DisplayAction actionKey="edit" path={path} disabled={disabled} render={ButtonRenderer} buttonProps={{variant: 'outlined', size: 'big', className: styles.item}}/>
+            <DisplayAction actionKey={editActionKey} path={path} disabled={disabled} render={ButtonRenderer} buttonProps={{variant: 'outlined', size: 'big', className: styles.item}}/>
 
             <ButtonGroup size="big" variant="default" color="accent" className={styles.item}>
                 <DisplayAction actionKey={publishAction} path={path} disabled={disabled} render={ButtonRendererShortLabel} buttonProps={{variant: 'default', size: 'big', color: 'accent'}}/>

--- a/src/javascript/JContent/ContentRoute/ToolBar/BrowseControlBar/BrowseControlBar.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/BrowseControlBar/BrowseControlBar.jsx
@@ -7,7 +7,21 @@ import {ButtonRenderer, ButtonRendererNoLabel} from '~/utils/getButtonRenderer';
 import {useSelector} from 'react-redux';
 import PropTypes from 'prop-types';
 
-const excludedActions = ['subContents', 'edit', 'publishMenu', 'cut', 'deletePermanently', 'publishDeletion', 'copy', 'paste', 'createFolder', 'createContentFolder', 'createContent', 'fileUpload'];
+const excludedActions = [
+    'subContents',
+    'edit',
+    'editPage',
+    'publishMenu',
+    'cut',
+    'deletePermanently',
+    'publishDeletion',
+    'copy',
+    'paste',
+    'createFolder',
+    'createContentFolder',
+    'createContent',
+    'fileUpload'
+];
 
 export const BrowseControlBar = ({showActions}) => {
     const {path, mode, siteKey} = useSelector(state => ({

--- a/src/javascript/JContent/JContent.actions.jsx
+++ b/src/javascript/JContent/JContent.actions.jsx
@@ -243,10 +243,19 @@ export const jContentActions = registry => {
         targets: ['contentActions:0.1'],
         component: SubContentsActionComponent
     });
+    registry.add('action', 'exportPage', {
+        buttonIcon: <Upload/>,
+        buttonLabel: 'jcontent:label.contentManager.export.actionLabel',
+        targets: ['contentActions:4.2'],
+        showOnNodeTypes: ['jnt:page'],
+        requiredSitePermission: ['exportPageAction'],
+        component: ExportActionComponent
+    });
     registry.add('action', 'export', {
         buttonIcon: <Upload/>,
         buttonLabel: 'jcontent:label.contentManager.export.actionLabel',
         targets: ['contentActions:4.2'],
+        showOnNodeTypes: ['jnt:contentFolder', 'jnt:content'],
         component: ExportActionComponent
     });
     registry.add('action', 'import', {

--- a/src/javascript/JContent/actions/exportAction/exportAction.jsx
+++ b/src/javascript/JContent/actions/exportAction/exportAction.jsx
@@ -6,10 +6,7 @@ import PropTypes from 'prop-types';
 
 export const ExportActionComponent = ({path, render: Render, loading: Loading, ...others}) => {
     const componentRenderer = useContext(ComponentRendererContext);
-    const res = useNodeChecks(
-        {path},
-        {showOnNodeTypes: ['jnt:page', 'jnt:contentFolder', 'jnt:content']}
-    );
+    const res = useNodeChecks({path}, {...others});
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-15789

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Create separate actions for export page/content; add permission check on export page action
* Add action key for action items for edit and edit page in the header bar

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
