### PR TITLE
QA-14173: Fix incorrect error message for duplicate folder name

### DIFF
--- a/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.jsx
+++ b/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.jsx
@@ -11,7 +11,7 @@ const useErrMsg = (isNameAvailable, isNameValid) => {
     let [errMsg, setErrMsg] = useState('');
     useEffect(() => {
         if (!isNameAvailable) {
-            setErrMsg(t('jcontent:label.contentManager.createFolderAction.text'));
+            setErrMsg(t('jcontent:label.contentManager.createFolderAction.exists'));
         } else if (!isNameValid) {
             setErrMsg(t('jcontent:label.contentManager.createFolderAction.invalidChars'));
         } else {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14173

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Fix regression of using incorrect message