### PR TITLE
BACKLOG-17350: Disable selection checkbox for non-selectable types

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellSelection.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellSelection.jsx
@@ -3,14 +3,18 @@ import {Checkbox, TableBodyCell} from '@jahia/moonstone';
 import PropTypes from 'prop-types';
 import {columnWidths} from '../../columns';
 
-export const CellSelection = ({row, cell, column}) => (
-    <TableBodyCell key={row.id + column.id}
-                   {...cell.getCellProps()}
-                   width={columnWidths[column.id]}
-    >
-        <Checkbox {...row.getToggleRowSelectedProps()}/>
-    </TableBodyCell>
-);
+export const CellSelection = ({row, cell, column}) => {
+    // Not selectable only if 'isSelectable' is explicitly set to false
+    const selectable = row.original.isSelectable !== false;
+    return (
+        <TableBodyCell key={row.id + column.id}
+                       {...cell.getCellProps()}
+                       width={columnWidths[column.id]}
+        >
+            {selectable && <Checkbox {...row.getToggleRowSelectedProps()}/>}
+        </TableBodyCell>
+    );
+};
 
 CellSelection.propTypes = {
     value: PropTypes.string,


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17350

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Disable selection checkbox for row only if `isSelectable` is explicitly set to false