### PR TITLE
BACKLOG-16064: Migrate edit permissions to content-editor

### DIFF
--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -7,7 +7,6 @@
         <jContentActions jcr:primaryType="jnt:permission">
             <pageTreeActions jcr:primaryType="jnt:permission">
                 <orderPagesAction jcr:primaryType="jnt:permission"/>
-                <editPageAction jcr:primaryType="jnt:permission"/>
                 <copyPageAction jcr:primaryType="jnt:permission"/>
                 <cutPageAction jcr:primaryType="jnt:permission"/>
                 <pastePageAction jcr:primaryType="jnt:permission"/>
@@ -20,7 +19,6 @@
                 <exportPageAction jcr:primaryType="jnt:permission"/>
                 <importPageAction jcr:primaryType="jnt:permission"/>
             </pageTreeActions>
-            <editAction jcr:primaryType="jnt:permission"/>
             <copyAction jcr:primaryType="jnt:permission"/>
             <cutAction jcr:primaryType="jnt:permission"/>
             <pasteAction jcr:primaryType="jnt:permission"/>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16064

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- migrate (remove) editAction and editPageAction permission from jcontent to content-editor

Related PR (in content-editor): https://github.com/Jahia/content-editor/pull/969
