### PR TITLE
BACKLOG-16589: Upgrade moonstone version, remove invalid flag on checkbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@jahia/design-system-kit": "^1.1.2",
     "@jahia/icons": "^1.1.1",
     "@jahia/jahia-reporter": "^1.0.3",
-    "@jahia/moonstone": "^1.6.2",
+    "@jahia/moonstone": "^2.0.0",
     "@jahia/react-material": "^3.0.1",
     "@jahia/ui-extender": "^1.0.0",
     "@material-ui/core": "^3.6.2",

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellSelection.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellSelection.jsx
@@ -8,7 +8,7 @@ export const CellSelection = ({row, cell, column}) => (
                    {...cell.getCellProps()}
                    width={columnWidths[column.id]}
     >
-        <Checkbox isUncontrolled {...row.getToggleRowSelectedProps()}/>
+        <Checkbox {...row.getToggleRowSelectedProps()}/>
     </TableBodyCell>
 );
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/headers/headers.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/headers/headers.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /* eslint-disable react/prop-types */
 
 export const HeaderSelection = ({getToggleAllRowsSelectedProps}) => (
-    <Checkbox isUncontrolled {...getToggleAllRowsSelectedProps()}/>
+    <Checkbox {...getToggleAllRowsSelectedProps()}/>
 );
 
 export const Header = ({column}) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -982,7 +982,7 @@
     "@babel/plugin-transform-react-jsx-development" "^7.14.5"
     "@babel/plugin-transform-react-pure-annotations" "^7.14.5"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.5", "@babel/runtime@^7.2.0", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.5", "@babel/runtime@^7.2.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
   integrity sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==
@@ -1160,14 +1160,12 @@
     uuid "^8.3.1"
     xml-js "^1.6.11"
 
-"@jahia/moonstone@^1.6.2":
-  version "1.6.2"
-  resolved "https://npm.jahia.com/@jahia%2fmoonstone/-/moonstone-1.6.2.tgz#601029ffd1ef4fbea9edc28227e7a6f7b477cd44"
-  integrity sha512-6JVC13z5lxjvW3cJNWsON2GlOc3LPbichrJvFMomjXpxkElXus4+EQm9Lm129LceMIAI94Torz/kdowRh1qSuw==
+"@jahia/moonstone@^2.0.0":
+  version "2.0.0"
+  resolved "https://npm.jahia.com/@jahia%2fmoonstone/-/moonstone-2.0.0.tgz#78db4d407741ad983757929f80970bf215841222"
+  integrity sha512-cvakbXE+Y8LrgF119bxeWwqcrA9BkUhoS2XC8M74k62dvu8JtiDPc22CeXDQukauitenUNFLwV1VIQ9+HgLKaQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@react-aria/checkbox" "^3.2.1"
-    "@react-stately/toggle" "^3.2.1"
     clsx "^1.1.1"
     prop-types "^15.7.2"
     re-resizable "^6.9.0"
@@ -1556,135 +1554,6 @@
   version "1.0.0-next.15"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.15.tgz#6a9d143f7f4f49db2d782f9e1c8839a29b43ae23"
   integrity sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA==
