### PR TITLE
DMF-5354 - Minor fixes in EditFrame, allow to customize bar

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/EditFrame/Boxes.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/EditFrame/Boxes.jsx
@@ -51,7 +51,7 @@ export const Boxes = ({currentDocument, currentFrameRef, onSaved}) => {
 
     const onMouseOut = useCallback(event => {
         event.stopPropagation();
-        if (event.relatedTarget && getModuleElement(event.currentTarget)?.getAttribute('path') !== getModuleElement(event.relatedTarget)?.getAttribute('path')) {
+        if (!event.relatedTarget || (getModuleElement(currentDocument, event.currentTarget)?.getAttribute('path') !== getModuleElement(currentDocument, event.relatedTarget)?.getAttribute('path'))) {
             setCurrentElement(null);
         }
     }, [setCurrentElement]);
@@ -62,7 +62,7 @@ export const Boxes = ({currentDocument, currentFrameRef, onSaved}) => {
     useEffect(() => {
         const placeholders = [];
         currentDocument.querySelectorAll('[jahiatype=module]').forEach(elem => {
-            if (elem.getAttribute('path') === '*') {
+            if (elem.getAttribute('path') === '*' || elem.getAttribute('type') === 'placeholder') {
                 placeholders.push(elem);
             }
         });

--- a/src/javascript/JContent/ContentRoute/ContentLayout/EditFrame/Create.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/EditFrame/Create.jsx
@@ -30,7 +30,7 @@ export const Create = ({element, onMouseOver, onMouseOut, onSaved}) => {
         element.style.height = '28px';
     });
 
-    const path = parent.getAttribute('path');
+    const parentPath = parent.getAttribute('path');
 
     const currentOffset = {
         top: rect.top + scrollTop,
@@ -38,6 +38,10 @@ export const Create = ({element, onMouseOver, onMouseOut, onSaved}) => {
         width: rect.width,
         height: 25
     };
+
+    const nodePath = element.getAttribute('path') !== '*' ? element.getAttribute('path') : null;
+    console.log('place holder for path', nodePath);
+    const nodetypes = element.getAttribute('nodetypes') ? element.getAttribute('nodetypes').split(' ') : null;
 
     return (
         <div className={classnames(styles.root, dropClassName)}
@@ -50,8 +54,8 @@ export const Create = ({element, onMouseOver, onMouseOut, onSaved}) => {
              onDragLeave={onDragLeave}
              onDrop={onDrop}
         >
-            <DisplayAction actionKey="createContent" path={path} loading={() => false} render={ButtonRenderer}/>
-            <DisplayAction actionKey="paste" path={path} loading={() => false} render={ButtonRenderer}/>
+            <DisplayAction actionKey="createContent" path={parentPath} name={nodePath} nodeTypes={nodetypes} loading={() => false} render={ButtonRenderer}/>
+            <DisplayAction actionKey="paste" path={parentPath} loading={() => false} render={ButtonRenderer}/>
         </div>
     );
 };


### PR DESCRIPTION
- Add in registry items with type "customContentEditorBar" and primary nodetype name as the id. Item need to contain a "component" entry that will be used for the editframe jcontent box bar.
- Pass name to create action when needed, and support named children