### PR TITLE
BACKLOG-16278: Add jnt:contentFolder in non-recurse filter

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx
@@ -75,8 +75,7 @@ export const ContentLayoutContainer = ({
 
     // Update params for structured view to use different type and recursion filters
     if (isStructuredView) {
-        layoutQueryParams = queryHandler.updateQueryParamsForStructuredView(layoutQueryParams,
-            mode === JContentConstants.mode.PAGES ? tableView.viewType : JContentConstants.tableView.viewType.ALL);
+        layoutQueryParams = queryHandler.updateQueryParamsForStructuredView(layoutQueryParams, tableView.viewType);
     }
 
     const {data, error, loading, refetch} = useQuery(layoutQuery, {

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.gql-queries.js
@@ -167,27 +167,21 @@ class ContentQueryHandler {
             limit: 10000
         };
 
-        if (JContentConstants.tableView.viewType.CONTENT === viewType) {
-            return {
+        const {CONTENT, PAGES} = JContentConstants.tableView.viewType;
+        switch (viewType) {
+            case CONTENT: return {
                 ...p,
-                recursionTypesFilter: {types: ['jnt:content']},
+                recursionTypesFilter: {multi: 'NONE', types: ['jnt:contentFolder']},
                 typeFilter: ['jnt:content']
             };
-        }
-
-        if (JContentConstants.tableView.viewType.PAGES === viewType) {
-            return {
+            case PAGES: return {
                 ...p,
                 recursionTypesFilter: {types: ['jnt:page']},
                 typeFilter: ['jnt:page']
             };
-        }
 
-        return {
-            ...p,
-            recursionTypesFilter: null,
-            typeFilter: ['jnt:page', 'jnt:content']
-        };
+            default: return p;
+        }
     }
 
     getResultsPath(data) {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16278

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Filter jnt:contentFilter for recursion in graphql. 

This hides content under content folders in both flat list and structured view.

