### PR TITLE
BACKLOG-16290: Fix disappearing params being overridden

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx
@@ -200,7 +200,7 @@ export const ContentLayoutContainer = ({
             let subTypes = ['jnt:page', 'jnt:contentFolder', 'jnt:virtualsite'];
             let isSub = !subTypes.includes(nodeTypeName);
             // Sub is not the same as params.sub; refresh and sync up path param state
-            if (isSub !== Boolean(params.sub)) {
+            if (isSub !== (params.sub === true)) { // Params.sub needs to be boolean type; else falsy
                 setPath(path, {sub: isSub});
             }
         }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16290

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Check for `params.sub` needed to be a boolean-type check rather than just truthy/falsy since params can be a string and `params.sub` resolves to truthy (i.e. `sub()` is an existing function of string)