### PR TITLE
BACKLOG-19906: move search modes config in registry

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.gql-queries.js
@@ -97,7 +97,7 @@ const nodeFields = gql`
     ${PredefinedFragments.nodeCacheRequiredFields.gql}
 `;
 
-const ContentQueryHandler = {
+const BaseQueryHandler = {
     getQuery() {
         return gql`
             query getNodeSubTree($path:String!, $language:String!, $offset:Int, $limit:Int, $displayLanguage:String!, $typeFilter:[String]!, $recursionTypesFilter: InputNodeTypesInput, $fieldSorter: InputFieldSorterInput, $fieldGrouping: InputFieldGroupingInput) {
@@ -127,7 +127,11 @@ const ContentQueryHandler = {
         return data && data.jcr && data.jcr.nodeByPath && data.jcr.nodeByPath.descendants;
     },
 
-    getLayoutQueryParams({path, lang, uilang, pagination, typeFilter, recursionTypesFilter, sort}) {
+    getFragments() {
+        return [];
+    },
+
+    getBaseQueryParams({path, lang, uilang, pagination, typeFilter, recursionTypesFilter, sort}) {
         return {
             path: path,
             language: lang,
@@ -151,12 +155,12 @@ const ContentQueryHandler = {
 };
 
 const ContentQueryHandlerPages = {
-    ...ContentQueryHandler,
+    ...BaseQueryHandler,
     getQueryParams({path, uilang, lang, pagination, sort, viewType, viewMode}) {
         const typeFilter = JContentConstants.tableView.viewType.PAGES === viewType ? ['jnt:page'] : [JContentConstants.contentType];
         const recursionTypesFilter = {multi: 'NONE', types: ['jnt:page', 'jnt:contentFolder']};
 
-        const layoutQueryParams = this.getLayoutQueryParams({path, lang, uilang, pagination, sort, typeFilter, recursionTypesFilter});
+        const layoutQueryParams = this.getBaseQueryParams({path, lang, uilang, pagination, sort, typeFilter, recursionTypesFilter});
 
         if (viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
             layoutQueryParams.fieldGrouping = null;
@@ -177,12 +181,12 @@ const ContentQueryHandlerPages = {
 };
 
 const ContentQueryHandlerContentFolders = {
-    ...ContentQueryHandler,
+    ...BaseQueryHandler,
     getQueryParams({path, uilang, lang, pagination, sort, viewMode}) {
         const typeFilter = ['jnt:content', 'jnt:contentFolder'];
         const recursionTypesFilter = {multi: 'NONE', types: ['nt:base']};
 
-        const layoutQueryParams = this.getLayoutQueryParams({path, lang, uilang, pagination, sort, typeFilter, recursionTypesFilter});
+        const layoutQueryParams = this.getBaseQueryParams({path, lang, uilang, pagination, sort, typeFilter, recursionTypesFilter});
 
         if (viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
             layoutQueryParams.fieldGrouping = null;
@@ -198,6 +202,7 @@ const ContentQueryHandlerContentFolders = {
 };
 
 const FilesQueryHandler = {
+    ...BaseQueryHandler,
     getQuery() {
         return gql`
             query getFiles($path:String!, $language:String!, $offset:Int, $limit:Int, $displayLanguage:String!, $typeFilter:[String]!, $fieldSorter: InputFieldSorterInput, $fieldGrouping: InputFieldGroupingInput) {
@@ -242,24 +247,10 @@ const FilesQueryHandler = {
     },
 
     getQueryParams({path, uilang, lang, pagination, sort}) {
-        return {
-            path: path,
-            language: lang,
-            displayLanguage: uilang,
-            offset: pagination.currentPage * pagination.pageSize,
-            limit: pagination.pageSize,
-            typeFilter: ['jnt:file', 'jnt:folder'],
-            fieldSorter: sort.orderBy === '' ? null : {
-                sortType: sort.order === '' ? null : (sort.order === 'DESC' ? 'ASC' : 'DESC'),
-                fieldName: sort.orderBy === '' ? null : sort.orderBy,
-                ignoreCase: true
-            },
-            fieldGrouping: {
-                fieldName: 'primaryNodeType.name',
-                groups: ['jnt:folder'],
-                groupingType: 'START'
-            }
-        };
+        const typeFilter = ['jnt:file', 'jnt:folder'];
+        const recursionTypesFilter = {multi: 'NONE', types: ['nt:base']};
+
+        return this.getBaseQueryParams({path, lang, uilang, pagination, sort, typeFilter, recursionTypesFilter});
     },
 
     getResultsPath(data) {
@@ -270,7 +261,7 @@ const FilesQueryHandler = {
 const SearchQueryHandler = {
     getQuery() {
         return gql`
-            query searchContentQuery($searchPath:String!, $nodeType:String!, $searchTerms:String!, $nodeNameSearchTerms:String!, $language:String!, $displayLanguage:String!, $offset:Int, $limit:Int, $fieldSorter: InputFieldSorterInput) {
+            query searchContentQuery($searchPath:String!, $nodeType:String!, $searchTerms:String!, $nodeNameSearchTerms:String!, $language:String!, $displayLanguage:String!, $offset:Int, $limit:Int, $fieldFilter: InputFieldFiltersInput, $fieldSorter: InputFieldSorterInput) {
                 jcr {
                     nodesByCriteria(
                         criteria: {
@@ -285,6 +276,7 @@ const SearchQueryHandler = {
                                 ]
                             }
                         },
+                        fieldFilter: $fieldFilter
                         offset: $offset,
                         limit: $limit,
                         fieldSorter: $fieldSorter
@@ -303,12 +295,12 @@ const SearchQueryHandler = {
         `;
     },
 
-    getQueryParams({uilang, lang, urlParams, pagination, sort}) {
+    getQueryParams({uilang, lang, params, pagination, sort}) {
         return {
-            searchPath: urlParams.searchPath,
-            nodeType: (urlParams.searchContentType || 'jmix:searchable'),
-            searchTerms: urlParams.searchTerms,
-            nodeNameSearchTerms: `%${urlParams.searchTerms}%`,
+            searchPath: params.searchPath,
+            nodeType: (params.searchContentType || 'jmix:searchable'),
+            searchTerms: params.searchTerms,
+            nodeNameSearchTerms: `%${params.searchTerms}%`,
             language: lang,
             displayLanguage: uilang,
             offset: pagination.currentPage * pagination.pageSize,
@@ -317,6 +309,10 @@ const SearchQueryHandler = {
                 sortType: sort.order === '' ? null : (sort.order === 'DESC' ? 'ASC' : 'DESC'),
                 fieldName: sort.orderBy === '' ? null : sort.orderBy,
                 ignoreCase: true
+            },
+            fieldFilter: {
+                filters: [],
+                multi: 'NONE'
             }
         };
     },
@@ -346,9 +342,9 @@ const Sql2SearchQueryHandler = {
         `;
     },
 
-    getQueryParams({uilang, lang, urlParams, pagination, sort}) {
-        let {sql2SearchFrom, sql2SearchWhere} = urlParams;
-        let query = `SELECT * FROM [${sql2SearchFrom}] WHERE ISDESCENDANTNODE('${urlParams.searchPath}')`;
+    getQueryParams({uilang, lang, params, pagination, sort}) {
+        let {sql2SearchFrom, sql2SearchWhere} = params;
+        let query = `SELECT * FROM [${sql2SearchFrom}] WHERE ISDESCENDANTNODE('${params.searchPath}')`;
         if (sql2SearchWhere && sql2SearchWhere !== '') {
             query += ` AND (${sql2SearchWhere})`;
         }

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTypeSelector/ContentTypeSelector.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTypeSelector/ContentTypeSelector.jsx
@@ -13,7 +13,7 @@ import {useLayoutQuery} from '~/JContent/ContentRoute/ContentLayout/useLayoutQue
 const localStorage = window.localStorage;
 const VIEW_TYPE = JContentConstants.localStorageKeys.viewType;
 
-const ContentTypeSelector = ({selector, reduxActions}) => {
+const ContentTypeSelector = ({selector, reduxActions, pagesQueryVariables, contentQueryVariables}) => {
     const {t} = useTranslation('jcontent');
     const {tableView} = useSelector(selector, shallowEqual);
     const dispatch = useDispatch();
@@ -31,7 +31,7 @@ const ContentTypeSelector = ({selector, reduxActions}) => {
             ...selector(state).tableView,
             viewType: JContentConstants.tableView.viewType.PAGES
         }
-    }), {fetchPolicy: 'cache-and-network'});
+    }), {fetchPolicy: 'cache-and-network'}, [], pagesQueryVariables);
     const pagesCount = pages.loading ? 0 : pages.queryHandler.getResultsPath(pages.data).pageInfo.totalCount;
 
     const content = useLayoutQuery(state => ({
@@ -40,7 +40,7 @@ const ContentTypeSelector = ({selector, reduxActions}) => {
             ...selector(state).tableView,
             viewType: JContentConstants.tableView.viewType.CONTENT
         }
-    }), {fetchPolicy: 'cache-and-network'});
+    }), {fetchPolicy: 'cache-and-network'}, [], contentQueryVariables);
     const contentCount = content.loading ? 0 : content.queryHandler.getResultsPath(content.data).pageInfo.totalCount;
 
     return (
@@ -72,7 +72,9 @@ ContentTypeSelector.propTypes = {
     reduxActions: {
         setPageAction: PropTypes.func.isRequired,
         setTableViewTypeAction: PropTypes.func.isRequired
-    }
+    },
+    pagesQueryVariables: PropTypes.object,
+    contentQueryVariables: PropTypes.object
 };
 
 ContentTypeSelector.defaultProps = {

--- a/src/javascript/JContent/ContentRoute/ContentLayout/useLayoutQuery.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/useLayoutQuery.jsx
@@ -1,23 +1,8 @@
 import {shallowEqual, useSelector} from 'react-redux';
 import JContentConstants from '~/JContent/JContent.constants';
 import {useQuery} from 'react-apollo';
-import {
-    SearchQueryHandler,
-    Sql2SearchQueryHandler
-} from '~/JContent/ContentRoute/ContentLayout/ContentLayout.gql-queries';
 import {registry} from '@jahia/ui-extender';
 import {replaceFragmentsInDocument} from '@jahia/data-helper';
-
-const contentQueryHandlerByMode = mode => {
-    switch (mode) {
-        case JContentConstants.mode.SEARCH:
-            return SearchQueryHandler;
-        case JContentConstants.mode.SQL2SEARCH:
-            return Sql2SearchQueryHandler;
-        default:
-            return registry.get('accordionItem', mode).queryHandler;
-    }
-};
 
 export function useLayoutQuery(selector, options, fragments, queryVariables) {
     const defaultOptions = {
@@ -41,8 +26,8 @@ export function useLayoutQuery(selector, options, fragments, queryVariables) {
     const {mode, siteKey, path, lang, uilang, params, pagination, sort, tableView} = useSelector(selector, shallowEqual);
     const {fetchPolicy} = {...defaultOptions, ...options};
 
-    const queryHandler = contentQueryHandlerByMode(mode);
-    const layoutQuery = replaceFragmentsInDocument(queryHandler.getQuery(), fragments);
+    const queryHandler = registry.get('accordionItem', mode).queryHandler;
+    const layoutQuery = replaceFragmentsInDocument(queryHandler.getQuery(), [...queryHandler.getFragments(), ...(fragments || [])]);
     const rootPath = `/sites/${siteKey}`;
 
     const isStructuredView = tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED;
@@ -51,7 +36,7 @@ export function useLayoutQuery(selector, options, fragments, queryVariables) {
         path,
         uilang,
         lang,
-        urlParams: params,
+        params,
         rootPath,
         pagination,
         sort,

--- a/src/javascript/JContent/JContent.accordion-items.jsx
+++ b/src/javascript/JContent/JContent.accordion-items.jsx
@@ -5,7 +5,12 @@ import ContentRoute from './ContentRoute';
 import AdditionalAppsTree from './AdditionalAppsTree';
 import AdditionalAppsRoute from './AdditionalAppsRoute';
 import JContentConstants from './JContent.constants';
-import {ContentQueryHandlerPages, ContentQueryHandlerContentFolders, FilesQueryHandler} from '~/JContent/ContentRoute/ContentLayout/ContentLayout.gql-queries';
+import {
+    ContentQueryHandlerPages,
+    ContentQueryHandlerContentFolders,
+    FilesQueryHandler,
+    SearchQueryHandler, Sql2SearchQueryHandler
+} from '~/JContent/ContentRoute/ContentLayout/ContentLayout.gql-queries';
 import ContentTypeSelector from '~/JContent/ContentRoute/ContentLayout/ContentTable/ContentTypeSelector';
 import FileModeSelector from '~/JContent/ContentRoute/ToolBar/FileModeSelector';
 import ViewModeSelector from '~/JContent/ContentRoute/ToolBar/ViewModeSelector';
@@ -47,7 +52,7 @@ export const jContentAccordionItems = registry => {
         getPathForItem: node => {
             return node.ancestors[node.ancestors.length - 1].path;
         },
-        queryHandler: ContentQueryHandlerPages
+        queryHandler: ContentQueryHandlerContentFolders
     });
 
     const renderDefaultApps = registry.add('accordionItem', 'renderDefaultApps', {
@@ -58,6 +63,14 @@ export const jContentAccordionItems = registry => {
         ),
         routeRender: (v, item) => <AdditionalAppsRoute target={item.appsTarget} match={v.match}/>,
         defaultPath: () => '/'
+    });
+
+    registry.add('accordionItem', 'search', {
+        queryHandler: SearchQueryHandler
+    });
+
+    registry.add('accordionItem', 'sql2Search', {
+        queryHandler: Sql2SearchQueryHandler
     });
 
     registry.add('accordionItem', 'pages', renderDefaultContentTrees, {
@@ -81,11 +94,12 @@ export const jContentAccordionItems = registry => {
             rootLabel: 'jcontent:label.contentManager.browsePages',
             key: 'browse-tree-pages'
         },
+        queryHandler: ContentQueryHandlerPages,
         viewSelector: <ViewModeSelector/>,
         tableHeader: <ContentTypeSelector/>
     });
 
-    registry.add('accordionItem', 'content-folders', {...renderDefaultContentTrees, queryHandler: ContentQueryHandlerContentFolders}, {
+    registry.add('accordionItem', 'content-folders', renderDefaultContentTrees, {
         targets: ['jcontent:60'],
         icon: <FolderSpecial/>,
         label: 'jcontent:label.contentManager.navigation.contentFolders',


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19906

## Description

Create mode for search and sqlsearch with queryHandler only, so that we can override them in content-pickers
Clean up useLayoutQuery and queries, added an optional getFragments() function to just add fragment without redefinig the query
