### PR TITLE
Fixed duplicate css load

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/EditFrame/Box.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/EditFrame/Box.jsx
@@ -10,7 +10,6 @@ import {getButtonRenderer} from '~/utils/getButtonRenderer';
 import {useDragSource} from './useDragSource';
 import {useDropTarget} from './useDropTarget';
 import PublicationStatus from '../PublicationStatus/PublicationStatus';
-import '@jahia/moonstone/dist/globals.css';
 
 const DefaultBar = ({node, path, onSaved, ButtonRenderer}) => (
     <>


### PR DESCRIPTION
This loads the globals.css from an older version of moonstone, breaking all styles/fonts