### PR TITLE
QA-14173: Add error message in Create Folder dialog; Add % to invalid chars

### DIFF
--- a/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.container.jsx
+++ b/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.container.jsx
@@ -13,7 +13,7 @@ const CreateFolderDialogContainer = ({path, contentType, onExit}) => {
     const [isNameAvailable, updateIsNameAvailable] = useState(true);
     const [childNodes, updateChildNodes] = useState([]);
 
-    const invalidRegex = /[\\/:*?"<>|]/g;
+    const invalidRegex = /[\\/:*?"<>|%]/g;
     const gqlParams = {
         mutation: {
             parentPath: path,

--- a/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.jsx
+++ b/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.jsx
@@ -1,12 +1,30 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import {useEffect, useState} from 'react';
 import {Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, TextField} from '@material-ui/core';
 import {Button} from '@jahia/moonstone';
 import {useTranslation} from 'react-i18next';
 import styles from './CreateFolderDialog.scss';
 
+const useErrMsg = (isNameAvailable, isNameValid) => {
+    const {t} = useTranslation();
+    let [errMsg, setErrMsg] = useState('');
+    useEffect(() => {
+        if (!isNameAvailable) {
+            setErrMsg(t('jcontent:label.contentManager.createFolderAction.text'));
+        } else if (!isNameValid) {
+            setErrMsg(t('jcontent:label.contentManager.createFolderAction.invalidChars'));
+        } else {
+            setErrMsg('');
+        }
+    }, [t, isNameValid, isNameAvailable]);
+    return errMsg;
+};
+
 const CreateFolderDialog = ({isOpen, isLoading, name, isNameValid, isNameAvailable, handleCancel, handleCreate, onChangeName}) => {
     const {t} = useTranslation();
+    const errMsg = useErrMsg(isNameAvailable, isNameValid);
+
     return (
         <Dialog open={isOpen}
                 aria-labelledby="form-dialog-title"
@@ -26,7 +44,7 @@ const CreateFolderDialog = ({isOpen, isLoading, name, isNameValid, isNameAvailab
                     id="folder-name"
                     aria-describedby="folder-name-error-text"
                     margin="dense"
-                    helperText={isNameAvailable ? '' : t('jcontent:label.contentManager.createFolderAction.exists')}
+                    helperText={errMsg}
                     onChange={onChangeName}
                 />
             </DialogContent>

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -321,7 +321,8 @@
         "text": "Geben Sie einen Ordner-Namen ein",
         "ok": "OK",
         "cancel": "Abbrechen",
-        "exists": "Ein Ordner mit diesem Namen existiert bereits"
+        "exists": "Ein Ordner mit diesem Namen existiert bereits",
+        "invalidChars": "Ungültige Zeichen: \/:*?\"<>|%"
       },
       "contentStatus": {
         "locked": "Gesperrt",

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -322,7 +322,8 @@
         "text": "Enter a folder name",
         "ok": "OK",
         "cancel": "Cancel",
-        "exists": "A folder with this name already exists"
+        "exists": "A folder with this name already exists",
+        "invalidChars": "Invalid characters:  \/:*?\"<>|%"
       },
       "contentStatus": {
         "locked": "Locked",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -322,7 +322,8 @@
         "text": "Entrez un nom de dossier",
         "ok": "OK",
         "cancel": "Annuler",
-        "exists": "Un dossier de ce nom existe déjà"
+        "exists": "Un dossier de ce nom existe déjà",
+        "invalidChars": "Caractères invalides: \/:*?\"<>|%"
       },
       "contentStatus": {
         "locked": "Verrouillé",


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14173

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Include `%` as invalid character when creating jContent folder name is it causes errors when navigating to the folder (temp fix)
* Added error message in create folder dialog