### PR TITLE
QA-13820: Changed to fixed width columns in jContent table

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@jahia/data-helper": "^1.0.3",
     "@jahia/design-system-kit": "^1.1.2",
     "@jahia/icons": "^1.1.1",
-    "@jahia/moonstone": "^1.5.0",
+    "@jahia/moonstone": "^1.5.1",
     "@jahia/react-material": "^3.0.1",
     "@jahia/ui-extender": "^1.0.0",
     "@material-ui/core": "^3.6.2",

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
                         </goals>
                         <configuration>
                             <nodeVersion>v12.16.0</nodeVersion>
-                            <yarnVersion>v1.19.1</yarnVersion>
+                            <yarnVersion>v1.22.10</yarnVersion>
                         </configuration>
                     </execution>
                     <execution>

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentEmptyDropZone.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentEmptyDropZone.jsx
@@ -15,6 +15,7 @@ const styles = theme => ({
         padding: theme.spacing.unit * 4
     },
     dragZone: {
+        justifyContent: 'center',
         display: 'flex',
         padding: 0,
         width: '100%'

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentListHeader/ContentListHeader.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentListHeader/ContentListHeader.jsx
@@ -3,14 +3,24 @@ import PropTypes from 'prop-types';
 import {withTranslation} from 'react-i18next';
 import {compose} from '~/utils';
 import {TableHeadCell, TableRow, TableHead, SortIndicator} from '@jahia/moonstone';
+import {columnWidths} from '../reactTable/columns';
+import clsx from 'clsx';
+import classes from '../ContentTable.scss';
 
 export const ContentListHeader = ({headerGroups}) => {
     return (
         <TableHead>
             {headerGroups.map(headerGroup => (
-                <TableRow key={'headerGroup' + headerGroup.id} {...headerGroup.getHeaderGroupProps()}>
+                <TableRow key={'headerGroup' + headerGroup.id}
+                          {...headerGroup.getHeaderGroupProps()}
+                          className={classes.tableHeader}
+                >
                     {headerGroup.headers.map(column => (
-                        <TableHeadCell key={column.id} {...column.getHeaderProps(column.getSortProps())}>
+                        <TableHeadCell key={column.id}
+                                       {...column.getHeaderProps(column.getSortProps())}
+                                       className={clsx(classes[`header-${column.id}`])}
+                                       width={columnWidths[column.id]}
+                        >
                             {column.render('Header')}
                             {column.sortable && <SortIndicator isSorted={column.sorted} direction={column.sortDirection}/>}
                         </TableHeadCell>

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
@@ -19,7 +19,7 @@ import ContentListEmptyDropZone from './ContentEmptyDropZone';
 import ContentNotFound from './ContentNotFound';
 import EmptyTable from './EmptyTable';
 import {Table, TableBody, TablePagination, TableRow} from '@jahia/moonstone';
-import {useTable, useFlexLayout, useExpanded} from 'react-table';
+import {useTable, useExpanded} from 'react-table';
 import {useRowSelection} from './reactTable/plugins';
 import {useSort} from './reactTable/plugins';
 import ContentListHeader from './ContentListHeader/ContentListHeader';
@@ -80,8 +80,7 @@ export const ContentTable = ({
         },
         useRowSelection,
         useSort,
-        useExpanded,
-        useFlexLayout
+        useExpanded
     );
 
     useEffect(() => {
@@ -147,7 +146,11 @@ export const ContentTable = ({
                                  onKeyDown={handleKeyboardNavigation}
                                  onClick={setFocusOnMainContainer}
             >
-                <Table aria-labelledby="tableTitle" data-cm-role="table-content-list" {...getTableProps()} style={{width: '100%'}}>
+                <Table aria-labelledby="tableTitle"
+                       data-cm-role="table-content-list"
+                       {...getTableProps()}
+                       style={{width: '100%', minWidth: '1100px'}}
+                >
                     <ContentListHeader headerGroups={headerGroups}/>
                     <UploadTransformComponent uploadTargetComponent={TableBody}
                                               uploadPath={path}

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.scss
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.scss
@@ -2,11 +2,7 @@
 
 .tableRow {
     &:hover .cellActions {
-        display: flex;
-    }
-
-    &:hover .cellLastModifiedText {
-        display: none;
+        visibility: inherit;
     }
 }
 
@@ -18,6 +14,12 @@
 
     outline: none;
     overflow: auto;
+}
+
+.tableHeader {
+    .header-name {
+        flex-grow: 1;
+    }
 }
 
 .empty {

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/columns/columns.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/columns/columns.js
@@ -1,20 +1,27 @@
 import {Cell, CellLastModified, CellPublicationStatus, CellSelection, CellVisibleActions, CellName, CellStatus, CellType} from '../components/cells';
 import {Header, HeaderSelection} from '../components/headers';
 
+export const columnWidths = {
+    publicationStatus: '15px',
+    selection: '50px',
+    name: '300px',
+    status: '115px',
+    type: '180px',
+    createdBy: '150px',
+    lastModified: '220px',
+    visibleActions: '60px'
+};
+
 export const allColumnData = [
     {
         id: 'publicationStatus',
         sortable: false,
-        width: 50,
-        maxWidth: 50,
         Header: '',
         Cell: CellPublicationStatus
     },
     {
         id: 'selection',
         sortable: false,
-        width: 50,
-        maxWidth: 50,
         Header: HeaderSelection,
         Cell: CellSelection
     },
@@ -24,7 +31,6 @@ export const allColumnData = [
         label: 'jcontent:label.contentManager.listColumns.name',
         sortable: true,
         property: 'displayName',
-        width: 300,
         Cell: CellName,
         Header: Header
     },
@@ -32,8 +38,6 @@ export const allColumnData = [
         id: 'status',
         label: 'jcontent:label.contentManager.listColumns.status',
         sortable: false,
-        width: 100,
-        maxWidth: 100,
         Header: '',
         Cell: CellStatus
     },
@@ -43,8 +47,6 @@ export const allColumnData = [
         label: 'jcontent:label.contentManager.listColumns.type',
         sortable: true,
         property: 'primaryNodeType.displayName',
-        width: 150,
-        maxWidth: 150,
         Cell: CellType,
         Header: Header
     },
@@ -53,8 +55,6 @@ export const allColumnData = [
         accessor: 'createdBy',
         label: 'jcontent:label.contentManager.listColumns.createdBy',
         sortable: true,
-        width: 100,
-        maxWidth: 100,
         property: 'createdBy.value',
         Header: Header,
         Cell: Cell
@@ -65,15 +65,12 @@ export const allColumnData = [
         label: 'jcontent:label.contentManager.listColumns.lastModified',
         sortable: true,
         property: 'lastModified.value',
-        width: 200,
         Cell: CellLastModified,
         Header: Header
     },
     {
         id: 'visibleActions',
         Header: '',
-        width: 40,
-        maxWidth: 40,
         Cell: CellVisibleActions
     }
 ];

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/Cell.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/Cell.jsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {columnWidths} from '../../columns';
 import {TableBodyCell, Typography} from '@jahia/moonstone';
 
 export const Cell = ({value, cell, column, row}) => (
-    <TableBodyCell key={row.id + column.id} {...cell.getCellProps()} data-cm-role={'table-content-list-cell-' + column.id}>
+    <TableBodyCell key={row.id + column.id}
+                   {...cell.getCellProps()}
+                   width={columnWidths[column.id]}
+                   data-cm-role={'table-content-list-cell-' + column.id}
+    >
         <Typography>{value}</Typography>
     </TableBodyCell>
 );

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellLastModified.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellLastModified.jsx
@@ -19,8 +19,8 @@ export const CellLastModified = ({row, value, cell, column}) => {
                        data-cm-role={'table-content-list-cell-' + column.id}
         >
             <div className={css.cellLastModified}>
-                <Typography className={css.cellLastModifiedText}>
-                    <time>{dayjs(value).locale(getDefaultLocale(uilang)).format('ll')}</time>
+                <Typography className={css.cellLastModifiedText} component="time">
+                    {dayjs(value).locale(getDefaultLocale(uilang)).format('ll')}
                 </Typography>
                 <div className={css.cellActions}
                      data-cm-role="table-content-list-cell-actions"

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellLastModified.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellLastModified.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {useSelector} from 'react-redux';
 import {TableBodyCell, Typography} from '@jahia/moonstone';
+import {columnWidths} from '../../columns';
 import css from '../../../ContentTable.scss';
 import dayjs from 'dayjs';
 import {ButtonRendererNoLabel} from '~/utils/getButtonRenderer';
@@ -12,23 +13,30 @@ import PropTypes from 'prop-types';
 export const CellLastModified = ({row, value, cell, column}) => {
     const uilang = useSelector(state => state.uilang);
     return (
-        <TableBodyCell key={row.id + column.id} {...cell.getCellProps()} data-cm-role={'table-content-list-cell-' + column.id}>
-            <Typography className={css.cellLastModifiedText}>
-                <time>{dayjs(value).locale(getDefaultLocale(uilang)).format('ll')}</time>
-            </Typography>
-            <div className={css.cellActions}
-                 data-cm-role="table-content-list-cell-actions"
-            >
-                <DisplayActions
-                    target="contentActions"
-                    filter={value => {
-                        return includes(['edit', 'preview', 'subContents', 'locate'], value.key);
-                    }}
-                    path={row.original.path}
-                    render={ButtonRendererNoLabel}
-                    buttonProps={{variant: 'ghost', size: 'big'}}
-                />
+        <TableBodyCell key={row.id + column.id}
+                       {...cell.getCellProps()}
+                       width={columnWidths[column.id]}
+                       data-cm-role={'table-content-list-cell-' + column.id}
+        >
+            <div className={css.cellLastModified}>
+                <Typography className={css.cellLastModifiedText}>
+                    <time>{dayjs(value).locale(getDefaultLocale(uilang)).format('ll')}</time>
+                </Typography>
+                <div className={css.cellActions}
+                     data-cm-role="table-content-list-cell-actions"
+                >
+                    <DisplayActions
+                        target="contentActions"
+                        filter={value => {
+                            return includes(['edit', 'preview', 'subContents', 'locate'], value.key);
+                        }}
+                        path={row.original.path}
+                        render={ButtonRendererNoLabel}
+                        buttonProps={{variant: 'ghost', size: 'big'}}
+                    />
+                </div>
             </div>
+
         </TableBodyCell>
     );
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellName.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellName.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import {TableBodyCell} from '@jahia/moonstone';
-import css from './Cells.scss';
 import {Folder} from 'mdi-material-ui';
 import {isEmpty} from 'lodash';
 import {DocumentIcon, FileIcon, ImageIcon, ZipIcon} from '../../../../icons';
 import PropTypes from 'prop-types';
 import {isMarkedForDeletion} from '../../../../../../JContent.utils';
+import {columnWidths} from '../../columns';
 import classes from './Cells.scss';
+import clsx from 'clsx';
 
 const addIconSuffix = icon => {
     return (icon.includes('.png') ? icon : icon + '.png');
@@ -15,23 +16,23 @@ const addIconSuffix = icon => {
 const getMediaIcon = node => {
     switch (node.primaryNodeType.name) {
         case 'jnt:folder':
-            return <Folder className={css.icon}/>;
+            return <Folder className={classes.icon}/>;
         case 'jnt:file':
             if (node.mixinTypes.length !== 0 && !isEmpty(node.mixinTypes.filter(mixin => mixin.name === 'jmix:image'))) {
-                return <ImageIcon className={css.icon}/>;
+                return <ImageIcon className={classes.icon}/>;
             }
 
             if (node.name.match(/.zip$/g) || node.name.match(/.tar$/g) || node.name.match(/.rar$/g)) {
-                return <ZipIcon className={css.icon}/>;
+                return <ZipIcon className={classes.icon}/>;
             }
 
             if (node.mixinTypes.length !== 0 && !isEmpty(node.mixinTypes.filter(mixin => mixin.name === 'jmix:document'))) {
-                return <DocumentIcon className={css.icon}/>;
+                return <DocumentIcon className={classes.icon}/>;
             }
 
-            return <FileIcon className={css.icon}/>;
+            return <FileIcon className={classes.icon}/>;
         default:
-            return <img src={addIconSuffix(node.primaryNodeType.icon)}/>;
+            return <img className={classes.icon} src={addIconSuffix(node.primaryNodeType.icon)}/>;
     }
 };
 
@@ -39,7 +40,19 @@ export const CellName = ({value, cell, column, row}) => {
     const node = row.original;
     const deleted = isMarkedForDeletion(node);
     return (
-        <TableBodyCell key={row.id + column.id} isExpandableColumn className={deleted ? classes.deleted : ''} {...cell.getCellProps()} row={row} cell={cell} iconStart={row.original[cell.column.id]?.icon} data-cm-role="table-content-list-cell-name">
+        <TableBodyCell key={row.id + column.id}
+                       isExpandableColumn
+                       className={clsx(
+                           classes.cellName,
+                           {[classes.deleted]: deleted}
+                       )}
+                       width={columnWidths[column.id]}
+                       {...cell.getCellProps()}
+                       row={row}
+                       cell={cell}
+                       iconStart={row.original[cell.column.id]?.icon}
+                       data-cm-role="table-content-list-cell-name"
+        >
             {getMediaIcon(node)}{value}
         </TableBodyCell>
     );

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellPublicationStatus.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellPublicationStatus.jsx
@@ -3,6 +3,8 @@ import {TableBodyCell} from '@jahia/moonstone';
 import PublicationStatus from '../../../../PublicationStatus';
 import PropTypes from 'prop-types';
 import {withStyles} from '@material-ui/core';
+import scssStyles from './Cells.scss';
+import {columnWidths} from '../../columns';
 
 const styles = () => ({
     root: {
@@ -17,7 +19,12 @@ const styles = () => ({
 });
 
 export const CellPublicationStatus = withStyles(styles)(({row, cell, column, classes}) => (
-    <TableBodyCell key={row.id + column.id} {...cell.getCellProps()} data-cm-role="table-content-list-cell-publication">
+    <TableBodyCell key={row.id + column.id}
+                   className={scssStyles.publicationStatusCell}
+                   {...cell.getCellProps()}
+                   width={columnWidths[column.id]}
+                   data-cm-role="table-content-list-cell-publication"
+    >
         <PublicationStatus node={row.original} classes={{root: classes.root}}/>
     </TableBodyCell>
 ));

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellSelection.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellSelection.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import {Checkbox, TableBodyCell} from '@jahia/moonstone';
 import PropTypes from 'prop-types';
+import {columnWidths} from '../../columns';
 
 export const CellSelection = ({row, cell, column}) => (
-    <TableBodyCell key={row.id + column.id} {...cell.getCellProps()}>
+    <TableBodyCell key={row.id + column.id}
+                   {...cell.getCellProps()}
+                   width={columnWidths[column.id]}
+    >
         <Checkbox isUncontrolled {...row.getToggleRowSelectedProps()}/>
     </TableBodyCell>
 );

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellStatus.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellStatus.jsx
@@ -5,6 +5,7 @@ import {isWorkInProgress} from '../../../../../../JContent.utils';
 import {useSelector} from 'react-redux';
 import {useTranslation} from 'react-i18next';
 import {Tooltip} from '@material-ui/core';
+import {columnWidths} from '../../columns';
 import classes from './Cells.scss';
 
 export const CellStatus = ({cell, column, row}) => {
@@ -14,7 +15,10 @@ export const CellStatus = ({cell, column, row}) => {
     const showSubNodes = node.primaryNodeType.name !== 'jnt:page' && node.subNodes && node.subNodes.pageInfo.totalCount > 0;
 
     return (
-        <TableBodyCell key={row.id + column.id} {...cell.getCellProps()}>
+        <TableBodyCell key={row.id + column.id}
+                       {...cell.getCellProps()}
+                       width={columnWidths[column.id]}
+        >
             {isWorkInProgress(node, lang) &&
             <Tooltip title={node.wipLangs ? t('jcontent:label.contentManager.workInProgress', {wipLang: node.wipLangs.values}) : t('jcontent:label.contentManager.workInProgressAll')}><Chip className={classes.statusCellItem} icon={<Build fontSize="small"/>}/></Tooltip>}
             {node.lockOwner !== null &&

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellType.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellType.jsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {columnWidths} from '../../columns';
-import css from '../../../ContentTable.scss';
 import {TableBodyCell, Typography} from '@jahia/moonstone';
 
 export const CellType = ({value, cell, column, row}) => {
     return (
         <TableBodyCell key={row.id + column.id} {...cell.getCellProps()} width={columnWidths[column.id]}>
-            <div className={css.cellType}>
-                <Typography>{value}</Typography>
-            </div>
+            <Typography isNowrap>{value}</Typography>
         </TableBodyCell>
     );
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellType.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellType.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {columnWidths} from '../../columns';
 import css from '../../../ContentTable.scss';
 import {TableBodyCell, Typography} from '@jahia/moonstone';
 
 export const CellType = ({value, cell, column, row}) => {
     return (
-        <TableBodyCell key={row.id + column.id} {...cell.getCellProps()}>
+        <TableBodyCell key={row.id + column.id} {...cell.getCellProps()} width={columnWidths[column.id]}>
             <div className={css.cellType}>
                 <Typography>{value}</Typography>
             </div>

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellVisibleActions.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellVisibleActions.jsx
@@ -4,9 +4,16 @@ import {DisplayAction} from '@jahia/ui-extender';
 import {includes} from 'lodash';
 import {ButtonRendererNoLabel} from '~/utils/getButtonRenderer';
 import PropTypes from 'prop-types';
+import {columnWidths} from '../../columns';
+import classes from './Cells.scss';
 
 export const CellVisibleActions = ({row, cell, column}) => (
-    <TableBodyCell key={row.id + column.id} {...cell.getCellProps()} data-cm-role="table-content-list-cell-actions">
+    <TableBodyCell key={row.id + column.id}
+                   className={classes.visibleActions}
+                   {...cell.getCellProps()}
+                   width={columnWidths[column.id]}
+                   data-cm-role="table-content-list-cell-actions"
+    >
         <DisplayAction
             actionKey="contentMenu"
             path={row.original.path}

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/Cells.scss
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/Cells.scss
@@ -1,29 +1,47 @@
 .cellActions {
-    display: none;
+    display: flex;
     justify-content: flex-end;
     align-items: center;
     width: inherit;
     height: 48px;
 
     background-color: transparent;
+
+    visibility: hidden;
 }
 
 .cellType {
-    display: flex;
-    flex-direction: row;
+    p {
+        overflow: hidden;
 
+        text-overflow: ellipsis;
+    }
+}
+
+.cellName {
+    flex-grow: 1;
+}
+
+.cellLastModified {
+    display: flex;
     justify-content: space-between;
     align-items: center;
 }
 
-.cellLastModifiedText {
-    display: inherit;
+.visibleActions {
+    div {
+        width: inherit;
+    }
 }
 
 .icon {
-    margin-right: 3px;
+    padding: 0 var(--spacing-nano);
 
-    vertical-align: bottom;
+    vertical-align: top;
+}
+
+.publicationStatusCell div {
+    padding-left: 0;
 }
 
 .badge {

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/Cells.scss
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/Cells.scss
@@ -10,14 +10,6 @@
     visibility: hidden;
 }
 
-.cellType {
-    p {
-        overflow: hidden;
-
-        text-overflow: ellipsis;
-    }
-}
-
 .cellName {
     flex-grow: 1;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1323,10 +1323,10 @@
     mdi-material-ui "^5.10.0"
     recompose "^0.30.0"
 
-"@jahia/moonstone@^1.5.0":
-  version "1.5.0"
-  resolved "https://npm.jahia.com/@jahia%2fmoonstone/-/moonstone-1.5.0.tgz#3f6e8e7df225bd7f1674cba5217806dccd303137"
-  integrity sha512-CUbsrA3E7OxppzebTtlDEfL/aI9vtQZ9eZCScew6L9uHurP76lqoSA1s3mkeVcz+OIYrcWiy3ueCkarCrGHc2w==
+"@jahia/moonstone@^1.5.1":
+  version "1.5.1"
+  resolved "https://npm.jahia.com/@jahia%2fmoonstone/-/moonstone-1.5.1.tgz#c252d4a892cbfa616525e42867a416e85a29ff19"
+  integrity sha512-mFmkw45kCj4x8zKvgaIZ3h2/X2LMVG2mgWslXKlk914/Wj5V5KsUPbfpmSPwdloQNFvNHFn94J88GVdFO8rCOQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@react-aria/checkbox" "^3.2.1"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-13820

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Override with fixed widths defined in [column.scss](https://github.com/Jahia/jcontent/compare/QA-13820-fixed-width-table?expand=1#diff-2f18d76aac076d4cbe19864378679f9ecf450e075e5b27246abe29647a3d06c2R4) by adding `width` attribute in the Cell components
* Also modify so that name column flexes and takes rest of space (using `flex-grow: 1`)
* Fixed spacing of icons in the name column
* Fixed to left-align publication status indicator
* Fixed issue of disappearing last modified text when hovered
* Fixed cut-off context menu hover icon
* Fixed moving text on hover issue 
* Center-align EmptyDropZone text


https://user-images.githubusercontent.com/75278792/127507206-b8453052-514d-4742-af45-3b987c01c85e.mov


