### PR TITLE
BACKLOG-16326: Fixed lint issues

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": "@jahia",
   "rules": {
-    "react/boolean-prop-naming": [1, { "rule": "^(is|has)[A-Z]([A-Za-z0-9]?)+" }]
+    "react/boolean-prop-naming": [2, { "rule": "^(is|has)[A-Z]([A-Za-z0-9]?)+|enabled" }]
   }
 }

--- a/src/javascript/JContent.register.jsx
+++ b/src/javascript/JContent.register.jsx
@@ -69,7 +69,7 @@ export default function () {
                             label={t('label.name')}
                             icon={<Collections/>}
                             onClick={() => {
-                                history.push(buildUrl(site, language, mode || defaultMode, path, params));
+                                history.push(buildUrl({site, language, mode: mode || defaultMode, path, params}));
                                 initClipboardWatcher(dispatch, client);
                             }}/>
         );

--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SiteSwitcher.jsx
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SiteSwitcher.jsx
@@ -49,7 +49,6 @@ class SiteSwitcher extends React.Component {
     getSites(data) {
         let siteNodes = [];
         if (data && data.jcr.result !== null) {
-            // eslint-disable-next-line no-unused-vars
             for (let i in data.jcr.result.siteNodes) {
                 if (data.jcr.result.siteNodes[i].hasPermission) {
                     siteNodes.push(data.jcr.result.siteNodes[i]);
@@ -63,7 +62,6 @@ class SiteSwitcher extends React.Component {
     getTargetSiteLanguageForSwitch(siteNode, currentLang) {
         let newLang = null;
         let siteLanguages = siteNode.site.languages;
-        // eslint-disable-next-line no-unused-vars
         for (let i in siteLanguages) {
             if (Object.prototype.hasOwnProperty.call(siteLanguages, i)) {
                 let lang = siteLanguages[i];

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx
@@ -71,7 +71,7 @@ export const ContentLayoutContainer = ({
     const layoutQuery = queryHandler.getQuery();
     const rootPath = `/sites/${siteKey}`;
     const preloadForType = tableView.viewType === JContentConstants.tableView.viewType.PAGES ? JContentConstants.tableView.viewType.CONTENT : JContentConstants.tableView.viewType.PAGES;
-    let layoutQueryParams = queryHandler.getQueryParams(path, uilang, lang, params, rootPath, pagination, sort, tableView.viewType);
+    let layoutQueryParams = queryHandler.getQueryParams({path, uilang, lang, urlParams: params, rootPath, pagination, sort, viewType: tableView.viewType});
 
     // Update params for structured view to use different type and recursion filters
     if (isStructuredView) {
@@ -83,117 +83,133 @@ export const ContentLayoutContainer = ({
         fetchPolicy: fetchPolicy
     });
 
-    const onGwtContentModification = async (nodeUuid, nodePath, nodeName, operation) => {
-        let refetchObservableQueries = true;
+    function onGwtCreate(nodePath) {
+        let parentPath = nodePath.substring(0, nodePath.lastIndexOf('/'));
+        client.cache.flushNodeEntryByPath(parentPath);
+        if (path !== parentPath) {
+            // Make sure the created CONTENT is visible in the main panel.
+            setPath(parentPath);
+        }
 
+        return client.reFetchObservableQueries();
+    }
+
+    function onGwtDelete(nodePath) {
+        // Clear cache entries for subnodes
+        Object.keys(client.cache.idByPath)
+            .filter(p => isDescendantOrSelf(p, nodePath))
+            .forEach(p => client.cache.flushNodeEntryByPath(p));
+
+        // Switch to the closest available ancestor node in case of currently selected node or any of its ancestor nodes deletion.
+        if (isDescendantOrSelf(path, nodePath)) {
+            setPath(nodePath.substring(0, nodePath.lastIndexOf('/')));
+        }
+
+        // Close any expanded nodes that have been just removed.
+        let pathsToClose = _.filter(openedPaths, openedPath => isDescendantOrSelf(openedPath, nodePath));
+        if (!_.isEmpty(pathsToClose)) {
+            closePaths(pathsToClose);
+        }
+
+        // De-select any removed nodes.
+        if (previewSelection && isDescendantOrSelf(previewSelection, nodePath)) {
+            setPreviewSelection(null);
+        }
+
+        return client.reFetchObservableQueries();
+    }
+
+    function onGwtRename(nodePath, nodeName) {
+        let parentPath = nodePath.substring(0, nodePath.lastIndexOf('/'));
+        let newPath = parentPath + '/' + nodeName;
+
+        // Clear cache entries for subnodes
+        Object.keys(client.cache.idByPath)
+            .filter(p => isDescendantOrSelf(p, nodePath))
+            .forEach(p => client.cache.flushNodeEntryByPath(p));
+
+        // Switch to the new renamed node
+        if (isDescendantOrSelf(path, nodePath)) {
+            setPath(getNewNodePath(path, nodePath, newPath));
+        }
+
+        let pathsToReopen = _.filter(openedPaths, openedPath => isDescendantOrSelf(openedPath, nodePath));
+        if (!_.isEmpty(pathsToReopen)) {
+            closePaths(pathsToReopen);
+            pathsToReopen = _.map(pathsToReopen, pathToReopen => getNewNodePath(pathToReopen, nodePath, newPath));
+            openPaths(pathsToReopen);
+        }
+
+        // De-select any removed nodes.
+        if (previewSelection && isDescendantOrSelf(previewSelection, nodePath)) {
+            setPreviewSelection(getNewNodePath(previewSelection, nodePath, newPath));
+        }
+
+        return client.reFetchObservableQueries();
+    }
+
+    async function onGwtUpdate(nodePath, nodeUuid) {
+        // If we're modifying the contribute settings we need to flush also node descendants
+        // so we fetch the node in cache and we search for contribute mixin
+        let node;
+        try {
+            node = client.readQuery({query: mixinTypes, variables: {path: nodePath}});
+        } catch (e) {
+            console.log(e);
+        }
+
+        client.cache.flushNodeEntryById(nodeUuid);
+        await client.reFetchObservableQueries();
+        let nodeAfterCacheFlush = client.readQuery({query: mixinTypes, variables: {path: nodePath}});
+        if (node && nodeAfterCacheFlush && (!_.isEmpty(nodeAfterCacheFlush.jcr.nodeByPath.mixinTypes.filter(mixin => mixin.name === 'jmix:contributeMode')) ||
+            !_.isEmpty(node.jcr.nodeByPath.mixinTypes.filter(mixin => mixin.name === 'jmix:contributeMode')))) {
+            Object.keys(client.cache.idByPath)
+                .filter(p => isDescendantOrSelf(p, nodePath))
+                .forEach(p => client.cache.flushNodeEntryByPath(p));
+        }
+
+        if (selection.length > 0) {
+            // Modification when using multiple selection actions
+            let selectedNodes = _.clone(selection);
+            setTimeout(function () {
+                if (_.includes(selectedNodes, nodePath)) {
+                    removeSelection(nodePath);
+                    switchSelection(nodePath);
+                }
+            });
+        }
+    }
+
+    const onGwtContentModification = async (nodeUuid, nodePath, nodeName, operation) => {
         if (operation === 'update' && !nodePath.endsWith('/' + nodeName)) {
             operation = 'rename';
         }
 
         if (operation === 'create') {
-            let parentPath = nodePath.substring(0, nodePath.lastIndexOf('/'));
-            client.cache.flushNodeEntryByPath(parentPath);
-            if (path !== parentPath) {
-                // Make sure the created CONTENT is visible in the main panel.
-                setPath(parentPath);
-            }
+            await onGwtCreate(nodePath);
         } else if (operation === 'delete') {
-            // Clear cache entries for subnodes
-            Object.keys(client.cache.idByPath)
-                .filter(p => isDescendantOrSelf(p, nodePath))
-                .forEach(p => client.cache.flushNodeEntryByPath(p));
-
-            // Switch to the closest available ancestor node in case of currently selected node or any of its ancestor nodes deletion.
-            if (isDescendantOrSelf(path, nodePath)) {
-                setPath(nodePath.substring(0, nodePath.lastIndexOf('/')));
-            }
-
-            // Close any expanded nodes that have been just removed.
-            let pathsToClose = _.filter(openedPaths, openedPath => isDescendantOrSelf(openedPath, nodePath));
-            if (!_.isEmpty(pathsToClose)) {
-                closePaths(pathsToClose);
-            }
-
-            // De-select any removed nodes.
-            if (previewSelection && isDescendantOrSelf(previewSelection, nodePath)) {
-                setPreviewSelection(null);
-            }
+            await onGwtDelete(nodePath);
         } else if (operation === 'rename') {
-            let parentPath = nodePath.substring(0, nodePath.lastIndexOf('/'));
-            let newPath = parentPath + '/' + nodeName;
-
-            // Clear cache entries for subnodes
-            Object.keys(client.cache.idByPath)
-                .filter(p => isDescendantOrSelf(p, nodePath))
-                .forEach(p => client.cache.flushNodeEntryByPath(p));
-
-            // Switch to the new renamed node
-            if (isDescendantOrSelf(path, nodePath)) {
-                setPath(getNewNodePath(path, nodePath, newPath));
-            }
-
-            let pathsToReopen = _.filter(openedPaths, openedPath => isDescendantOrSelf(openedPath, nodePath));
-            if (!_.isEmpty(pathsToReopen)) {
-                closePaths(pathsToReopen);
-                pathsToReopen = _.map(pathsToReopen, pathToReopen => getNewNodePath(pathToReopen, nodePath, newPath));
-                openPaths(pathsToReopen);
-            }
-
-            // De-select any removed nodes.
-            if (previewSelection && isDescendantOrSelf(previewSelection, nodePath)) {
-                setPreviewSelection(getNewNodePath(previewSelection, nodePath, newPath));
-            }
+            await onGwtRename(nodePath, nodeName);
         } else if (operation === 'update') {
-            // If we're modifying the contribute settings we need to flush also node descendants
-            // so we fetch the node in cache and we search for contribute mixin
-            let node;
-            try {
-                node = client.readQuery({query: mixinTypes, variables: {path: nodePath}});
-            } catch (e) {
-                console.log(e);
-            }
-
-            client.cache.flushNodeEntryById(nodeUuid);
-            await client.reFetchObservableQueries();
-            refetchObservableQueries = false;
-            let nodeAfterCacheFlush = client.readQuery({query: mixinTypes, variables: {path: nodePath}});
-            if (node && nodeAfterCacheFlush && (!_.isEmpty(nodeAfterCacheFlush.jcr.nodeByPath.mixinTypes.filter(mixin => mixin.name === 'jmix:contributeMode')) ||
-                !_.isEmpty(node.jcr.nodeByPath.mixinTypes.filter(mixin => mixin.name === 'jmix:contributeMode')))) {
-                Object.keys(client.cache.idByPath)
-                    .filter(p => isDescendantOrSelf(p, nodePath))
-                    .forEach(p => client.cache.flushNodeEntryByPath(p));
-            }
-
-            if (selection.length > 0) {
-                // Modification when using multiple selection actions
-                let selectedNodes = _.clone(selection);
-                setTimeout(function () {
-                    if (_.includes(selectedNodes, nodePath)) {
-                        removeSelection(nodePath);
-                        switchSelection(nodePath);
-                    }
-                });
-            }
-        }
-
-        if (refetchObservableQueries) {
-            client.reFetchObservableQueries();
+            await onGwtUpdate(nodePath, nodeUuid);
         }
     };
 
     // Preload data either for pages or contents depending on current view type
-    const preloadedData = usePreloadedData(
+    const preloadedData = usePreloadedData({
         client,
-        {
+        options: {
             query: layoutQuery,
             variables: isStructuredView ?
                 queryHandler.updateQueryParamsForStructuredView(layoutQueryParams, preloadForType, mode) :
-                queryHandler.getQueryParams(path, uilang, lang, params, rootPath, {...pagination, currentPage: 0}, sort, preloadForType),
+                queryHandler.getQueryParams({path, uilang, lang, urlParams: params, rootPath, pagination: {...pagination, currentPage: 0}, sort, viewType: preloadForType}),
             fetchPolicy: fetchPolicy
         },
         tableView,
         path,
-        pagination);
+        pagination
+    });
 
     useEffect(() => {
         if (data && data.jcr && data.jcr.nodeByPath) {
@@ -228,14 +244,14 @@ export const ContentLayoutContainer = ({
         }
 
         return (
-            <ContentLayout contentNotFound
+            <ContentLayout isContentNotFound
                            mode={mode}
                            path={path}
                            filesMode={filesMode}
                            previewState={previewState}
                            previewSelection={previewSelection}
                            rows={[]}
-                           loading={loading}
+                           isLoading={loading}
                            totalCount={0}
             />
         );

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.gql-queries.js
@@ -121,7 +121,7 @@ class ContentQueryHandler {
         `;
     }
 
-    getQueryParams(path, uilang, lang, urlParams, rootPath, pagination, sort, viewType) {
+    getQueryParams({path, uilang, lang, urlParams, rootPath, pagination, sort, viewType}) {
         let type = urlParams.type || (_.startsWith(path, rootPath + '/contents') ? 'contents' : 'pages');
         if (urlParams.sub) {
             type = 'contents';
@@ -229,7 +229,7 @@ class FilesQueryHandler {
         `;
     }
 
-    getQueryParams(path, uilang, lang, urlParams, rootPath, pagination, sort) {
+    getQueryParams({path, uilang, lang, pagination, sort}) {
         return {
             path: path,
             language: lang,
@@ -294,7 +294,7 @@ class SearchQueryHandler {
         `;
     }
 
-    getQueryParams(path, uilang, lang, urlParams, rootPath, pagination, sort) {
+    getQueryParams({uilang, lang, urlParams, pagination, sort}) {
         return {
             searchPath: urlParams.searchPath,
             nodeType: (urlParams.searchContentType || 'jmix:searchable'),
@@ -339,7 +339,7 @@ class Sql2SearchQueryHandler {
         `;
     }
 
-    getQueryParams(path, uilang, lang, urlParams, rootPath, pagination, sort) {
+    getQueryParams({uilang, lang, urlParams, pagination, sort}) {
         let {sql2SearchFrom, sql2SearchWhere} = urlParams;
         let query = `SELECT * FROM [${sql2SearchFrom}] WHERE ISDESCENDANTNODE('${urlParams.searchPath}')`;
         if (sql2SearchWhere && sql2SearchWhere !== '') {

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.jsx
@@ -90,8 +90,8 @@ export class ContentLayout extends React.Component {
 
     render() {
         const {
-            mode, path, previewState, classes, filesMode, previewSelection, rows, contentNotFound,
-            totalCount, loading, dataCounts
+            mode, path, previewState, classes, filesMode, previewSelection, rows, isContentNotFound,
+            totalCount, isLoading, dataCounts
         } = this.props;
 
         let previewOpen = previewState >= CM_DRAWER_STATES.SHOW;
@@ -130,12 +130,12 @@ export class ContentLayout extends React.Component {
                                 {mode === JContentConstants.mode.MEDIA && filesMode === JContentConstants.mode.GRID ?
                                     <FilesGrid totalCount={totalCount}
                                                rows={rows}
-                                               contentNotFound={contentNotFound}
-                                               loading={loading}/> :
+                                               isContentNotFound={isContentNotFound}
+                                               isLoading={isLoading}/> :
                                     <ContentTable totalCount={totalCount}
                                                   rows={rows}
-                                                  contentNotFound={contentNotFound}
-                                                  loading={loading}
+                                                  isContentNotFound={isContentNotFound}
+                                                  isLoading={isLoading}
                                                   dataCounts={dataCounts}/>}
                             </ErrorBoundary>
                         </Paper>
@@ -154,9 +154,9 @@ ContentLayout.propTypes = {
     previewState: PropTypes.number.isRequired,
     previewSelection: PropTypes.string,
     rows: PropTypes.array.isRequired,
-    contentNotFound: PropTypes.bool,
+    isContentNotFound: PropTypes.bool,
     totalCount: PropTypes.number.isRequired,
-    loading: PropTypes.bool.isRequired,
+    isLoading: PropTypes.bool.isRequired,
     dataCounts: PropTypes.object
 };
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
@@ -38,7 +38,7 @@ export const ContentTable = ({
     rows,
     selection,
     removeSelection,
-    contentNotFound,
+    isContentNotFound,
     pagination,
     setCurrentPage,
     setPageSize,
@@ -49,7 +49,7 @@ export const ContentTable = ({
     previewState,
     tableView,
     dataCounts,
-    loading}) => {
+    isLoading}) => {
     const isStructuredView = JContentConstants.tableView.viewMode.STRUCTURED === tableView.viewMode;
     const {t} = useTranslation();
     const paths = useMemo(() => flattenTree(rows).map(n => n.path), [rows]);
@@ -90,22 +90,22 @@ export const ContentTable = ({
                 removeSelection(toRemove);
             }
         }
-    }, [rows, selection, removeSelection]);
+    }, [rows, selection, removeSelection, paths]);
 
     useEffect(() => {
         if (isStructuredView) {
             toggleAllRowsExpanded(true);
         }
-    }, [rows]);
+    }, [rows, isStructuredView, toggleAllRowsExpanded]);
 
     const contextualMenus = useRef({});
 
     const doubleClickNavigation = node => {
         let newMode = mode;
         if (mode === JContentConstants.mode.SEARCH) {
-            if (node.path.indexOf('/files') !== -1) {
+            if (node.path.indexOf('/files') > -1) {
                 newMode = JContentConstants.mode.MEDIA;
-            } else if (node.path.indexOf('/contents') !== -1) {
+            } else if (node.path.indexOf('/contents') > -1) {
                 newMode = JContentConstants.mode.CONTENT_FOLDERS;
             } else {
                 newMode = JContentConstants.mode.PAGES;
@@ -120,13 +120,13 @@ export const ContentTable = ({
     let columnData = previewState === CM_DRAWER_STATES.SHOW ? reducedColumnData : allColumnData;
     let isPreviewOpened = previewState === CM_DRAWER_STATES.SHOW;
 
-    if (contentNotFound) {
+    if (isContentNotFound) {
         return <ContentNotFound columnSpan={columnData.length} t={t}/>;
     }
 
     const typeSelector = mode === JContentConstants.mode.PAGES && dataCounts ? <ContentTypeSelector contentCount={dataCounts.contents} pagesCount={dataCounts.pages}/> : null;
 
-    if (_.isEmpty(rows) && !loading) {
+    if (_.isEmpty(rows) && !isLoading) {
         if ((mode === JContentConstants.mode.SEARCH || mode === JContentConstants.mode.SQL2SEARCH)) {
             return <EmptyTable columnSpan={columnData.length} t={t}/>;
         }
@@ -256,8 +256,8 @@ const mapDispatchToProps = dispatch => ({
 });
 
 ContentTable.propTypes = {
-    contentNotFound: PropTypes.bool,
-    loading: PropTypes.bool,
+    isContentNotFound: PropTypes.bool,
+    isLoading: PropTypes.bool,
     mode: PropTypes.string.isRequired,
     onPreviewSelect: PropTypes.func.isRequired,
     pagination: PropTypes.object.isRequired,

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileIcon/FileIcon.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileIcon/FileIcon.jsx
@@ -13,6 +13,7 @@ import {
     Folder
 } from 'mdi-material-ui';
 
+// eslint-disable-next-line complexity
 export const FileIcon = ({filename, ...props}) => {
     switch (filename.split('.').pop().toLowerCase()) {
         case 'png':

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.jsx
@@ -57,7 +57,7 @@ const styles = theme => ({
 });
 
 export const FilesGrid = ({
-    contentNotFound,
+    isContentNotFound,
     classes,
     path,
     totalCount,
@@ -66,7 +66,7 @@ export const FilesGrid = ({
     onPreviewSelect,
     setCurrentPage,
     rows,
-    loading,
+    isLoading,
     mode,
     uilang,
     siteKey,
@@ -86,11 +86,11 @@ export const FilesGrid = ({
         onSelectionChange: index => onPreviewSelect(rows[index].path)
     });
 
-    if ((!rows || rows.length === 0) && loading) {
+    if ((!rows || rows.length === 0) && isLoading) {
         return null;
     }
 
-    if (contentNotFound) {
+    if (isContentNotFound) {
         return (
             <React.Fragment>
                 <Grid container className={classes.gridEmpty} data-cm-role="grid-content-list">
@@ -102,7 +102,7 @@ export const FilesGrid = ({
         );
     }
 
-    if ((!rows || rows.length === 0) && !loading) {
+    if ((!rows || rows.length === 0) && !isLoading) {
         return (
             <React.Fragment>
                 <FilesGridEmptyDropZone mode={JContentConstants.mode.MEDIA} path={path}/>
@@ -186,8 +186,8 @@ let mapDispatchToProps = dispatch => ({
 
 FilesGrid.propTypes = {
     classes: PropTypes.object.isRequired,
-    contentNotFound: PropTypes.bool,
-    loading: PropTypes.bool.isRequired,
+    isContentNotFound: PropTypes.bool,
+    isLoading: PropTypes.bool.isRequired,
     pagination: PropTypes.object.isRequired,
     path: PropTypes.string.isRequired,
     rows: PropTypes.array.isRequired,

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/DocumentViewer/DocumentViewer.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/DocumentViewer/DocumentViewer.jsx
@@ -42,7 +42,6 @@ const styles = theme => ({
     }
 });
 
-// eslint-disable-next-line
 const FileViewer = React.lazy(() => import('react-file-viewer'));
 
 export class DocumentViewer extends React.Component {

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PDFViewer/PDFViewer.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PDFViewer/PDFViewer.jsx
@@ -56,7 +56,6 @@ const styles = theme => ({
 
 const scaleSizes = [0.25, 0.33, 0.5, 0.67, 0.75, 0.8, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2];
 
-// eslint-disable-next-line
 const Pdf = React.lazy(() => import(/* webpackChunkName: "reactPdfJs" */ 'react-pdf-js'));
 
 export class PDFViewer extends React.Component {

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PreviewComponent.container.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PreviewComponent.container.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import {useContentPreview} from '@jahia/data-helper';
 import {CM_DRAWER_STATES} from '~/JContent/JContent.redux';
 import PreviewComponent from './PreviewComponent';
@@ -18,13 +18,6 @@ export const PreviewComponentContainer = ({previewMode, previewSelection, previe
         language,
         workspace: previewMode
     });
-
-    // Trigger manual refetch only on language change
-    useEffect(() => {
-        if (!loading && !error) {
-            refetch();
-        }
-    }, [language]);
 
     if (!loading && Object.keys(data || {}).length === 0) {
         refetch();

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PreviewComponent.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PreviewComponent.jsx
@@ -53,7 +53,7 @@ const styles = theme => ({
     }
 });
 
-const iframeLoadContent = (assets, displayValue, element, domLoadedCallback, iFrameStyle) => {
+const iframeLoadContent = ({assets, displayValue, element, domLoadedCallback, iFrameStyle}) => {
     if (element) {
         let frameDoc = element.document;
         if (element.contentWindow) {
@@ -87,6 +87,10 @@ const iframeLoadContent = (assets, displayValue, element, domLoadedCallback, iFr
     }
 };
 
+function getFile(workspace, data) {
+    return window.contextJsParameters.contextPath + '/files/' + (workspace === 'edit' ? 'default' : 'live') + data.nodeByPath.path.replace(/[^/]/g, encodeURIComponent) + (data.nodeByPath.lastModified ? ('?lastModified=' + data.nodeByPath.lastModified.value) : '');
+}
+
 const PreviewComponentCmp = ({classes, data, workspace, fullScreen, domLoadedCallback, iFrameStyle, iframeProps}) => {
     const {t} = useTranslation();
 
@@ -97,7 +101,7 @@ const PreviewComponentCmp = ({classes, data, workspace, fullScreen, domLoadedCal
 
     // If node type is "jnt:file" use specific viewer
     if (data && data.nodeByPath && data.nodeByPath.lastModified && data.nodeByPath.isFile) {
-        let file = window.contextJsParameters.contextPath + '/files/' + (workspace === 'edit' ? 'default' : 'live') + data.nodeByPath.path.replace(/[^/]/g, encodeURIComponent) + (data.nodeByPath.lastModified ? ('?lastModified=' + data.nodeByPath.lastModified.value) : '');
+        let file = getFile(workspace, data);
         if (isPDF(data.nodeByPath.path)) {
             return (
                 <div className={classes.previewContainer} data-sel-role="preview-type-pdf">
@@ -134,7 +138,7 @@ const PreviewComponentCmp = ({classes, data, workspace, fullScreen, domLoadedCal
         >
             <Paper elevation={1} classes={{root: classes.contentPaper}}>
                 <iframe key={data && data.nodeByPath ? data.nodeByPath.path : 'NoPreviewAvailable'}
-                        ref={element => iframeLoadContent(assets, displayValue, element, domLoadedCallback, iFrameStyle)}
+                        ref={element => iframeLoadContent({assets, displayValue, element, domLoadedCallback, iFrameStyle})}
                         data-sel-role={workspace + '-preview-frame'}
                         className={classes.contentIframe}
                         {...iframeProps}

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PublicationStatus/PublicationStatus.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PublicationStatus/PublicationStatus.jsx
@@ -10,8 +10,6 @@ import {connect} from 'react-redux';
 import {isMarkedForDeletion, getDefaultLocale} from '../../../../JContent.utils';
 import {compose} from '~/utils';
 
-// TODO Here as well as in ContentListTable unpublished status is not clear
-
 const styles = theme => ({
     publicationInfoModified: {
         borderLeft: '5px solid ' + theme.palette.publicationStatus.modified.main,

--- a/src/javascript/JContent/ContentRoute/ContentLayout/Upload/Upload.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/Upload/Upload.jsx
@@ -130,9 +130,9 @@ export class Upload extends React.Component {
 
         if (!status) {
             us = uploadsStatuses.NOT_STARTED;
-        } else if (status.uploading !== 0) {
+        } else if (status.uploading > 0) {
             us = uploadsStatuses.UPLOADING;
-        } else if (status.error !== 0) {
+        } else if (status.error > 0) {
             us = uploadsStatuses.HAS_ERROR;
         } else {
             us = uploadsStatuses.UPLOADED;

--- a/src/javascript/JContent/ContentRoute/ContentLayout/Upload/Upload.utils.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/Upload/Upload.utils.js
@@ -6,7 +6,7 @@ export const files = {
     acceptedFiles: []
 };
 
-export const onFilesSelected = (acceptedFiles, dispatchBatch, uploadInfo, type, additionalActions = []) => {
+export const onFilesSelected = ({acceptedFiles, dispatchBatch, uploadInfo, type, additionalActions = []}) => {
     if (acceptedFiles.length > 0) {
         files.acceptedFiles = files.acceptedFiles.concat(acceptedFiles);
         const uploads = acceptedFiles.map(() => ({

--- a/src/javascript/JContent/ContentRoute/ContentLayout/UploadTransformComponent/UploadTransformComponent.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/UploadTransformComponent/UploadTransformComponent.jsx
@@ -124,12 +124,12 @@ export class UploadTransformComponent extends React.Component {
 
                 let acceptedFiles = fileList.filter(file => fileMatchSize(file, uploadMaxSize, uploadMinSize));
 
-                onFilesSelected(
+                onFilesSelected({
                     acceptedFiles,
-                    this.props.uploadDispatchBatch,
-                    {path: uploadPath},
-                    mode === JContentConstants.mode.MEDIA ? JContentConstants.mode.UPLOAD : JContentConstants.mode.IMPORT
-                );
+                    dispatchBatch: this.props.uploadDispatchBatch,
+                    uploadInfo: {path: uploadPath},
+                    type: mode === JContentConstants.mode.MEDIA ? JContentConstants.mode.UPLOAD : JContentConstants.mode.IMPORT
+                });
             });
         }
     }

--- a/src/javascript/JContent/ContentRoute/ContentLayout/usePreloadedData.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/usePreloadedData.js
@@ -3,7 +3,7 @@ import {useEffect, useState} from 'react';
 const EMPTY_STATE = {totalCount: 0};
 const TIMEOUT = 30;
 
-export default (client, options, tableView, path, pagination) => {
+export default ({client, options, tableView, path, pagination}) => {
     const [data, setData] = useState(EMPTY_STATE);
 
     useEffect(() => {
@@ -29,7 +29,7 @@ export default (client, options, tableView, path, pagination) => {
         setTimeout(() => {
             fetch();
         }, TIMEOUT);
-    }, [tableView.viewType, tableView.viewMode, path, pagination.currentPage, pagination.pageSize]);
+    }, [tableView.viewType, tableView.viewMode, path, pagination.currentPage, pagination.pageSize, client]);
 
     return data;
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/usePreloadedData.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/usePreloadedData.js
@@ -29,7 +29,7 @@ export default ({client, options, tableView, path, pagination}) => {
         setTimeout(() => {
             fetch();
         }, TIMEOUT);
-    }, [tableView.viewType, tableView.viewMode, path, pagination.currentPage, pagination.pageSize, client]);
+    }, [tableView.viewType, tableView.viewMode, path, pagination.currentPage, pagination.pageSize, client, options]);
 
     return data;
 };

--- a/src/javascript/JContent/ContentRoute/MainActionBar/MainActionBar.jsx
+++ b/src/javascript/JContent/ContentRoute/MainActionBar/MainActionBar.jsx
@@ -17,21 +17,21 @@ export const MainActionBar = () => {
 
     const publishAction = node['jnt:folder'] || node['jnt:contentFolder'] ? 'publishAll' : 'publish';
     const editActionKey = node['jnt:page'] ? 'editPage' : 'edit';
-    const disabled = selection && selection.length > 0;
+    const isDisabled = selection && selection.length > 0;
 
     return (
         <div className={styles.root}>
-            <DisplayAction actionKey="search" path={path} disabled={disabled} render={ButtonRenderer} buttonProps={{variant: 'ghost', size: 'big', 'data-sel-role': 'open-search-dialog'}}/>
+            <DisplayAction actionKey="search" path={path} isDisabled={isDisabled} render={ButtonRenderer} buttonProps={{variant: 'ghost', size: 'big', 'data-sel-role': 'open-search-dialog'}}/>
             <Separator variant="vertical" invisible="firstOrLastChild" className={styles.showSeparator}/>
-            <DisplayAction actionKey="pageComposer" path={path} disabled={disabled} render={ButtonRenderer} buttonProps={{variant: 'ghost', size: 'big', color: 'accent', className: styles.item}}/>
-            <DisplayAction actionKey={editActionKey} path={path} disabled={disabled} render={ButtonRenderer} buttonProps={{variant: 'outlined', size: 'big', className: styles.item}}/>
+            <DisplayAction actionKey="pageComposer" path={path} isDisabled={isDisabled} render={ButtonRenderer} buttonProps={{variant: 'ghost', size: 'big', color: 'accent', className: styles.item}}/>
+            <DisplayAction actionKey={editActionKey} path={path} isDisabled={isDisabled} render={ButtonRenderer} buttonProps={{variant: 'outlined', size: 'big', className: styles.item}}/>
 
             <ButtonGroup size="big" variant="default" color="accent" className={styles.item}>
-                <DisplayAction actionKey={publishAction} path={path} disabled={disabled} render={ButtonRendererShortLabel} buttonProps={{variant: 'default', size: 'big', color: 'accent'}}/>
-                <DisplayAction menuUseElementAnchor actionKey="publishMenu" path={path} disabled={disabled} render={ButtonRendererNoLabel} buttonProps={{variant: 'default', size: 'big', color: 'accent'}}/>
+                <DisplayAction actionKey={publishAction} path={path} isDisabled={isDisabled} render={ButtonRendererShortLabel} buttonProps={{variant: 'default', size: 'big', color: 'accent'}}/>
+                <DisplayAction menuUseElementAnchor actionKey="publishMenu" path={path} isDisabled={isDisabled} render={ButtonRendererNoLabel} buttonProps={{variant: 'default', size: 'big', color: 'accent'}}/>
             </ButtonGroup>
-            <DisplayAction actionKey="publishDeletion" path={path} disabled={disabled} render={ButtonRendererShortLabel}/>
-            <DisplayAction actionKey="deletePermanently" path={path} disabled={disabled} render={ButtonRendererShortLabel}/>
+            <DisplayAction actionKey="publishDeletion" path={path} isDisabled={isDisabled} render={ButtonRendererShortLabel}/>
+            <DisplayAction actionKey="deletePermanently" path={path} isDisabled={isDisabled} render={ButtonRendererShortLabel}/>
         </div>
     );
 };

--- a/src/javascript/JContent/ContentRoute/MainActionBar/MainActionBar.test.jsx
+++ b/src/javascript/JContent/ContentRoute/MainActionBar/MainActionBar.test.jsx
@@ -28,7 +28,7 @@ describe('MainActionBar', () => {
         const wrapper = shallow(<MainActionBar/>);
 
         wrapper.find('DisplayAction').forEach(node => {
-            expect(node.props().disabled).toBeFalsy();
+            expect(node.props().isDisabled).toBeFalsy();
         });
         expect(wrapper.findWhere(node => node.props().actionKey === 'publish').exists()).toBeTruthy();
         expect(wrapper.findWhere(node => node.props().actionKey === 'publishAll').exists()).toBeFalsy();
@@ -49,7 +49,7 @@ describe('MainActionBar', () => {
         const wrapper = shallow(<MainActionBar/>);
 
         wrapper.find('DisplayAction').forEach(node => {
-            expect(node.props().disabled).toBeTruthy();
+            expect(node.props().isDisabled).toBeTruthy();
         });
         expect(wrapper.findWhere(node => node.props().actionKey === 'publish').exists()).toBeTruthy();
         expect(wrapper.findWhere(node => node.props().actionKey === 'publishAll').exists()).toBeFalsy();

--- a/src/javascript/JContent/ContentRoute/SearchInput/SearchInput.jsx
+++ b/src/javascript/JContent/ContentRoute/SearchInput/SearchInput.jsx
@@ -17,16 +17,15 @@ const SearchInput = function () {
         searchContentType: state.jcontent.params.searchContentType
     }));
     const [t, setT] = useState(searchTerms);
+
     // This updates component state when user changes search via dialog
     useEffect(() => {
-        if (searchTerms !== t) {
-            setT(searchTerms);
-        }
-    }, [searchTerms]);
+        setT(searchTerms);
+    }, [searchTerms, setT]);
 
     const performSearchDebounced = (time, value) => e => {
         clearTimeout(timeOut);
-        const searchForValue = value !== undefined ? value : e.target.value;
+        const searchForValue = value === undefined ? e.target.value : value;
         setT(searchForValue);
         timeOut = setTimeout(() => {
             clearTimeout(timeOut);

--- a/src/javascript/JContent/ContentRoute/ToolBar/BrowseControlBar/BrowseControlBar.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/BrowseControlBar/BrowseControlBar.jsx
@@ -24,7 +24,7 @@ const excludedActions = [
     'fileUpload'
 ];
 
-export const BrowseControlBar = ({isShowActions}) => {
+export const BrowseControlBar = ({isShowingActions}) => {
     const {path, mode, siteKey} = useSelector(state => ({
         path: state.jcontent.path,
         mode: state.jcontent.mode,
@@ -39,7 +39,7 @@ export const BrowseControlBar = ({isShowActions}) => {
 
     return (
         <React.Fragment>
-            {isShowActions && !isRootNode && (
+            {isShowingActions && !isRootNode && (
                 <>
                     <div className="flexRow">
                         <DisplayActions target="headerPrimaryActions"
@@ -62,16 +62,16 @@ export const BrowseControlBar = ({isShowActions}) => {
                 </>
             )}
             <div className="flexFluid"/>
-            {isShowActions && mode === JContentConstants.mode.MEDIA &&
+            {isShowingActions && mode === JContentConstants.mode.MEDIA &&
             <FileModeSelector/>}
-            {isShowActions && mode !== JContentConstants.mode.MEDIA &&
+            {isShowingActions && mode !== JContentConstants.mode.MEDIA &&
             <ViewModeSelector/>}
         </React.Fragment>
     );
 };
 
 BrowseControlBar.propTypes = {
-    isShowActions: PropTypes.bool.isRequired
+    isShowingActions: PropTypes.bool.isRequired
 };
 
 export default BrowseControlBar;

--- a/src/javascript/JContent/ContentRoute/ToolBar/BrowseControlBar/BrowseControlBar.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/BrowseControlBar/BrowseControlBar.jsx
@@ -24,7 +24,7 @@ const excludedActions = [
     'fileUpload'
 ];
 
-export const BrowseControlBar = ({showActions}) => {
+export const BrowseControlBar = ({isShowActions}) => {
     const {path, mode, siteKey} = useSelector(state => ({
         path: state.jcontent.path,
         mode: state.jcontent.mode,
@@ -39,7 +39,7 @@ export const BrowseControlBar = ({showActions}) => {
 
     return (
         <React.Fragment>
-            {showActions && !isRootNode && (
+            {isShowActions && !isRootNode && (
                 <>
                     <div className="flexRow">
                         <DisplayActions target="headerPrimaryActions"
@@ -62,16 +62,16 @@ export const BrowseControlBar = ({showActions}) => {
                 </>
             )}
             <div className="flexFluid"/>
-            {showActions && mode === JContentConstants.mode.MEDIA &&
+            {isShowActions && mode === JContentConstants.mode.MEDIA &&
             <FileModeSelector/>}
-            {showActions && mode !== JContentConstants.mode.MEDIA &&
+            {isShowActions && mode !== JContentConstants.mode.MEDIA &&
             <ViewModeSelector/>}
         </React.Fragment>
     );
 };
 
 BrowseControlBar.propTypes = {
-    showActions: PropTypes.bool.isRequired
+    isShowActions: PropTypes.bool.isRequired
 };
 
 export default BrowseControlBar;

--- a/src/javascript/JContent/ContentRoute/ToolBar/BrowseControlBar/BrowseControlBar.test.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/BrowseControlBar/BrowseControlBar.test.jsx
@@ -29,14 +29,14 @@ jest.mock('connected-react-router', () => jest.fn(() => {
 
 describe('BrowseControlBar', () => {
     it('should display', () => {
-        const bar = shallow(<BrowseControlBar showActions/>);
+        const bar = shallow(<BrowseControlBar isShowActions/>);
         expect(bar.find('DisplayActions').length).toEqual(1);
         expect(bar.find('DisplayAction').length).toEqual(1);
         expect(bar.find('FileModeSelector').length).toEqual(0);
     });
 
     it('should not display actions', () => {
-        const bar = shallow(<BrowseControlBar showActions={false}/>);
+        const bar = shallow(<BrowseControlBar isShowActions={false}/>);
         expect(bar.find('DisplayActions').length).toEqual(0);
         expect(bar.find('DisplayAction').length).toEqual(0);
         expect(bar.find('FileModeSelector').length).toEqual(0);
@@ -48,7 +48,7 @@ describe('BrowseControlBar', () => {
             mode: 'media',
             siteKey: 'testSite'
         }));
-        const bar = shallow(<BrowseControlBar showActions/>);
+        const bar = shallow(<BrowseControlBar isShowActions/>);
         expect(bar.find('DisplayActions').length).toEqual(1);
         expect(bar.find('DisplayAction').length).toEqual(1);
         expect(bar.find('FileModeSelector').length).toEqual(1);

--- a/src/javascript/JContent/ContentRoute/ToolBar/BrowseControlBar/BrowseControlBar.test.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/BrowseControlBar/BrowseControlBar.test.jsx
@@ -29,14 +29,14 @@ jest.mock('connected-react-router', () => jest.fn(() => {
 
 describe('BrowseControlBar', () => {
     it('should display', () => {
-        const bar = shallow(<BrowseControlBar isShowActions/>);
+        const bar = shallow(<BrowseControlBar isShowingActions/>);
         expect(bar.find('DisplayActions').length).toEqual(1);
         expect(bar.find('DisplayAction').length).toEqual(1);
         expect(bar.find('FileModeSelector').length).toEqual(0);
     });
 
     it('should not display actions', () => {
-        const bar = shallow(<BrowseControlBar isShowActions={false}/>);
+        const bar = shallow(<BrowseControlBar isShowingActions={false}/>);
         expect(bar.find('DisplayActions').length).toEqual(0);
         expect(bar.find('DisplayAction').length).toEqual(0);
         expect(bar.find('FileModeSelector').length).toEqual(0);
@@ -48,7 +48,7 @@ describe('BrowseControlBar', () => {
             mode: 'media',
             siteKey: 'testSite'
         }));
-        const bar = shallow(<BrowseControlBar isShowActions/>);
+        const bar = shallow(<BrowseControlBar isShowingActions/>);
         expect(bar.find('DisplayActions').length).toEqual(1);
         expect(bar.find('DisplayAction').length).toEqual(1);
         expect(bar.find('FileModeSelector').length).toEqual(1);

--- a/src/javascript/JContent/ContentRoute/ToolBar/SearchControlBar/SearchControlBar.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/SearchControlBar/SearchControlBar.jsx
@@ -29,7 +29,7 @@ export const SearchControlBar = () => {
     if (advancedSearchMode) {
         typeInfo = from;
     } else {
-        typeInfo = searchContentType !== '' ? searchContentType : t('jcontent:label.contentManager.search.anyContent');
+        typeInfo = searchContentType === '' ? t('jcontent:label.contentManager.search.anyContent') : searchContentType;
     }
 
     return (

--- a/src/javascript/JContent/ContentRoute/ToolBar/ToolBar.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/ToolBar.jsx
@@ -38,8 +38,8 @@ export const ToolBar = () => {
     return (
         <div className={`flexRow ${styles.root}`}>
             {(mode === JContentConstants.mode.SEARCH || mode === JContentConstants.mode.SQL2SEARCH) ?
-                <SearchControlBar isShowActions={selection.length === 0}/> :
-                <BrowseControlBar isShowActions={selection.length === 0}/>}
+                <SearchControlBar/> :
+                <BrowseControlBar isShowingActions={selection.length === 0}/>}
             {paths.length > 0 &&
             <React.Fragment>
                 <div className="flexRow">

--- a/src/javascript/JContent/ContentRoute/ToolBar/ToolBar.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/ToolBar.jsx
@@ -38,8 +38,8 @@ export const ToolBar = () => {
     return (
         <div className={`flexRow ${styles.root}`}>
             {(mode === JContentConstants.mode.SEARCH || mode === JContentConstants.mode.SQL2SEARCH) ?
-                <SearchControlBar showActions={selection.length === 0}/> :
-                <BrowseControlBar showActions={selection.length === 0}/>}
+                <SearchControlBar isShowActions={selection.length === 0}/> :
+                <BrowseControlBar isShowActions={selection.length === 0}/>}
             {paths.length > 0 &&
             <React.Fragment>
                 <div className="flexRow">

--- a/src/javascript/JContent/ImageEditor/ConfirmSaveDialog.jsx
+++ b/src/javascript/JContent/ImageEditor/ConfirmSaveDialog.jsx
@@ -18,8 +18,8 @@ let styles = {
     }
 };
 
-export const ConfirmSaveDialog = ({open, handleClose, handleSave, classes, t}) => (
-    <Dialog open={open}
+export const ConfirmSaveDialog = ({isOpen, handleClose, handleSave, classes, t}) => (
+    <Dialog open={isOpen}
             aria-labelledby="form-dialog-title"
             classes={{paper: classes.root}}
             onClose={handleClose}
@@ -46,7 +46,7 @@ ConfirmSaveDialog.propTypes = {
     classes: PropTypes.object.isRequired,
     handleClose: PropTypes.func.isRequired,
     handleSave: PropTypes.func.isRequired,
-    open: PropTypes.bool.isRequired
+    isOpen: PropTypes.bool.isRequired
 };
 
 export default compose(

--- a/src/javascript/JContent/ImageEditor/Feedback.jsx
+++ b/src/javascript/JContent/ImageEditor/Feedback.jsx
@@ -18,8 +18,8 @@ let styles = theme => ({
     }
 });
 
-export const Feedback = ({open, messageKey, classes, onClose, t}) => (
-    <Snackbar open={open}
+export const Feedback = ({isOpen, messageKey, classes, onClose, t}) => (
+    <Snackbar open={isOpen}
               className={classes.feedback}
               autoHideDuration={2000}
               anchorOrigin={{
@@ -41,7 +41,7 @@ export const Feedback = ({open, messageKey, classes, onClose, t}) => (
 Feedback.propTypes = {
     classes: PropTypes.object.isRequired,
     t: PropTypes.func.isRequired,
-    open: PropTypes.bool.isRequired,
+    isOpen: PropTypes.bool.isRequired,
     messageKey: PropTypes.string,
     onClose: PropTypes.func
 };

--- a/src/javascript/JContent/ImageEditor/ImageEditor.container.jsx
+++ b/src/javascript/JContent/ImageEditor/ImageEditor.container.jsx
@@ -97,8 +97,7 @@ export class ImageEditorContainer extends React.Component {
     }
 
     resize({width, height, keepRatio}) {
-        this.setState(({resizeParams, originalHeight, originalWidth}) => {
-            let snackBarMessage = null;
+        function getMessage(snackBarMessage, resizeParams, originalHeight, originalWidth) {
             if (keepRatio === false) {
                 snackBarMessage = 'jcontent:label.contentManager.editImage.ratioUnlocked';
             } else if (keepRatio === true) {
@@ -114,6 +113,13 @@ export class ImageEditorContainer extends React.Component {
             } else if (keepRatio) {
                 height = Math.round(resizeParams.width * originalHeight / originalWidth);
             }
+
+            return snackBarMessage;
+        }
+
+        this.setState(({resizeParams, originalHeight, originalWidth}) => {
+            let snackBarMessage = null;
+            snackBarMessage = getMessage(snackBarMessage, resizeParams, originalHeight, originalWidth);
 
             width = width || resizeParams.width;
             height = height || resizeParams.height;
@@ -156,25 +162,11 @@ export class ImageEditorContainer extends React.Component {
                 width = height * aspect;
             }
 
-            width = width || cropParams.width;
-            height = height || cropParams.height;
-            top = top || cropParams.top;
-            left = left || cropParams.left;
-            if (width > originalWidth) {
-                width = originalWidth;
-            }
-
-            if (height > originalHeight) {
-                height = originalHeight;
-            }
-
-            if (width && left + width > originalWidth) {
-                left = originalWidth - width;
-            }
-
-            if (height && top + height > originalHeight) {
-                top = originalHeight - height;
-            }
+            const box = this.getBox({width, cropParams, height, top, left, originalWidth, originalHeight});
+            width = box.width;
+            height = box.height;
+            top = box.top;
+            left = box.left;
 
             return {
                 cropParams: {
@@ -197,6 +189,30 @@ export class ImageEditorContainer extends React.Component {
                 snackBarMessage: snackBarMessage
             };
         });
+    }
+
+    getBox({width, cropParams, height, top, left, originalWidth, originalHeight}) {
+        width = width || cropParams.width;
+        height = height || cropParams.height;
+        top = top || cropParams.top;
+        left = left || cropParams.left;
+        if (width > originalWidth) {
+            width = originalWidth;
+        }
+
+        if (height > originalHeight) {
+            height = originalHeight;
+        }
+
+        if (width && left + width > originalWidth) {
+            left = originalWidth - width;
+        }
+
+        if (height && top + height > originalHeight) {
+            top = originalHeight - height;
+        }
+
+        return {width, height, top, left};
     }
 
     undoChanges() {
@@ -298,12 +314,12 @@ export class ImageEditorContainer extends React.Component {
                             onBackNavigation={this.onBackNavigation}
                         />
                         <ConfirmSaveDialog
-                            open={confirmSaveOpen}
+                            isOpen={confirmSaveOpen}
                             handleSave={() => mutation({variables: {path}})}
                             handleClose={this.handleClose}
                         />
                         <SaveAsDialog
-                            open={saveAsOpen}
+                            isOpen={saveAsOpen}
                             name={newName}
                             isNameValid={isNameValid}
                             handleSave={() => {
@@ -319,7 +335,7 @@ export class ImageEditorContainer extends React.Component {
                             onChangeName={this.handleChangeName}
                         />
                         <UnsavedChangesDialog
-                            open={confirmCloseOpen}
+                            isOpen={confirmCloseOpen}
                             onBack={() => {
                                 this.undoChanges();
                                 this.handleClose();
@@ -328,7 +344,7 @@ export class ImageEditorContainer extends React.Component {
                             onClose={this.handleClose}
                         />
 
-                        <Feedback open={Boolean(snackBarMessage)}
+                        <Feedback isOpen={Boolean(snackBarMessage)}
                                   messageKey={snackBarMessage}
                                   anchorOrigin={{
                                       vertical: 'bottom',

--- a/src/javascript/JContent/ImageEditor/ImageEditor.jsx
+++ b/src/javascript/JContent/ImageEditor/ImageEditor.jsx
@@ -112,7 +112,7 @@ export class ImageEditor extends React.Component {
                 }
             >
                 <TwoColumnsContent classes={{root: classes.root, left: classes.left, right: classes.right}}
-                                   rightCol={<ImageEditorPreview cropExpanded={expanded === PANELS.CROP}
+                                   rightCol={<ImageEditorPreview isCropExpanded={expanded === PANELS.CROP}
                                                                  path={this.props.path}
                                                                  ts={this.props.ts}
                                                                  cropParams={this.props.cropParams}
@@ -136,7 +136,7 @@ export class ImageEditor extends React.Component {
                                 <ExpansionPanelDetails className={classes.panel}>
                                     <RotatePanel onRotate={onRotate}/>
                                 </ExpansionPanelDetails>
-                                <ImageEditorActions dirty={dirty} undoChanges={undoChanges} saveChanges={saveChanges}/>
+                                <ImageEditorActions isDirty={dirty} undoChanges={undoChanges} saveChanges={saveChanges}/>
                             </ExpansionPanel>
                         </Tooltip>
                         <Tooltip title={(rotationParams.dirty || cropParams.dirty) ? t('jcontent:label.contentManager.editImage.tooltip') : ''}>
@@ -155,7 +155,7 @@ export class ImageEditor extends React.Component {
                                                  onResize={onResize}
                                     />
                                 </ExpansionPanelDetails>
-                                <ImageEditorActions dirty={dirty} undoChanges={undoChanges} saveChanges={saveChanges}/>
+                                <ImageEditorActions isDirty={dirty} undoChanges={undoChanges} saveChanges={saveChanges}/>
                             </ExpansionPanel>
                         </Tooltip>
                         <Tooltip title={(resizeParams.dirty || rotationParams.dirty) ? t('jcontent:label.contentManager.editImage.tooltip') : ''}>
@@ -172,7 +172,7 @@ export class ImageEditor extends React.Component {
                                                onCrop={onCrop}
                                     />
                                 </ExpansionPanelDetails>
-                                <ImageEditorActions dirty={dirty} undoChanges={undoChanges} saveChanges={saveChanges}/>
+                                <ImageEditorActions isDirty={dirty} undoChanges={undoChanges} saveChanges={saveChanges}/>
                             </ExpansionPanel>
                         </Tooltip>
                     </>

--- a/src/javascript/JContent/ImageEditor/ImageEditorActions/ImageEditorActions.jsx
+++ b/src/javascript/JContent/ImageEditor/ImageEditorActions/ImageEditorActions.jsx
@@ -18,16 +18,16 @@ let styles = {
     }
 };
 
-const ImageEditorActions = ({classes, t, undoChanges, saveChanges, dirty}) => (
+const ImageEditorActions = ({classes, t, undoChanges, saveChanges, isDirty}) => (
     <ExpansionPanelActions className={classes.buttons}>
-        <Button data-cm-role="undo-changes" variant="ghost" disabled={!dirty} onClick={undoChanges}>
+        <Button data-cm-role="undo-changes" variant="ghost" disabled={!isDirty} onClick={undoChanges}>
             {t('jcontent:label.contentManager.editImage.undo')}
         </Button>
         <div className={classes.spacer}/>
-        <Button variant="secondary" data-cm-role="image-save-as-button" disabled={!dirty} onClick={() => saveChanges(true)}>
+        <Button variant="secondary" data-cm-role="image-save-as-button" disabled={!isDirty} onClick={() => saveChanges(true)}>
             {t('jcontent:label.contentManager.editImage.saveAs')}
         </Button>
-        <Button variant="primary" data-cm-role="image-save-button" disabled={!dirty} onClick={() => saveChanges(false)}>
+        <Button variant="primary" data-cm-role="image-save-button" disabled={!isDirty} onClick={() => saveChanges(false)}>
             {t('jcontent:label.contentManager.editImage.save')}
         </Button>
     </ExpansionPanelActions>
@@ -36,7 +36,7 @@ const ImageEditorActions = ({classes, t, undoChanges, saveChanges, dirty}) => (
 ImageEditorActions.propTypes = {
     t: PropTypes.func.isRequired,
     classes: PropTypes.object.isRequired,
-    dirty: PropTypes.bool.isRequired,
+    isDirty: PropTypes.bool.isRequired,
     saveChanges: PropTypes.func.isRequired,
     undoChanges: PropTypes.func.isRequired
 };

--- a/src/javascript/JContent/ImageEditor/ImageEditorActions/ImageEditorActions.test.jsx
+++ b/src/javascript/JContent/ImageEditor/ImageEditorActions/ImageEditorActions.test.jsx
@@ -11,7 +11,7 @@ describe('Image actions', () => {
     beforeEach(() => {
         try {
             props = {
-                dirty: false,
+                isDirty: false,
                 undoChanges: jest.fn(),
                 saveChanges: jest.fn()
             };
@@ -24,30 +24,30 @@ describe('Image actions', () => {
     });
 
     it('should have disabled buttons', () => {
-        wrapper.setProps({dirty: false});
+        wrapper.setProps({isDirty: false});
         expect(wrapper.find(Button).everyWhere(n => n.prop('disabled'))).toBeTruthy();
     });
 
     it('should have enabled buttons', () => {
-        wrapper.setProps({dirty: true});
+        wrapper.setProps({isDirty: true});
         expect(wrapper.find(Button).everyWhere(n => !n.prop('disabled'))).toBeTruthy();
     });
 
     it('should undo changes', () => {
-        wrapper.setProps({dirty: true});
+        wrapper.setProps({isDirty: true});
         wrapper.find(Button).at(0).simulate('click');
         expect(props.undoChanges.mock.calls.length).toBe(1);
     });
 
     it('should save changes', () => {
-        wrapper.setProps({dirty: true});
+        wrapper.setProps({isDirty: true});
         wrapper.find(Button).at(1).simulate('click');
         expect(props.saveChanges.mock.calls.length).toBe(1);
         expect(props.saveChanges.mock.calls[0][0]).toBe(true);
     });
 
     it('should save as changes', () => {
-        wrapper.setProps({dirty: true});
+        wrapper.setProps({isDirty: true});
         wrapper.find(Button).at(2).simulate('click');
         expect(props.saveChanges.mock.calls.length).toBe(1);
         expect(props.saveChanges.mock.calls[0][0]).toBe(false);

--- a/src/javascript/JContent/ImageEditor/ImageEditorPreview/ImageEditorPreview.jsx
+++ b/src/javascript/JContent/ImageEditor/ImageEditorPreview/ImageEditorPreview.jsx
@@ -23,7 +23,7 @@ function getCropValue(cropParams, originalWidth, originalHeight) {
     };
 }
 
-export const ImageEditorPreview = ({path, cropParams, onCrop, cropExpanded, ts, classes, originalHeight, originalWidth, onImageLoaded, rotationParams, resizeParams, theme}) => {
+export const ImageEditorPreview = ({path, cropParams, onCrop, isCropExpanded, ts, classes, originalHeight, originalWidth, onImageLoaded, rotationParams, resizeParams, theme}) => {
     let filepath = window.contextJsParameters.contextPath + '/files/default' + path.replace(/[^/]/g, encodeURIComponent) + '?ts=' + ts;
     let containerHeight = containerRef.current ? containerRef.current.parentElement.offsetHeight - (theme.spacing.unit * 4) : 0;
     let containerWidth = containerRef.current ? containerRef.current.parentElement.offsetWidth - (theme.spacing.unit * 4) : 0;
@@ -36,7 +36,7 @@ export const ImageEditorPreview = ({path, cropParams, onCrop, cropExpanded, ts, 
     let translate = (rotationParams.rotations % 2) * (width - height) / reduceFactor / 2;
     return (
         <div ref={containerRef} style={{width: rotatedWidth / reduceFactor, height: rotatedHeight / reduceFactor}}>
-            {cropExpanded ?
+            {isCropExpanded ?
                 <ReactCrop keepSelection
                            useNaturalImageDimensions
                            className={classes.cropPreview}
@@ -77,7 +77,7 @@ ImageEditorPreview.propTypes = {
     classes: PropTypes.object.isRequired,
     theme: PropTypes.object.isRequired,
     ts: PropTypes.number.isRequired,
-    cropExpanded: PropTypes.bool.isRequired,
+    isCropExpanded: PropTypes.bool.isRequired,
     onCrop: PropTypes.func.isRequired,
     cropParams: PropTypes.object,
     rotationParams: PropTypes.object.isRequired,

--- a/src/javascript/JContent/ImageEditor/SaveAsDialog.jsx
+++ b/src/javascript/JContent/ImageEditor/SaveAsDialog.jsx
@@ -19,9 +19,9 @@ let styles = {
     }
 };
 
-export const SaveAsDialog = ({open, handleClose, handleSave, classes, t, name, onChangeName, isNameValid}) => {
+export const SaveAsDialog = ({isOpen, handleClose, handleSave, classes, t, name, onChangeName, isNameValid}) => {
     return (
-        <Dialog open={open}
+        <Dialog open={isOpen}
                 aria-labelledby="form-dialog-title"
                 classes={{paper: classes.root}}
                 onClose={handleClose}
@@ -58,7 +58,7 @@ SaveAsDialog.propTypes = {
     classes: PropTypes.object.isRequired,
     handleClose: PropTypes.func.isRequired,
     handleSave: PropTypes.func.isRequired,
-    open: PropTypes.bool.isRequired,
+    isOpen: PropTypes.bool.isRequired,
     name: PropTypes.string.isRequired,
     onChangeName: PropTypes.func.isRequired,
     isNameValid: PropTypes.bool.isRequired

--- a/src/javascript/JContent/ImageEditor/UnsavedChangesDialog/UnsavedChangesDialog.jsx
+++ b/src/javascript/JContent/ImageEditor/UnsavedChangesDialog/UnsavedChangesDialog.jsx
@@ -7,9 +7,9 @@ import PropTypes from 'prop-types';
 
 export class UnsavedChangesDialog extends React.Component {
     render() {
-        let {t, open, onBack, onClose} = this.props;
+        let {t, isOpen, onBack, onClose} = this.props;
         return (
-            <Dialog fullWidth open={open} aria-labelledby="form-dialog-title" onClose={onClose}>
+            <Dialog fullWidth open={isOpen} aria-labelledby="form-dialog-title" onClose={onClose}>
                 <DialogTitle>
                     {t('jcontent:label.contentManager.editImage.discardChangesTitle')}
                 </DialogTitle>
@@ -33,7 +33,7 @@ export class UnsavedChangesDialog extends React.Component {
 
 UnsavedChangesDialog.propTypes = {
     t: PropTypes.func.isRequired,
-    open: PropTypes.bool.isRequired,
+    isOpen: PropTypes.bool.isRequired,
     onBack: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired
 };

--- a/src/javascript/JContent/JContent.actions.jsx
+++ b/src/javascript/JContent/JContent.actions.jsx
@@ -109,7 +109,7 @@ export const jContentActions = registry => {
         buttonLabelShort: 'jcontent:label.contentManager.contentPreview.publishShort',
         targets: ['publishMenu:1'],
         publishType: 'publish',
-        isAllLanguages: false,
+        isPublishingAllLanguages: false,
         component: PublishActionComponent
     });
     registry.add('action', 'publishInAllLanguages', {
@@ -117,7 +117,7 @@ export const jContentActions = registry => {
         buttonLabel: 'jcontent:label.contentManager.contentPreview.publishInAllLanguages',
         targets: ['publishMenu:2'],
         publishType: 'publish',
-        isAllLanguages: true,
+        isPublishingAllLanguages: true,
         component: PublishActionComponent
     });
     registry.add('action', 'publishAll', {
@@ -126,7 +126,7 @@ export const jContentActions = registry => {
         buttonLabelShort: 'jcontent:label.contentManager.contentPreview.publishShort',
         targets: ['publishMenu:3'],
         publishType: 'publishAll',
-        isAllLanguages: false,
+        isPublishingAllLanguages: false,
         component: PublishActionComponent
     });
     registry.add('action', 'publishAllInAllLanguages', {
@@ -134,7 +134,7 @@ export const jContentActions = registry => {
         buttonLabel: 'jcontent:label.contentManager.contentPreview.publishAllInAllLanguages',
         targets: ['publishMenu:4'],
         publishType: 'publishAll',
-        isAllLanguages: true,
+        isPublishingAllLanguages: true,
         component: PublishActionComponent
     });
     registry.add('action', 'publishDeletion', {
@@ -148,7 +148,7 @@ export const jContentActions = registry => {
         buttonLabel: 'jcontent:label.contentManager.contentPreview.unpublish',
         targets: ['publishMenu:5'],
         publishType: 'unpublish',
-        isAllLanguages: false,
+        isPublishingAllLanguages: false,
         component: PublishActionComponent
     });
     registry.add('action', 'unpublishInAllLanguages', {
@@ -156,7 +156,7 @@ export const jContentActions = registry => {
         buttonLabel: 'jcontent:label.contentManager.contentPreview.unpublishInAllLanguages',
         targets: ['publishMenu:6'],
         publishType: 'unpublish',
-        isAllLanguages: true,
+        isPublishingAllLanguages: true,
         component: PublishActionComponent
     });
     registry.add('action', 'contentMenu', menuActionWithRenderer, {

--- a/src/javascript/JContent/JContent.actions.jsx
+++ b/src/javascript/JContent/JContent.actions.jsx
@@ -109,7 +109,7 @@ export const jContentActions = registry => {
         buttonLabelShort: 'jcontent:label.contentManager.contentPreview.publishShort',
         targets: ['publishMenu:1'],
         publishType: 'publish',
-        allLanguages: false,
+        isAllLanguages: false,
         component: PublishActionComponent
     });
     registry.add('action', 'publishInAllLanguages', {
@@ -117,7 +117,7 @@ export const jContentActions = registry => {
         buttonLabel: 'jcontent:label.contentManager.contentPreview.publishInAllLanguages',
         targets: ['publishMenu:2'],
         publishType: 'publish',
-        allLanguages: true,
+        isAllLanguages: true,
         component: PublishActionComponent
     });
     registry.add('action', 'publishAll', {
@@ -126,7 +126,7 @@ export const jContentActions = registry => {
         buttonLabelShort: 'jcontent:label.contentManager.contentPreview.publishShort',
         targets: ['publishMenu:3'],
         publishType: 'publishAll',
-        allLanguages: false,
+        isAllLanguages: false,
         component: PublishActionComponent
     });
     registry.add('action', 'publishAllInAllLanguages', {
@@ -134,7 +134,7 @@ export const jContentActions = registry => {
         buttonLabel: 'jcontent:label.contentManager.contentPreview.publishAllInAllLanguages',
         targets: ['publishMenu:4'],
         publishType: 'publishAll',
-        allLanguages: true,
+        isAllLanguages: true,
         component: PublishActionComponent
     });
     registry.add('action', 'publishDeletion', {
@@ -148,7 +148,7 @@ export const jContentActions = registry => {
         buttonLabel: 'jcontent:label.contentManager.contentPreview.unpublish',
         targets: ['publishMenu:5'],
         publishType: 'unpublish',
-        allLanguages: false,
+        isAllLanguages: false,
         component: PublishActionComponent
     });
     registry.add('action', 'unpublishInAllLanguages', {
@@ -156,7 +156,7 @@ export const jContentActions = registry => {
         buttonLabel: 'jcontent:label.contentManager.contentPreview.unpublishInAllLanguages',
         targets: ['publishMenu:6'],
         publishType: 'unpublish',
-        allLanguages: true,
+        isAllLanguages: true,
         component: PublishActionComponent
     });
     registry.add('action', 'contentMenu', menuActionWithRenderer, {

--- a/src/javascript/JContent/JContent.redux.js
+++ b/src/javascript/JContent/JContent.redux.js
@@ -44,7 +44,7 @@ const deserializeQueryString = search => {
     return {};
 };
 
-export const buildUrl = (site, language, mode, path, params) => {
+export const buildUrl = ({site, language, mode, path, params}) => {
     let registryItem = registry.get('accordionItem', mode);
     if (registryItem && registryItem.getUrlPathPart) {
         path = registryItem.getUrlPathPart(site, path, registryItem);
@@ -64,11 +64,13 @@ export const cmGoto = data => (
     (dispatch, getStore) => {
         const {site, language, jcontent: {mode, path, params}} = getStore();
 
-        dispatch(push(buildUrl(data.site || site,
-            data.language || language,
-            data.mode || mode,
-            data.path || path,
-            data.params || params)));
+        dispatch(push(buildUrl({
+            site: data.site || site,
+            language: data.language || language,
+            mode: data.mode || mode,
+            path: data.path || path,
+            params: data.params || params
+        })));
     }
 );
 
@@ -128,7 +130,7 @@ export const jContentRedux = registry => {
     registry.add('redux-action', 'jcontentGoto', {action: cmGoto});
     registry.add('redux-action', 'jcontentReplaceOpenedPath', {action: replaceOpenedPath});
     registry.add('jcontent', 'utils', {
-        extractParamsFromUrl: extractParamsFromUrl,
-        buildUrl: buildUrl
+        extractParamsFromUrl,
+        buildUrl
     });
 };

--- a/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.container.jsx
+++ b/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.container.jsx
@@ -61,9 +61,9 @@ const CreateFolderDialogContainer = ({path, contentType, onExit}) => {
     }, [data, updateChildNodes]);
 
     return (
-        <CreateFolderDialog open={open}
+        <CreateFolderDialog isOpen={open}
                             name={name}
-                            loading={loading}
+                            isLoading={loading}
                             isNameValid={isNameValid}
                             isNameAvailable={isNameAvailable}
                             handleCancel={handleCancel}

--- a/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.jsx
+++ b/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.jsx
@@ -22,9 +22,9 @@ let styles = theme => ({
     }
 });
 
-const CreateFolderDialog = ({classes, t, open, loading, name, isNameValid, isNameAvailable, handleCancel, handleCreate, onChangeName}) => {
+const CreateFolderDialog = ({classes, t, isOpen, isLoading, name, isNameValid, isNameAvailable, handleCancel, handleCreate, onChangeName}) => {
     return (
-        <Dialog open={open}
+        <Dialog open={isOpen}
                 aria-labelledby="form-dialog-title"
                 classes={{paper: classes.root}}
                 onClose={handleCancel}
@@ -57,7 +57,7 @@ const CreateFolderDialog = ({classes, t, open, loading, name, isNameValid, isNam
                     color="accent"
                     size="big"
                     data-cm-role="create-folder-as-confirm"
-                    isDisabled={loading || !name || !isNameValid || !isNameAvailable}
+                    isDisabled={isLoading || !name || !isNameValid || !isNameAvailable}
                     label={t('jcontent:label.contentManager.createFolderAction.ok')}
                     onClick={handleCreate}
                 />
@@ -71,8 +71,8 @@ CreateFolderDialog.propTypes = {
     classes: PropTypes.object.isRequired,
     handleCancel: PropTypes.func.isRequired,
     handleCreate: PropTypes.func.isRequired,
-    open: PropTypes.bool.isRequired,
-    loading: PropTypes.bool.isRequired,
+    isOpen: PropTypes.bool.isRequired,
+    isLoading: PropTypes.bool.isRequired,
     isNameValid: PropTypes.bool.isRequired,
     isNameAvailable: PropTypes.bool.isRequired,
     name: PropTypes.string.isRequired,

--- a/src/javascript/JContent/actions/exportAction/Export/Export.jsx
+++ b/src/javascript/JContent/actions/exportAction/Export/Export.jsx
@@ -62,10 +62,10 @@ export class Export extends React.Component {
     }
 
     render() {
-        let {t, classes, onClose, onExited, path} = this.props;
+        let {t, classes, onClose, onExited, path, isOpen} = this.props;
         let live = (this.state.workspace === 'live');
         return (
-            <Dialog fullWidth open={this.props.open} aria-labelledby="form-dialog-title" data-cm-role="export-options" onExited={onExited} onClose={onClose}>
+            <Dialog fullWidth open={isOpen} aria-labelledby="form-dialog-title" data-cm-role="export-options" onExited={onExited} onClose={onClose}>
                 <DialogTitle>
                     {t('jcontent:label.contentManager.export.dialogTitle')}
                 </DialogTitle>
@@ -130,7 +130,7 @@ Export.propTypes = {
     classes: PropTypes.object.isRequired,
     onClose: PropTypes.func.isRequired,
     onExited: PropTypes.func.isRequired,
-    open: PropTypes.bool.isRequired,
+    isOpen: PropTypes.bool.isRequired,
     path: PropTypes.string.isRequired,
     t: PropTypes.func.isRequired
 };

--- a/src/javascript/JContent/actions/exportAction/exportAction.jsx
+++ b/src/javascript/JContent/actions/exportAction/exportAction.jsx
@@ -18,10 +18,10 @@ export const ExportActionComponent = ({path, render: Render, loading: Loading, .
             isVisible={res.checksResult}
             onClick={() => {
                 componentRenderer.render('exportDialog', Export, {
-                        open: true,
+                        isOpen: true,
                         path: res.node.path,
                         onClose: () => {
-                            componentRenderer.setProperties('exportDialog', {open: false});
+                            componentRenderer.setProperties('exportDialog', {isOpen: false});
                         },
                         onExited: () => {
                             componentRenderer.destroy('exportDialog');

--- a/src/javascript/JContent/actions/fileUploadAction.jsx
+++ b/src/javascript/JContent/actions/fileUploadAction.jsx
@@ -62,7 +62,7 @@ export const FileUploadActionComponent = props => {
 
     useEffect(() => {
         componentRenderer.render('upload-' + id, Upload, {actionKey: id, uploadType});
-    }, [id, componentRenderer]);
+    }, [id, componentRenderer, uploadType]);
 
     if (res.loading) {
         return (Loading && <Loading {...props}/>) || false;
@@ -70,12 +70,12 @@ export const FileUploadActionComponent = props => {
 
     const handleClick = () => {
         currentUploadHandler = files => {
-            onFilesSelected(
-                [...files],
+            onFilesSelected({
+                acceptedFiles: [...files],
                 dispatchBatch,
-                {path},
-                uploadType
-            );
+                uploadInfo: {path},
+                type: uploadType
+            });
         };
 
         document.getElementById('file-upload-input-' + id).click();

--- a/src/javascript/JContent/actions/publishAction.jsx
+++ b/src/javascript/JContent/actions/publishAction.jsx
@@ -7,7 +7,7 @@ import {useSelector} from 'react-redux';
 import {useTranslation} from 'react-i18next';
 import {setRefetcher, unsetRefetcher} from '../JContent.refetches';
 
-function checkAction(res, node, publishType, allLanguages) {
+function checkAction(res, node, publishType, isAllLanguages) {
     let enabled = true;
     let isVisible = res.checksResult && node.operationsSupport.publication;
 
@@ -25,7 +25,7 @@ function checkAction(res, node, publishType, allLanguages) {
             (publishType === 'publishAll' || node.aggregatedPublicationInfo.publicationStatus !== 'PUBLISHED');
     }
 
-    if (allLanguages) {
+    if (isAllLanguages) {
         isVisible = isVisible && node.site.languages.length > 1;
     }
 
@@ -36,13 +36,13 @@ function checkAction(res, node, publishType, allLanguages) {
     return {enabled, isVisible};
 }
 
-function checkActionOnNodes(res, publishType, allLanguages) {
+function checkActionOnNodes(res, publishType, isAllLanguages) {
     const defaults = {
         enabled: true,
         isVisible: true
     };
 
-    return res.nodes ? res.nodes.reduce((acc, node) => mergeChecks(acc, checkAction(res, node, publishType, allLanguages)), defaults) : defaults;
+    return res.nodes ? res.nodes.reduce((acc, node) => mergeChecks(acc, checkAction(res, node, publishType, isAllLanguages)), defaults) : defaults;
 }
 
 const mergeChecks = (v1, v2) => {
@@ -80,7 +80,7 @@ const constraintsByType = {
 };
 
 export const PublishActionComponent = props => {
-    const {id, path, paths, language, publishType, allLanguages, enabled, isVisible, render: Render, loading: Loading} = props;
+    const {id, path, paths, language, publishType, isAllLanguages, enabled, isVisible, render: Render, loading: Loading} = props;
     const languageToUse = useSelector(state => language ? language : state.language);
     const {t} = useTranslation();
 
@@ -106,9 +106,9 @@ export const PublishActionComponent = props => {
         return (Loading && <Loading {...props}/>) || false;
     }
 
-    let actionChecks = res.node ? checkAction(res, res.node, publishType, allLanguages) : checkActionOnNodes(res, publishType, allLanguages);
-    const actionEnabled = enabled !== undefined ? (enabled && actionChecks.enabled) : actionChecks.enabled;
-    const actionVisible = isVisible !== undefined ? (isVisible && actionChecks.isVisible) : actionChecks.isVisible;
+    let actionChecks = res.node ? checkAction(res, res.node, publishType, isAllLanguages) : checkActionOnNodes(res, publishType, isAllLanguages);
+    const actionEnabled = enabled === undefined ? actionChecks.enabled : (enabled && actionChecks.enabled);
+    const actionVisible = isVisible === undefined ? actionChecks.isVisible : (isVisible && actionChecks.isVisible);
 
     const buttonLabelParams = res.node ? {
         displayName: _.escape(ellipsizeText(res.node.displayName, 40)),
@@ -123,9 +123,9 @@ export const PublishActionComponent = props => {
             enabled={actionEnabled}
             onClick={() => {
                 if (path) {
-                    window.authoringApi.openPublicationWorkflow([res.node.uuid], publishType === 'publishAll', allLanguages, publishType === 'unpublish');
+                    window.authoringApi.openPublicationWorkflow([res.node.uuid], publishType === 'publishAll', isAllLanguages, publishType === 'unpublish');
                 } else if (paths) {
-                    window.authoringApi.openPublicationWorkflow(res.nodes.map(n => n.uuid), publishType === 'publishAll', allLanguages, publishType === 'unpublish');
+                    window.authoringApi.openPublicationWorkflow(res.nodes.map(n => n.uuid), publishType === 'publishAll', isAllLanguages, publishType === 'unpublish');
                 }
             }}
         />
@@ -147,7 +147,7 @@ PublishActionComponent.propTypes = {
 
     publishType: PropTypes.oneOf(['publish', 'publishAll', 'unpublish']),
 
-    allLanguages: PropTypes.bool,
+    isAllLanguages: PropTypes.bool,
 
     render: PropTypes.func.isRequired,
 

--- a/src/javascript/JContent/actions/publishAction.jsx
+++ b/src/javascript/JContent/actions/publishAction.jsx
@@ -7,7 +7,7 @@ import {useSelector} from 'react-redux';
 import {useTranslation} from 'react-i18next';
 import {setRefetcher, unsetRefetcher} from '../JContent.refetches';
 
-function checkAction(res, node, publishType, isAllLanguages) {
+function checkAction(res, node, publishType, isPublishingAllLanguages) {
     let enabled = true;
     let isVisible = res.checksResult && node.operationsSupport.publication;
 
@@ -25,7 +25,7 @@ function checkAction(res, node, publishType, isAllLanguages) {
             (publishType === 'publishAll' || node.aggregatedPublicationInfo.publicationStatus !== 'PUBLISHED');
     }
 
-    if (isAllLanguages) {
+    if (isPublishingAllLanguages) {
         isVisible = isVisible && node.site.languages.length > 1;
     }
 
@@ -36,13 +36,13 @@ function checkAction(res, node, publishType, isAllLanguages) {
     return {enabled, isVisible};
 }
 
-function checkActionOnNodes(res, publishType, isAllLanguages) {
+function checkActionOnNodes(res, publishType, isPublishingAllLanguages) {
     const defaults = {
         enabled: true,
         isVisible: true
     };
 
-    return res.nodes ? res.nodes.reduce((acc, node) => mergeChecks(acc, checkAction(res, node, publishType, isAllLanguages)), defaults) : defaults;
+    return res.nodes ? res.nodes.reduce((acc, node) => mergeChecks(acc, checkAction(res, node, publishType, isPublishingAllLanguages)), defaults) : defaults;
 }
 
 const mergeChecks = (v1, v2) => {
@@ -80,7 +80,7 @@ const constraintsByType = {
 };
 
 export const PublishActionComponent = props => {
-    const {id, path, paths, language, publishType, isAllLanguages, enabled, isVisible, render: Render, loading: Loading} = props;
+    const {id, path, paths, language, publishType, isPublishingAllLanguages, enabled, isVisible, render: Render, loading: Loading} = props;
     const languageToUse = useSelector(state => language ? language : state.language);
     const {t} = useTranslation();
 
@@ -106,7 +106,7 @@ export const PublishActionComponent = props => {
         return (Loading && <Loading {...props}/>) || false;
     }
 
-    let actionChecks = res.node ? checkAction(res, res.node, publishType, isAllLanguages) : checkActionOnNodes(res, publishType, isAllLanguages);
+    let actionChecks = res.node ? checkAction(res, res.node, publishType, isPublishingAllLanguages) : checkActionOnNodes(res, publishType, isPublishingAllLanguages);
     const actionEnabled = enabled === undefined ? actionChecks.enabled : (enabled && actionChecks.enabled);
     const actionVisible = isVisible === undefined ? actionChecks.isVisible : (isVisible && actionChecks.isVisible);
 
@@ -123,9 +123,9 @@ export const PublishActionComponent = props => {
             enabled={actionEnabled}
             onClick={() => {
                 if (path) {
-                    window.authoringApi.openPublicationWorkflow([res.node.uuid], publishType === 'publishAll', isAllLanguages, publishType === 'unpublish');
+                    window.authoringApi.openPublicationWorkflow([res.node.uuid], publishType === 'publishAll', isPublishingAllLanguages, publishType === 'unpublish');
                 } else if (paths) {
-                    window.authoringApi.openPublicationWorkflow(res.nodes.map(n => n.uuid), publishType === 'publishAll', isAllLanguages, publishType === 'unpublish');
+                    window.authoringApi.openPublicationWorkflow(res.nodes.map(n => n.uuid), publishType === 'publishAll', isPublishingAllLanguages, publishType === 'unpublish');
                 }
             }}
         />
@@ -147,7 +147,7 @@ PublishActionComponent.propTypes = {
 
     publishType: PropTypes.oneOf(['publish', 'publishAll', 'unpublish']),
 
-    isAllLanguages: PropTypes.bool,
+    isPublishingAllLanguages: PropTypes.bool,
 
     render: PropTypes.func.isRequired,
 

--- a/src/javascript/JContent/actions/publishDeletionAction.jsx
+++ b/src/javascript/JContent/actions/publishDeletionAction.jsx
@@ -14,7 +14,7 @@ const checkAction = node => node.operationsSupport.publication &&
         (node.aggregatedPublicationInfo.publicationStatus === 'NOT_PUBLISHED' &&
             (node.aggregatedPublicationInfo.existsInLive === undefined ? false : node.aggregatedPublicationInfo.existsInLive)));
 
-export const PublishDeletionActionComponent = ({path, paths, allSubTree, allLanguages, buttonProps, render: Render, loading: Loading, ...others}) => {
+export const PublishDeletionActionComponent = ({path, paths, isAllSubTree, isAllLanguages, buttonProps, render: Render, loading: Loading, ...others}) => {
     const {language} = useSelector(state => ({language: state.language}));
 
     const res = useNodeChecks({path, paths, language}, {
@@ -38,9 +38,9 @@ export const PublishDeletionActionComponent = ({path, paths, allSubTree, allLang
             buttonProps={{...buttonProps, color: 'danger'}}
             onClick={() => {
                 if (path) {
-                    window.authoringApi.openPublicationWorkflow([res.node.uuid], allSubTree, allLanguages);
+                    window.authoringApi.openPublicationWorkflow([res.node.uuid], isAllSubTree, isAllLanguages);
                 } else if (paths) {
-                    window.authoringApi.openPublicationWorkflow(res.nodes.map(n => n.uuid), allSubTree, allLanguages);
+                    window.authoringApi.openPublicationWorkflow(res.nodes.map(n => n.uuid), isAllSubTree, isAllLanguages);
                 }
             }}
         />
@@ -54,9 +54,9 @@ PublishDeletionActionComponent.propTypes = {
 
     buttonProps: PropTypes.object,
 
-    allSubTree: PropTypes.bool,
+    isAllSubTree: PropTypes.bool,
 
-    allLanguages: PropTypes.bool,
+    isAllLanguages: PropTypes.bool,
 
     render: PropTypes.func.isRequired,
 

--- a/src/javascript/JContent/actions/publishDeletionAction.jsx
+++ b/src/javascript/JContent/actions/publishDeletionAction.jsx
@@ -14,7 +14,7 @@ const checkAction = node => node.operationsSupport.publication &&
         (node.aggregatedPublicationInfo.publicationStatus === 'NOT_PUBLISHED' &&
             (node.aggregatedPublicationInfo.existsInLive === undefined ? false : node.aggregatedPublicationInfo.existsInLive)));
 
-export const PublishDeletionActionComponent = ({path, paths, isAllSubTree, isAllLanguages, buttonProps, render: Render, loading: Loading, ...others}) => {
+export const PublishDeletionActionComponent = ({path, paths, isAllSubTree, isPublishingAllLanguages, buttonProps, render: Render, loading: Loading, ...others}) => {
     const {language} = useSelector(state => ({language: state.language}));
 
     const res = useNodeChecks({path, paths, language}, {
@@ -38,9 +38,9 @@ export const PublishDeletionActionComponent = ({path, paths, isAllSubTree, isAll
             buttonProps={{...buttonProps, color: 'danger'}}
             onClick={() => {
                 if (path) {
-                    window.authoringApi.openPublicationWorkflow([res.node.uuid], isAllSubTree, isAllLanguages);
+                    window.authoringApi.openPublicationWorkflow([res.node.uuid], isAllSubTree, isPublishingAllLanguages);
                 } else if (paths) {
-                    window.authoringApi.openPublicationWorkflow(res.nodes.map(n => n.uuid), isAllSubTree, isAllLanguages);
+                    window.authoringApi.openPublicationWorkflow(res.nodes.map(n => n.uuid), isAllSubTree, isPublishingAllLanguages);
                 }
             }}
         />
@@ -56,7 +56,7 @@ PublishDeletionActionComponent.propTypes = {
 
     isAllSubTree: PropTypes.bool,
 
-    isAllLanguages: PropTypes.bool,
+    isPublishingAllLanguages: PropTypes.bool,
 
     render: PropTypes.func.isRequired,
 

--- a/src/javascript/JContent/actions/searchAction/SearchDialog/SearchDialog.container.jsx
+++ b/src/javascript/JContent/actions/searchAction/SearchDialog/SearchDialog.container.jsx
@@ -18,7 +18,7 @@ const SearchDialogContainer = ({isOpen, handleClose}) => {
         if (mode !== JContentConstants.mode.SQL2SEARCH && mode !== JContentConstants.mode.SEARCH) {
             dispatch(cmPreSearchModeMemo(mode));
         }
-    }, [mode]);
+    }, [mode, dispatch]);
 
     const [isAdvancedSearch, setIsAdvancedSearch] = useState(mode === JContentConstants.mode.SQL2SEARCH);
     const [searchPath, setSearchPath] = useState(params.searchPath ? params.searchPath : path);

--- a/src/javascript/utils/getButtonRenderer.jsx
+++ b/src/javascript/utils/getButtonRenderer.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 const getButtonRenderer = ({labelStyle} = {}) => {
     const ButtonRenderer = props => {
-        const {buttonLabelNamespace, buttonLabelShort, buttonLabel, isVisible, buttonLabelParams, buttonIcon, actionKey, enabled, disabled, onClick, buttonProps} = props;
+        const {buttonLabelNamespace, buttonLabelShort, buttonLabel, isVisible, buttonLabelParams, buttonIcon, actionKey, enabled, isDisabled, onClick, buttonProps} = props;
         const {t} = useTranslation(buttonLabelNamespace);
 
         let label = buttonLabel;
@@ -19,7 +19,7 @@ const getButtonRenderer = ({labelStyle} = {}) => {
             <Button data-sel-role={actionKey}
                     label={t(label, buttonLabelParams)}
                     icon={buttonIcon}
-                    disabled={enabled === false || disabled}
+                    disabled={enabled === false || isDisabled}
                     onClick={e => {
                         e.stopPropagation();
                         onClick(props, e);
@@ -38,7 +38,7 @@ const getButtonRenderer = ({labelStyle} = {}) => {
         buttonIcon: PropTypes.node,
         actionKey: PropTypes.string,
         enabled: PropTypes.bool,
-        disabled: PropTypes.bool,
+        isDisabled: PropTypes.bool,
         onClick: PropTypes.func,
         buttonProps: PropTypes.object
     };


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16326

## Description

Fixed all remaining lint issue.
- I'm still allowing "enabled" prop name instead of "isEnabled", as it would require changes in other modules declaring actions ( like content-editor ). All other boolean props renamed to is*
- For method parameter limit: use an object as parameter
- Dependency array on useEffect / useXx was often invalid and depending on calculated object, I had to add multiple useMemo to avoid the infinite reloads
- reduced complexity by extracting methods