-
-"@react-aria/checkbox@^3.2.1":
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/@react-aria/checkbox/-/checkbox-3.2.2.tgz#359ffb4b8d2dbf4cfcd6e54718e132e6eda78ad3"
-  integrity sha512-Vfi3PJvwaT9ftvu+KmKR3AhQ+oa4TE+cqqC33hvQB5isBCoxPppL7B93K9Cd0Tt4+IHUDikiIYxieOKl2HALLA==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-aria/label" "^3.1.2"
-    "@react-aria/toggle" "^3.1.3"
-    "@react-aria/utils" "^3.8.0"
-    "@react-stately/checkbox" "^3.0.2"
-    "@react-stately/toggle" "^3.2.2"
-    "@react-types/checkbox" "^3.2.1"
-
-"@react-aria/focus@^3.3.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@react-aria/focus/-/focus-3.4.0.tgz#b883b90595e02fcc126d1aad6c82de2a1fe19826"
-  integrity sha512-XlGn5XhYqPF6tAv+CBUDRqZHlpXTEWHQmpq/Oc+n8UaEICfrxkUrIqMatidEoeG21Sm5uCU7M6TNMmwhWIKLQQ==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-aria/interactions" "^3.5.0"
-    "@react-aria/utils" "^3.8.1"
-    "@react-types/shared" "^3.7.0"
-    clsx "^1.1.1"
-
-"@react-aria/interactions@^3.4.0", "@react-aria/interactions@^3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.5.0.tgz#40eeb2d668f324956feb753b3594ddca06e08393"
-  integrity sha512-EL5GWpzM9UHU17LztwgL/tF3H2tLG375CD64kieCgSfsRcCSlC3pavnPy9jbS8levdBQ2qo9e2xfoX5VtfJisw==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-aria/utils" "^3.8.1"
-    "@react-types/shared" "^3.7.0"
-
-"@react-aria/label@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@react-aria/label/-/label-3.1.2.tgz#3ed367f1e7fcf67304eaefc5202ec027bea27a1b"
-  integrity sha512-XwwmNfHYD12We7wjTMkfz37A8bN1L+Qkr3pSlsmuRYfSs0bg1RUDaQ6dzHL01sDilQWQidGSHibGKzwmELaMTw==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-aria/utils" "^3.8.0"
-    "@react-types/label" "^3.2.1"
-    "@react-types/shared" "^3.6.0"
-
-"@react-aria/ssr@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.0.2.tgz#f96a41a7314a60324b6de871cb872039b63be5c0"
-  integrity sha512-+M0wrUlc2eTuMiwTfd0iFZJGu2hvMeYBLE8gRdbPJCDjLhrNWOQLKR/y6ntxQ9u8zjrNl/YPOdRtcqkA2EBnAQ==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-
-"@react-aria/toggle@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@react-aria/toggle/-/toggle-3.1.3.tgz#f3b0a75b7b968b6d9592359ef863b2039e09663a"
-  integrity sha512-hyXpubOl1YOCaPDTdvqVBuvOLYWfuWU31cJiQFT/udOkcOYvpU2yBDTgavXWRLCuuyHkV0HHKC21Stc5wfbPEg==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-aria/focus" "^3.3.0"
-    "@react-aria/interactions" "^3.4.0"
-    "@react-aria/utils" "^3.8.0"
-    "@react-stately/toggle" "^3.2.2"
-    "@react-types/checkbox" "^3.2.2"
-    "@react-types/shared" "^3.6.0"
-    "@react-types/switch" "^3.1.1"
-
-"@react-aria/utils@^3.8.0", "@react-aria/utils@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.8.1.tgz#7c7246a2d22078c1962d238bdc14569a15d0d761"
-  integrity sha512-SvFf1T2HHAId6LS4+gbJNLQU9wr5GHuR5wA+HOtfVkZ82v3xhOnzfjR5qgjSLYGsPfqNgci5cpKYlHf4YqMf5w==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-aria/ssr" "^3.0.2"
-    "@react-stately/utils" "^3.2.1"
-    "@react-types/shared" "^3.7.0"
-    clsx "^1.1.1"
-
-"@react-stately/checkbox@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@react-stately/checkbox/-/checkbox-3.0.2.tgz#e42943365e5082c121a36df5b1dc6f367cabc3ec"
-  integrity sha512-wrEZjuDRPLj1xA6PHXqWPICBo5TLKbojRomqhne46Oy7FLHZzHS7t30bHY0AbGBIYyjP1oA9PuKY+MvZiRplyA==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-stately/toggle" "^3.2.2"
-    "@react-stately/utils" "^3.2.1"
-    "@react-types/checkbox" "^3.2.1"
-
-"@react-stately/toggle@^3.2.1", "@react-stately/toggle@^3.2.2":
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/@react-stately/toggle/-/toggle-3.2.2.tgz#d5ee9494eb23a937dee3399af007d7d058585cb0"
-  integrity sha512-jyWwcUSchpUBaiha1r5DI/4LM0w/Jp/JO+HiC+hRUTgf4bbWAwhlN/MUiFCwIumSESzexOjIKv6I3grL4zEnqQ==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-stately/utils" "^3.2.1"
-    "@react-types/checkbox" "^3.2.1"
-    "@react-types/shared" "^3.6.0"
-
-"@react-stately/utils@^3.2.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.2.1.tgz#1e85861e6963230f80610bd9d1f5f0d33a481273"
-  integrity sha512-H79CYKPiQZrO1/dMSwjRJxsRlYg7y8PbTwnZOQ1h3DI5W6tD8CCLSlU1A5/Fp1GfcGNnK8gHqsJ9oJSRAwFS1g==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-
-"@react-types/checkbox@^3.2.1", "@react-types/checkbox@^3.2.2":
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/@react-types/checkbox/-/checkbox-3.2.2.tgz#7182d44a533e2ffd2c9118372cbc2c33b006eb18"
-  integrity sha512-WAAqLdjf6GUWjsMN5NaFMFumOtGTq+3+48CpM0ah2L+qmhMdj1s4gvHDerhls6u4ovRK/7zhg7XK+qQwcYVqMg==
-  dependencies:
-    "@react-types/shared" "^3.4.0"
-
-"@react-types/label@^3.2.1":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@react-types/label/-/label-3.4.0.tgz#6023dc9dd0146324ead52e08540cd60e57a3e27f"
-  integrity sha512-l84ysm1dcjL/5qVk9iN74z+/Ul0999XqnwTu6aTbuwAXqMk2sTU45eK2Yp/FJ7YWeflcF1vsomTkjMkX0BHKMw==
-  dependencies:
-    "@react-types/shared" "^3.4.0"
-
-"@react-types/shared@^3.2.1", "@react-types/shared@^3.4.0", "@react-types/shared@^3.6.0", "@react-types/shared@^3.7.0":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.7.1.tgz#6aadddab0c7911a97a97a4c48723eb15a34b5fad"
-  integrity sha512-VNKlqh37UjB3Hd7gb5Hgsum/2x5mhd7vuBBGPEFevhkOMBW8KlqrU75yaKUe3rEFbky7H6+A8Dzoj4r68OS14w==
-
-"@react-types/switch@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@react-types/switch/-/switch-3.1.1.tgz#7909a8f7c2cb68ab7536efd03af3be3417e0eca3"
-  integrity sha512-nI5J/1CrJrVANwgikXyPMqxWJ4UyefzE4Vz/TwTgoXQ9v+LRNo22wbisfh1EmJAlZ0E52X/iKViVaBroNty+EA==
-  dependencies:
-    "@react-types/checkbox" "^3.2.1"
-    "@react-types/shared" "^3.2.1"
 
 "@slack/logger@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
Use new version of moonstone, `isUncontrolled` not supported anymore