### PR TITLE
BACKLOG-19909 Update canDisplayItem method to use either node or fold…

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
@@ -4,7 +4,7 @@ import {ContextualMenu, registry} from '@jahia/ui-extender';
 import * as _ from 'lodash';
 import {useTranslation} from 'react-i18next';
 import {CM_DRAWER_STATES, cmGoto, cmOpenPaths} from '~/JContent/JContent.redux';
-import {allowDoubleClickNavigation, extractPaths} from '~/JContent/JContent.utils';
+import {allowDoubleClickNavigation, extractPaths, getCanDisplayItemParams} from '~/JContent/JContent.utils';
 import {shallowEqual, useDispatch, useSelector} from 'react-redux';
 import UploadTransformComponent from '../UploadTransformComponent';
 import {cmSetPreviewSelection} from '~/JContent/preview.redux';
@@ -105,7 +105,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading}) =
     const doubleClickNavigation = node => {
         let newMode = mode;
         if (mode === JContentConstants.mode.SEARCH) {
-            const newMode = registry.find({type: 'accordionItem', target: 'jcontent'}).find(acc => acc.canDisplayItem(node))?.key;
+            newMode = registry.find({type: 'accordionItem', target: 'jcontent'}).find(acc => acc.canDisplayItem(getCanDisplayItemParams(node)))?.key;
             if (newMode) {
                 setMode(newMode);
             }

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
@@ -105,7 +105,8 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading}) =
     const doubleClickNavigation = node => {
         let newMode = mode;
         if (mode === JContentConstants.mode.SEARCH) {
-            newMode = registry.find({type: 'accordionItem', target: 'jcontent'}).find(acc => acc.canDisplayItem(getCanDisplayItemParams(node)))?.key;
+            const params = getCanDisplayItemParams(node);
+            newMode = registry.find({type: 'accordionItem', target: 'jcontent'}).find(acc => acc.canDisplayItem && acc.canDisplayItem(params))?.key;
             if (newMode) {
                 setMode(newMode);
             }

--- a/src/javascript/JContent/JContent.accordion-items.jsx
+++ b/src/javascript/JContent/JContent.accordion-items.jsx
@@ -18,6 +18,9 @@ import {Sql2SearchQueryHandler} from '~/JContent/ContentRoute/ContentLayout/quer
 
 const filesRegex = /^\/sites\/[^/]+\/files((\/.*)|$)/;
 const contentsRegex = /^\/sites\/[^/]+\/contents((\/.*)|$)/;
+const contentFolderRegex = /^\/sites\/[^/]+\/contents.*/;
+const folderRegex = /^\/sites\/[^/]+\/files.*/;
+const everythingUnderSitesRegex = /^\/sites\/.*/;
 
 export const jContentAccordionItems = registry => {
     const getPath = (site, pathElements, registryItem) => {
@@ -84,7 +87,12 @@ export const jContentAccordionItems = registry => {
                 .filter(n => n.primaryNodeType.name === 'jnt:page');
             return pages[pages.length - 1].path;
         },
-        canDisplayItem: ({selectionNode, folderNode}) => selectionNode ? !filesRegex.test(selectionNode.path) && !contentsRegex.test(selectionNode.path) : /^\/sites\/.*/.test(folderNode.path),
+        canDisplayItem: ({selectionNode, folderNode}) =>
+            selectionNode ? !filesRegex.test(selectionNode.path) &&
+                !contentsRegex.test(selectionNode.path) :
+                everythingUnderSitesRegex.test(folderNode.path) &&
+                !folderRegex.test(folderNode.path) &&
+                !contentFolderRegex.test(folderNode.path),
         getViewTypeForItem: node => node.primaryNodeType.name === 'jnt:page' ? 'pages' : 'content',
         requiredSitePermission: JContentConstants.accordionPermissions.pagesAccordionAccess,
         config: {
@@ -106,7 +114,7 @@ export const jContentAccordionItems = registry => {
         icon: <FolderSpecial/>,
         label: 'jcontent:label.contentManager.navigation.contentFolders',
         defaultPath: siteKey => '/sites/' + siteKey + '/contents',
-        canDisplayItem: ({selectionNode, folderNode}) => selectionNode ? contentsRegex.test(selectionNode.path) : /^\/sites\/[^/]+\/contents.*/.test(folderNode.path),
+        canDisplayItem: ({selectionNode, folderNode}) => selectionNode ? contentsRegex.test(selectionNode.path) : contentFolderRegex.test(folderNode.path),
         requiredSitePermission: JContentConstants.accordionPermissions.contentFolderAccordionAccess,
         config: {
             rootPath: '/contents',
@@ -124,7 +132,7 @@ export const jContentAccordionItems = registry => {
         icon: <Collections/>,
         label: 'jcontent:label.contentManager.navigation.media',
         defaultPath: siteKey => '/sites/' + siteKey + '/files',
-        canDisplayItem: ({selectionNode, folderNode}) => selectionNode ? filesRegex.test(selectionNode.path) : /^\/sites\/[^/]+\/files.*/.test(folderNode.node),
+        canDisplayItem: ({selectionNode, folderNode}) => selectionNode ? filesRegex.test(selectionNode.path) : folderRegex.test(folderNode.node),
         requiredSitePermission: JContentConstants.accordionPermissions.mediaAccordionAccess,
         config: {
             rootPath: '/files',

--- a/src/javascript/JContent/JContent.accordion-items.jsx
+++ b/src/javascript/JContent/JContent.accordion-items.jsx
@@ -18,7 +18,6 @@ import {Sql2SearchQueryHandler} from '~/JContent/ContentRoute/ContentLayout/quer
 
 const filesRegex = /^\/sites\/[^/]+\/files((\/.*)|$)/;
 const contentsRegex = /^\/sites\/[^/]+\/contents((\/.*)|$)/;
-const folderRegex = /^\/sites\/.*/;
 
 export const jContentAccordionItems = registry => {
     const getPath = (site, pathElements, registryItem) => {
@@ -42,18 +41,6 @@ export const jContentAccordionItems = registry => {
         return path;
     };
 
-    const compareNodesByPathDesc = (a, b) => {
-        if (a.path.length < b.path.length) {
-            return 1;
-        }
-
-        if (a.path.length > b.path.length) {
-            return -1;
-        }
-
-        return 0;
-    };
-
     const renderDefaultContentTrees = registry.add('accordionItem', 'renderDefaultContentTrees', {
         render: (v, item) => (
             <AccordionItem key={v.id} id={v.id} label={v.label} icon={v.icon}>
@@ -64,7 +51,7 @@ export const jContentAccordionItems = registry => {
         getPath,
         getUrlPathPart,
         getPathForItem: node => {
-            return node.ancestors.sort(compareNodesByPathDesc)[node.ancestors.length - 1].path;
+            return node.ancestors[node.ancestors.length - 1].path;
         },
         queryHandler: ContentFoldersQueryHandler
     });
@@ -94,11 +81,10 @@ export const jContentAccordionItems = registry => {
         defaultPath: siteKey => '/sites/' + siteKey,
         getPathForItem: node => {
             const pages = node.ancestors
-                .filter(n => n.primaryNodeType.name === 'jnt:page')
-                .sort(compareNodesByPathDesc);
+                .filter(n => n.primaryNodeType.name === 'jnt:page');
             return pages[pages.length - 1].path;
         },
-        canDisplayItem: (selectionNode, folderNode) => selectionNode ? !filesRegex.test(selectionNode.path) && !contentsRegex.test(selectionNode.path) : folderRegex.test(folderNode.path),
+        canDisplayItem: ({selectionNode, folderNode}) => selectionNode ? !filesRegex.test(selectionNode.path) && !contentsRegex.test(selectionNode.path) : /^\/sites\/.*/.test(folderNode.path),
         getViewTypeForItem: node => node.primaryNodeType.name === 'jnt:page' ? 'pages' : 'content',
         requiredSitePermission: JContentConstants.accordionPermissions.pagesAccordionAccess,
         config: {
@@ -120,7 +106,7 @@ export const jContentAccordionItems = registry => {
         icon: <FolderSpecial/>,
         label: 'jcontent:label.contentManager.navigation.contentFolders',
         defaultPath: siteKey => '/sites/' + siteKey + '/contents',
-        canDisplayItem: (selectionNode, folderNode) => selectionNode ? contentsRegex.test(selectionNode.path) : folderRegex.test(folderNode.path),
+        canDisplayItem: ({selectionNode, folderNode}) => selectionNode ? contentsRegex.test(selectionNode.path) : /^\/sites\/[^/]+\/contents.*/.test(folderNode.path),
         requiredSitePermission: JContentConstants.accordionPermissions.contentFolderAccordionAccess,
         config: {
             rootPath: '/contents',
@@ -138,7 +124,7 @@ export const jContentAccordionItems = registry => {
         icon: <Collections/>,
         label: 'jcontent:label.contentManager.navigation.media',
         defaultPath: siteKey => '/sites/' + siteKey + '/files',
-        canDisplayItem: (selectionNode, folderNode) => selectionNode ? filesRegex.test(selectionNode.path) : folderRegex.test(folderNode.node),
+        canDisplayItem: ({selectionNode, folderNode}) => selectionNode ? filesRegex.test(selectionNode.path) : /^\/sites\/[^/]+\/files.*/.test(folderNode.node),
         requiredSitePermission: JContentConstants.accordionPermissions.mediaAccordionAccess,
         config: {
             rootPath: '/files',

--- a/src/javascript/JContent/JContent.accordion-items.jsx
+++ b/src/javascript/JContent/JContent.accordion-items.jsx
@@ -132,7 +132,7 @@ export const jContentAccordionItems = registry => {
         icon: <Collections/>,
         label: 'jcontent:label.contentManager.navigation.media',
         defaultPath: siteKey => '/sites/' + siteKey + '/files',
-        canDisplayItem: ({selectionNode, folderNode}) => selectionNode ? filesRegex.test(selectionNode.path) : folderRegex.test(folderNode.node),
+        canDisplayItem: ({selectionNode, folderNode}) => selectionNode ? filesRegex.test(selectionNode.path) : folderRegex.test(folderNode.path),
         requiredSitePermission: JContentConstants.accordionPermissions.mediaAccordionAccess,
         config: {
             rootPath: '/files',

--- a/src/javascript/JContent/JContent.accordion-items.jsx
+++ b/src/javascript/JContent/JContent.accordion-items.jsx
@@ -16,10 +16,10 @@ import {FilesQueryHandler} from '~/JContent/ContentRoute/ContentLayout/queryHand
 import {SearchQueryHandler} from '~/JContent/ContentRoute/ContentLayout/queryHandlers/SearchQueryHandler';
 import {Sql2SearchQueryHandler} from '~/JContent/ContentRoute/ContentLayout/queryHandlers/Sql2SearchQueryHandler';
 
-const filesRegex = /^\/sites\/[^/]+\/files((\/.*)|$)/;
-const contentsRegex = /^\/sites\/[^/]+\/contents((\/.*)|$)/;
-const contentFolderRegex = /^\/sites\/[^/]+\/contents.*/;
-const folderRegex = /^\/sites\/[^/]+\/files.*/;
+const filesRegex = /^\/sites\/[^/]+\/files\/.*/;
+const contentsRegex = /^\/sites\/[^/]+\/contents\/.*/;
+const contentFolderRegex = /^\/sites\/[^/]+\/contents((\/.*)|$)/;
+const folderRegex = /^\/sites\/[^/]+\/files((\/.*)|$)/;
 const everythingUnderSitesRegex = /^\/sites\/.*/;
 
 export const jContentAccordionItems = registry => {

--- a/src/javascript/JContent/JContent.accordion-items.jsx
+++ b/src/javascript/JContent/JContent.accordion-items.jsx
@@ -88,7 +88,8 @@ export const jContentAccordionItems = registry => {
             return pages[pages.length - 1].path;
         },
         canDisplayItem: ({selectionNode, folderNode}) =>
-            selectionNode ? !filesRegex.test(selectionNode.path) &&
+            selectionNode ? everythingUnderSitesRegex.test(selectionNode.path) && 
+                !filesRegex.test(selectionNode.path) &&
                 !contentsRegex.test(selectionNode.path) :
                 everythingUnderSitesRegex.test(folderNode.path) &&
                 !folderRegex.test(folderNode.path) &&

--- a/src/javascript/JContent/JContent.utils.js
+++ b/src/javascript/JContent/JContent.utils.js
@@ -168,3 +168,16 @@ export const arrayValue = value => {
 };
 
 export const booleanValue = v => typeof v === 'string' ? v === 'true' : Boolean(v);
+
+export const getCanDisplayItemParams = node => {
+    const folders = ['jnt:contentFolder', 'jnt:folder'];
+    const params = {};
+
+    if (folders.includes(node.primaryNodeType.name)) {
+        params.folderNode = node;
+    } else {
+        params.selectionNode = node;
+    }
+
+    return params;
+};

--- a/src/javascript/JContent/actions/expandTree.jsx
+++ b/src/javascript/JContent/actions/expandTree.jsx
@@ -29,7 +29,7 @@ const GetAncestorsQuery = gql`
 export const expandTree = (path, client) => {
     return client.query({query: GetAncestorsQuery, variables: {path}}).then(res => {
         let node = res.data.jcr.nodeByPath;
-        const params = getCanDisplayItemParams(node);
+        const params = {selectionNode: node};
         const acc = registry.find({type: 'accordionItem', target: 'jcontent'}).find(acc => acc.canDisplayItem && acc.canDisplayItem(params));
         const mode = acc.key;
         const parentPath = acc.getPathForItem(node);

--- a/src/javascript/JContent/actions/expandTree.jsx
+++ b/src/javascript/JContent/actions/expandTree.jsx
@@ -29,7 +29,8 @@ const GetAncestorsQuery = gql`
 export const expandTree = (path, client) => {
     return client.query({query: GetAncestorsQuery, variables: {path}}).then(res => {
         let node = res.data.jcr.nodeByPath;
-        const acc = registry.find({type: 'accordionItem', target: 'jcontent'}).find(acc => acc.canDisplayItem(getCanDisplayItemParams(node)));
+        const params = getCanDisplayItemParams(node);
+        const acc = registry.find({type: 'accordionItem', target: 'jcontent'}).find(acc => acc.canDisplayItem && acc.canDisplayItem(params));
         const mode = acc.key;
         const parentPath = acc.getPathForItem(node);
         const viewType = acc.getViewTypeForItem ? acc.getViewTypeForItem(node) : null;

--- a/src/javascript/JContent/actions/expandTree.jsx
+++ b/src/javascript/JContent/actions/expandTree.jsx
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 import gql from 'graphql-tag';
 import {PredefinedFragments} from '@jahia/data-helper';
 import {registry} from '@jahia/ui-extender';
+import {getCanDisplayItemParams} from '~/JContent/JContent.utils';
 
 const GetAncestorsQuery = gql`
     query getAncestorsQuery($path:String!) {
@@ -28,7 +29,7 @@ const GetAncestorsQuery = gql`
 export const expandTree = (path, client) => {
     return client.query({query: GetAncestorsQuery, variables: {path}}).then(res => {
         let node = res.data.jcr.nodeByPath;
-        const acc = registry.find({type: 'accordionItem', target: 'jcontent'}).find(acc => acc.canDisplayItem(node));
+        const acc = registry.find({type: 'accordionItem', target: 'jcontent'}).find(acc => acc.canDisplayItem(getCanDisplayItemParams(node)));
         const mode = acc.key;
         const parentPath = acc.getPathForItem(node);
         const viewType = acc.getViewTypeForItem ? acc.getViewTypeForItem(node) : null;

--- a/src/javascript/JContent/actions/openInJcontentAction.jsx
+++ b/src/javascript/JContent/actions/openInJcontentAction.jsx
@@ -32,7 +32,7 @@ export const OpenInJContentActionComponent = ({path, render: Render, loading: Lo
                 isVisible={res.checksResult}
                 enabled={res.checksResult}
                 onClick={() => {
-                    const params = getCanDisplayItemParams(res.node);
+                    const params = {folderNode: res.node};
                     const acc = registry.find({type: 'accordionItem', target: 'jcontent'}).find(acc => acc.canDisplayItem && acc.canDisplayItem(params));
                     const mode = acc.key;
                     window.open(`${window.contextJsParameters.contextPath}/jahia/jcontent/${matchArray[1]}/${language}/${mode}/${matchArray[2]}`, '_blank');

--- a/src/javascript/JContent/actions/openInJcontentAction.jsx
+++ b/src/javascript/JContent/actions/openInJcontentAction.jsx
@@ -3,6 +3,7 @@ import {useNodeChecks} from '@jahia/data-helper';
 import {useSelector} from 'react-redux';
 import PropTypes from 'prop-types';
 import {registry} from '@jahia/ui-extender';
+import {getCanDisplayItemParams} from '~/JContent/JContent.utils';
 
 export const OpenInJContentActionComponent = ({path, render: Render, loading: Loading, ...others}) => {
     const {language} = useSelector(state => ({language: state.language}));
@@ -31,7 +32,7 @@ export const OpenInJContentActionComponent = ({path, render: Render, loading: Lo
                 isVisible={res.checksResult}
                 enabled={res.checksResult}
                 onClick={() => {
-                    const acc = registry.find({type: 'accordionItem', target: 'jcontent'}).find(acc => acc.canDisplayItem(res.node));
+                    const acc = registry.find({type: 'accordionItem', target: 'jcontent'}).find(acc => acc.canDisplayItem(getCanDisplayItemParams(res.node)));
                     const mode = acc.key;
                     window.open(`${window.contextJsParameters.contextPath}/jahia/jcontent/${matchArray[1]}/${language}/${mode}/${matchArray[2]}`, '_blank');
                 }}

--- a/src/javascript/JContent/actions/openInJcontentAction.jsx
+++ b/src/javascript/JContent/actions/openInJcontentAction.jsx
@@ -32,7 +32,8 @@ export const OpenInJContentActionComponent = ({path, render: Render, loading: Lo
                 isVisible={res.checksResult}
                 enabled={res.checksResult}
                 onClick={() => {
-                    const acc = registry.find({type: 'accordionItem', target: 'jcontent'}).find(acc => acc.canDisplayItem(getCanDisplayItemParams(res.node)));
+                    const params = getCanDisplayItemParams(res.node);
+                    const acc = registry.find({type: 'accordionItem', target: 'jcontent'}).find(acc => acc.canDisplayItem && acc.canDisplayItem(params));
                     const mode = acc.key;
                     window.open(`${window.contextJsParameters.contextPath}/jahia/jcontent/${matchArray[1]}/${language}/${mode}/${matchArray[2]}`, '_blank');
                 }}


### PR DESCRIPTION
…er, sort ancestors by path descending

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19909

## Description

Update canDisplayItem method 
Sort ancestors so that we always get closest one