### PR TITLE
BACKLOG-17367: Fix crop aspect ratio state after undo

### DIFF
--- a/src/javascript/JContent/actions/editImage/ImageEditorDialog/ImageEditorDialog.container.jsx
+++ b/src/javascript/JContent/actions/editImage/ImageEditorDialog/ImageEditorDialog.container.jsx
@@ -211,7 +211,7 @@ export const ImageEditorDialogContainer = ({path, onExit}) => {
     };
 
     const undoChanges = () => {
-        setOperations(previousState => ({
+        setOperations({
             transforms: [],
             rotationParams: {
                 dirty: false,
@@ -229,9 +229,9 @@ export const ImageEditorDialogContainer = ({path, onExit}) => {
                 left: 0,
                 height: null,
                 width: null,
-                aspect: previousState.originalWidth / previousState.originalHeight
+                aspect: imageSize.originalWidth / imageSize.originalHeight
             }
-        }));
+        });
     };
 
     const handleChangeName = ({target: {value}}) => {

--- a/src/javascript/JContent/actions/editImage/ImageEditorDialog/ImageEditorDialog.jsx
+++ b/src/javascript/JContent/actions/editImage/ImageEditorDialog/ImageEditorDialog.jsx
@@ -70,18 +70,21 @@ export const ImageEditorDialog = ({
                     <>
                         <Tab>
                             <TabItem size="big"
+                                     data-cm-role="rotate-panel"
                                      isSelected={currentPanel === PANELS.ROTATE}
                                      isDisabled={resizeParams.dirty || cropParams.dirty}
                                      label={t('jcontent:label.contentManager.editImage.rotate')}
                                      onClick={() => !resizeParams.dirty && !cropParams.dirty && setCurrentPanel(PANELS.ROTATE)}
                             />
                             <TabItem size="big"
+                                     data-cm-role="resize-panel"
                                      isSelected={currentPanel === PANELS.RESIZE}
                                      isDisabled={rotationParams.dirty || cropParams.dirty}
                                      label={t('jcontent:label.contentManager.editImage.resize')}
                                      onClick={() => !rotationParams.dirty && !cropParams.dirty && setCurrentPanel(PANELS.RESIZE)}
                             />
                             <TabItem size="big"
+                                     data-cm-role="crop-panel"
                                      isSelected={currentPanel === PANELS.CROP}
                                      isDisabled={resizeParams.dirty || rotationParams.dirty}
                                      label={t('jcontent:label.contentManager.editImage.crop')}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17367

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Due to refactoring, need to use new `imageSize` state instead of `previousState` to get original width/height.
* Added `data-cm-role` in tabs panel 