### PR TITLE
BACKLOG-17304: Fix moonstone header rendering of search input to avoid input in advanced mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <yarn.arguments>build:production</yarn.arguments>
         <jahia-module-signature>MCwCFE0pgyNuTlrOhuqW+cDZgWD0td+2AhRXJ5BJchKbY0CZB3zyIPPTUPccAA==</jahia-module-signature>
         <jahia-depends>jahia-ui-root</jahia-depends>
-        <jahia-plugin-version>5.11</jahia-plugin-version>
+        <jahia-plugin-version>6.4</jahia-plugin-version>
     </properties>
 
     <repositories>

--- a/src/javascript/JContent/ContentRoute/ContentHeader/ContentHeader.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentHeader/ContentHeader.jsx
@@ -50,7 +50,7 @@ const ContentHeader = () => {
     return inSearchMode ? (
         <Header
             backButton={<Button icon={<ArrowLeft/>} onClick={clearSearchFunc}/>}
-            mainActions={<SearchInput/>}
+            mainActions={JContentConstants.mode.SEARCH === mode && <SearchInput/>}
             title={title}
             toolbarLeft={<SearchControlBar/>}
             toolbarRight={paths.length > 0 && <SelectionActionsBar paths={paths} clear={clear}/>}


### PR DESCRIPTION
…

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17304


