### PR TITLE
BACKLOG-17084: fix registering of initClipboardWatcher 

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@apollo/react-hooks": "^3.1.5",
     "@babel/polyfill": "^7.0.0",
-    "@jahia/data-helper": "^1.0.3",
+    "@jahia/data-helper": "^1.0.4",
     "@jahia/design-system-kit": "^1.1.2",
     "@jahia/icons": "^1.1.1",
     "@jahia/jahia-reporter": "^1.0.3",

--- a/src/javascript/JContent.register.jsx
+++ b/src/javascript/JContent.register.jsx
@@ -17,9 +17,7 @@ import {paginationRedux} from './JContent/ContentRoute/ContentLayout/pagination.
 import {sortRedux} from './JContent/ContentRoute/ContentLayout/sort.redux';
 import {contentSelectionRedux} from './JContent/ContentRoute/ContentLayout/contentSelection.redux';
 import JContentConstants from './JContent/JContent.constants';
-import {useDispatch, useSelector} from 'react-redux';
-import {useApolloClient} from 'react-apollo';
-import {initClipboardWatcher} from './JContent/actions/copyPaste/localStorageHandler';
+import {useSelector} from 'react-redux';
 import {useNodeChecks} from '@jahia/data-helper';
 import {structuredViewRedux} from './JContent/ContentRoute/ContentLayout/StructuredView/StructuredView.redux';
 
@@ -27,8 +25,6 @@ export default function () {
     const CmmNavItem = () => {
         const history = useHistory();
         const {t} = useTranslation('jcontent');
-        const client = useApolloClient();
-        const dispatch = useDispatch();
         const {site, language, path, mode, params} = useSelector(state => ({
             language: state.language,
             site: state.site,
@@ -70,7 +66,6 @@ export default function () {
                             icon={<Collections/>}
                             onClick={() => {
                                 history.push(buildUrl({site, language, mode: mode || defaultMode, path, params}));
-                                initClipboardWatcher(dispatch, client);
                             }}/>
         );
     };

--- a/src/javascript/JContent/actions/copyPaste/copyPaste.gql-queries.js
+++ b/src/javascript/JContent/actions/copyPaste/copyPaste.gql-queries.js
@@ -1,8 +1,7 @@
 import gql from 'graphql-tag';
 import {PredefinedFragments} from '@jahia/data-helper';
 
-const copyPasteQueries = {
-    getClipboardInfo: gql`query getClipboardInfo($uuids: [String!]!) {
+const copyPasteQueries = gql`query getClipboardInfo($uuids: [String!]!) {
         jcr {
             nodesById(uuids: $uuids) {
                 name
@@ -46,7 +45,6 @@ const copyPasteQueries = {
         }
     }
     ${PredefinedFragments.nodeCacheRequiredFields.gql}
-    `
-};
+    `;
 
 export default copyPasteQueries;

--- a/src/javascript/JContentApp.jsx
+++ b/src/javascript/JContentApp.jsx
@@ -1,13 +1,24 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import JContent from './JContent';
 import {CssBaseline} from '@material-ui/core';
 import './date.config';
+import {initClipboardWatcher} from '~/JContent/actions/copyPaste/localStorageHandler';
+import {useApolloClient} from 'react-apollo';
+import {useDispatch} from 'react-redux';
 
-const JContentApp = () => (
-    <>
-        <CssBaseline/>
-        <JContent/>
-    </>
-);
+const JContentApp = () => {
+    const client = useApolloClient();
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        initClipboardWatcher(dispatch, client);
+    }, [client, dispatch]);
+    return (
+        <>
+            <CssBaseline/>
+            <JContent/>
+        </>
+    );
+};
 
 export default JContentApp;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,7 +1138,7 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@jahia/data-helper@^1.0.3":
+"@jahia/data-helper@^1.0.4":
   version "1.0.4"
   resolved "https://npm.jahia.com/@jahia%2fdata-helper/-/data-helper-1.0.4.tgz#1bfd8feb4ca1d61aadbfe00605d77ae7aeb82ef7"
   integrity sha512-a1wp2ut0iYxpkJAPwnYONaqaP5Jv4gM6PRZOht8nJU7sBHot7lSb/AXehAyqOCUuX+DBrJoK6rXGGLL7AhHaHQ==


### PR DESCRIPTION
fix registering of initClipboardWatcher by moving it to JContentApp.jsx as a useEffect(). In the interval functin rely on Apollo cache to not execute query all the time

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17084

## Description

fix registering of initClipboardWatcher by moving it to JContentApp.jsx as a useEffect(). 
In the interval function rely on Apollo cache to not execute query all the time

Tested locally with digitall, Copy/Paste of elements from home page with no issues. Monitored graphql network did not see any extra queries

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
