### PR TITLE
BACKLOG-17381: centralize structured view and result parsing in query…

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx
@@ -42,7 +42,7 @@ export const ContentLayoutContainer = () => {
     const removeSelection = path => dispatch(cmRemoveSelection(path));
     const switchSelection = path => dispatch(cmSwitchSelection(path));
 
-    const {layoutQuery, layoutQueryParams, result, error, loading, refetch} = useLayoutQuery();
+    const {layoutQuery, layoutQueryParams, isStructured, result, error, loading, refetch} = useLayoutQuery();
 
     function onGwtCreate(nodePath) {
         let parentPath = nodePath.substring(0, nodePath.lastIndexOf('/'));
@@ -186,6 +186,7 @@ export const ContentLayoutContainer = () => {
                            previewState={previewState}
                            previewSelection={previewSelection}
                            rows={[]}
+                           isStructured={isStructured}
                            isLoading={loading}
                            totalCount={0}
             />
@@ -220,6 +221,7 @@ export const ContentLayoutContainer = () => {
                            previewSelection={previewSelection}
                            rows={rows}
                            isLoading={loading}
+                           isStructured={isStructured}
                            totalCount={totalCount}
             />
         </React.Fragment>

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.jsx
@@ -13,7 +13,7 @@ import {ErrorBoundary} from '@jahia/jahia-ui-root';
 import {flattenTree} from './ContentLayout.utils';
 import styles from './ContentLayout.scss';
 
-export const ContentLayout = ({mode, path, previewState, filesMode, previewSelection, rows, isContentNotFound, totalCount, isLoading}) => {
+export const ContentLayout = ({mode, path, previewState, filesMode, previewSelection, rows, isContentNotFound, totalCount, isLoading, isStructured}) => {
     const contextualMenu = useRef();
     const previewOpen = previewState >= CM_DRAWER_STATES.SHOW;
     return (
@@ -56,6 +56,7 @@ export const ContentLayout = ({mode, path, previewState, filesMode, previewSelec
                                 <ContentTable totalCount={totalCount}
                                               rows={rows}
                                               isContentNotFound={isContentNotFound}
+                                              isStructured={isStructured}
                                               isLoading={isLoading}/>}
                         </ErrorBoundary>
                     </Paper>
@@ -74,7 +75,8 @@ ContentLayout.propTypes = {
     rows: PropTypes.array.isRequired,
     isContentNotFound: PropTypes.bool,
     totalCount: PropTypes.number.isRequired,
-    isLoading: PropTypes.bool.isRequired
+    isLoading: PropTypes.bool.isRequired,
+    isStructured: PropTypes.bool
 };
 
 export default ContentLayout;

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.utils.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.utils.js
@@ -30,29 +30,6 @@ export const getFileType = function (filename) {
     return filename.split('.').pop().toLowerCase();
 };
 
-export const structureData = function (parentPath, dataForParentPath = []) {
-    const structuredData = dataForParentPath.filter(d => d.parent.path === parentPath);
-    setSubrows(structuredData, dataForParentPath);
-    return structuredData;
-
-    // Recursively finds and puts children of data[i] in data[i].subRows
-    function setSubrows(data, unstructuredData) {
-        for (let i = 0; i < data.length; i++) {
-            data[i].subRows = [];
-            const rest = [];
-            for (let j = 0; j < unstructuredData.length; j++) {
-                if (data[i].path === unstructuredData[j].parent.path) {
-                    data[i].subRows.push(unstructuredData[j]);
-                } else {
-                    rest.push(unstructuredData[j]);
-                }
-            }
-
-            setSubrows(data[i].subRows, rest);
-        }
-    }
-};
-
 export const flattenTree = function (rows) {
     const items = [];
     collectItems(rows);

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
@@ -24,11 +24,11 @@ import ContentTableWrapper from './ContentTableWrapper';
 import {flattenTree, isInSearchMode} from '../ContentLayout.utils';
 import {useKeyboardNavigation} from '../useKeyboardNavigation';
 
-export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading}) => {
+export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, isStructured}) => {
     const {t} = useTranslation('jcontent');
     const dispatch = useDispatch();
 
-    const {mode, previewSelection, siteKey, path, pagination, previewState, selection, tableView, searchTerms} = useSelector(state => ({
+    const {mode, previewSelection, siteKey, path, pagination, previewState, selection, searchTerms} = useSelector(state => ({
         mode: state.jcontent.mode,
         previewSelection: state.jcontent.previewSelection,
         siteKey: state.site,
@@ -39,8 +39,6 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading}) =
         tableView: state.jcontent.tableView,
         searchTerms: state.jcontent.params.searchTerms
     }), shallowEqual);
-
-    const isStructuredView = JContentConstants.tableView.viewMode.STRUCTURED === tableView.viewMode;
 
     const onPreviewSelect = previewSelection => dispatch(cmSetPreviewSelection(previewSelection));
     const setPath = (siteKey, path, mode, params) => {
@@ -95,10 +93,10 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading}) =
     }, [rows, selection, dispatch, paths]);
 
     useEffect(() => {
-        if (isStructuredView) {
+        if (isStructured) {
             toggleAllRowsExpanded(true);
         }
-    }, [rows, isStructuredView, toggleAllRowsExpanded]);
+    }, [rows, isStructured, toggleAllRowsExpanded]);
 
     const contextualMenus = useRef({});
 
@@ -199,7 +197,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading}) =
                     </TableBody>
                 </Table>
             </UploadTransformComponent>
-            {(!isStructuredView || isInSearchMode(mode) || JContentConstants.mode.MEDIA === mode) &&
+            {(!isStructured || isInSearchMode(mode) || JContentConstants.mode.MEDIA === mode) &&
             <TablePagination totalNumberOfRows={totalCount}
                              currentPage={pagination.currentPage + 1}
                              rowsPerPage={pagination.pageSize}
@@ -218,6 +216,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading}) =
 ContentTable.propTypes = {
     isContentNotFound: PropTypes.bool,
     isLoading: PropTypes.bool,
+    isStructured: PropTypes.bool,
     rows: PropTypes.array.isRequired,
     totalCount: PropTypes.number.isRequired
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTypeSelector/ContentTypeSelector.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTypeSelector/ContentTypeSelector.jsx
@@ -32,7 +32,7 @@ const ContentTypeSelector = ({selector, reduxActions}) => {
             viewType: JContentConstants.tableView.viewType.PAGES
         }
     }), {fetchPolicy: 'cache-and-network'});
-    const pagesCount = pages.loading ? 0 : pages.queryHandler.getResultsPath(pages.data).pageInfo.totalCount;
+    const pagesCount = pages.loading ? 0 : pages.result.pageInfo.totalCount;
 
     const content = useLayoutQuery(state => ({
         ...selector(state),
@@ -41,7 +41,7 @@ const ContentTypeSelector = ({selector, reduxActions}) => {
             viewType: JContentConstants.tableView.viewType.CONTENT
         }
     }), {fetchPolicy: 'cache-and-network'});
-    const contentCount = content.loading ? 0 : content.queryHandler.getResultsPath(content.data).pageInfo.totalCount;
+    const contentCount = content.loading ? 0 : content.result.pageInfo.totalCount;
 
     return (
         <Tab className={classes.tabs}>

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.js
@@ -5,7 +5,34 @@ export const BaseQueryHandler = {
         return BaseChildrenQuery;
     },
 
-    getResultsPath(data) {
+    structureData(parentPath, result) {
+        const dataForParentPath = result?.nodes || [];
+        const structuredData = dataForParentPath.filter(d => d.parent.path === parentPath);
+        setSubrows(structuredData, dataForParentPath);
+        return {
+            ...result,
+            nodes: structuredData
+        };
+
+        // Recursively finds and puts children of data[i] in data[i].subRows
+        function setSubrows(data, unstructuredData) {
+            for (let i = 0; i < data.length; i++) {
+                data[i].subRows = [];
+                const rest = [];
+                for (let j = 0; j < unstructuredData.length; j++) {
+                    if (data[i].path === unstructuredData[j].parent.path) {
+                        data[i].subRows.push(unstructuredData[j]);
+                    } else {
+                        rest.push(unstructuredData[j]);
+                    }
+                }
+
+                setSubrows(data[i].subRows, rest);
+            }
+        }
+    },
+
+    getResults(data) {
         return data && data.jcr && data.jcr.nodeByPath && data.jcr.nodeByPath.children;
     },
 
@@ -13,21 +40,20 @@ export const BaseQueryHandler = {
         return [];
     },
 
-    getQueryParams({path, lang, uilang, pagination, typeFilter, recursionTypesFilter, sort, fieldGrouping}) {
+    getQueryParams({path, lang, uilang, pagination, sort}) {
         return {
             path: path,
             language: lang,
             displayLanguage: uilang,
             offset: pagination.currentPage * pagination.pageSize,
             limit: pagination.pageSize,
-            typeFilter: typeFilter || ['jnt:content'],
+            typeFilter: ['jnt:content'],
             fieldSorter: sort.orderBy === '' ? null : {
                 sortType: sort.order === '' ? null : (sort.order === 'DESC' ? 'ASC' : 'DESC'),
                 fieldName: sort.orderBy === '' ? null : sort.orderBy,
                 ignoreCase: true
             },
-            recursionTypesFilter: recursionTypesFilter || {multi: 'NONE', types: ['nt:base']},
-            fieldGrouping: fieldGrouping
+            recursionTypesFilter: {multi: 'NONE', types: ['nt:base']}
         };
     }
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.js
@@ -55,5 +55,7 @@ export const BaseQueryHandler = {
             },
             recursionTypesFilter: {multi: 'NONE', types: ['nt:base']}
         };
-    }
+    },
+
+    isStructured: () => false
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/ContentFoldersQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/ContentFoldersQueryHandler.js
@@ -5,23 +5,12 @@ import {BaseDescendantsQuery} from './BaseQueryHandler.gql-queries';
 export const ContentFoldersQueryHandler = {
     ...BaseQueryHandler,
 
-    getQuery() {
-        return BaseDescendantsQuery;
-    },
+    getQuery: () => BaseDescendantsQuery,
 
-    getQueryParams({path, uilang, lang, pagination, sort, viewMode}) {
-        const typeFilter = ['jnt:content', 'jnt:contentFolder'];
-
-        const layoutQueryParams = BaseQueryHandler.getQueryParams({
-            path,
-            lang,
-            uilang,
-            pagination,
-            sort,
-            typeFilter
-        });
-
-        if (viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
+    getQueryParams: selection => {
+        const layoutQueryParams = BaseQueryHandler.getQueryParams(selection);
+        layoutQueryParams.typeFilter = ['jnt:content', 'jnt:contentFolder'];
+        if (selection.tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
             layoutQueryParams.fieldGrouping = null;
             layoutQueryParams.offset = 0;
             layoutQueryParams.limit = 10000;
@@ -31,5 +20,14 @@ export const ContentFoldersQueryHandler = {
         }
 
         return layoutQueryParams;
+    },
+
+    getResults: (data, {tableView, path}) => {
+        const result = BaseQueryHandler.getResults(data);
+        if (tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
+            return BaseQueryHandler.structureData(path, result);
+        }
+
+        return result;
     }
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/ContentFoldersQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/ContentFoldersQueryHandler.js
@@ -22,12 +22,5 @@ export const ContentFoldersQueryHandler = {
         return layoutQueryParams;
     },
 
-    getResults: (data, {tableView, path}) => {
-        const result = BaseQueryHandler.getResults(data);
-        if (tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
-            return BaseQueryHandler.structureData(path, result);
-        }
-
-        return result;
-    }
+    isStructured: ({tableView}) => tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/FilesQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/FilesQueryHandler.js
@@ -4,11 +4,10 @@ import {imageFields} from './FilesQueryHandler.gql-queries';
 export const FilesQueryHandler = {
     ...BaseQueryHandler,
 
-    getQueryParams({path, uilang, lang, pagination, sort}) {
-        return BaseQueryHandler.getQueryParams({path, lang, uilang, pagination, sort, typeFilter: ['jnt:file', 'jnt:folder']});
-    },
+    getQueryParams: selection => ({
+        ...BaseQueryHandler.getQueryParams(selection),
+        typeFilter: ['jnt:file', 'jnt:folder']
+    }),
 
-    getFragments() {
-        return [imageFields];
-    }
+    getFragments: () => [imageFields]
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
@@ -5,43 +5,41 @@ import {BaseDescendantsQuery} from './BaseQueryHandler.gql-queries';
 export const PagesQueryHandler = {
     ...BaseQueryHandler,
 
-    getQuery() {
-        return BaseDescendantsQuery;
-    },
+    getQuery: () => BaseDescendantsQuery,
 
-    getQueryParams({path, uilang, lang, pagination, sort, viewType, viewMode, params}) {
-        let typeFilter = JContentConstants.tableView.viewType.PAGES === viewType ? ['jnt:page'] : [JContentConstants.contentType];
-        let recursionTypesFilter = {multi: 'NONE', types: ['jnt:page', 'jnt:contentFolder']};
+    getQueryParams: selection => {
+        const {tableView, params} = selection;
 
-        if (params.sub) {
-            typeFilter = ['jnt:content', 'jnt:contentFolder'];
-            recursionTypesFilter = {multi: 'NONE', types: ['nt:base']};
-        }
+        const layoutQueryParams = BaseQueryHandler.getQueryParams(selection);
 
-        const layoutQueryParams = BaseQueryHandler.getQueryParams({
-            path,
-            lang,
-            uilang,
-            pagination,
-            sort,
-            typeFilter,
-            recursionTypesFilter
-        });
-
-        if (viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
+        if (tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
             layoutQueryParams.fieldGrouping = null;
             layoutQueryParams.offset = 0;
             layoutQueryParams.limit = 10000;
 
-            if (viewType === JContentConstants.tableView.viewType.CONTENT) {
+            if (tableView.viewType === JContentConstants.tableView.viewType.CONTENT) {
                 layoutQueryParams.recursionTypesFilter = {types: ['jnt:content']};
                 layoutQueryParams.typeFilter = ['jnt:content'];
-            } else if (viewType === JContentConstants.tableView.viewType.PAGES) {
+            } else if (tableView.viewType === JContentConstants.tableView.viewType.PAGES) {
                 layoutQueryParams.recursionTypesFilter = {types: ['jnt:page']};
                 layoutQueryParams.typeFilter = ['jnt:page'];
             }
+        } else if (params.sub) {
+            layoutQueryParams.typeFilter = ['jnt:content', 'jnt:contentFolder'];
+        } else {
+            layoutQueryParams.typeFilter = JContentConstants.tableView.viewType.PAGES === tableView.viewType ? ['jnt:page'] : [JContentConstants.contentType];
+            layoutQueryParams.recursionTypesFilter = {multi: 'NONE', types: ['jnt:page', 'jnt:contentFolder']};
         }
 
         return layoutQueryParams;
+    },
+
+    getResults: (data, {tableView, path}) => {
+        const result = BaseQueryHandler.getResults(data);
+        if (tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
+            return BaseQueryHandler.structureData(path, result);
+        }
+
+        return result;
     }
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
@@ -34,12 +34,5 @@ export const PagesQueryHandler = {
         return layoutQueryParams;
     },
 
-    getResults: (data, {tableView, path}) => {
-        const result = BaseQueryHandler.getResults(data);
-        if (tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
-            return BaseQueryHandler.structureData(path, result);
-        }
-
-        return result;
-    }
+    isStructured: ({tableView}) => tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/SearchQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/SearchQueryHandler.js
@@ -4,33 +4,27 @@ import {BaseQueryHandler} from '~/JContent/ContentRoute/ContentLayout/queryHandl
 export const SearchQueryHandler = {
     ...BaseQueryHandler,
 
-    getQuery() {
-        return SearchQuery;
-    },
+    getQuery: () => SearchQuery,
 
-    getQueryParams({uilang, lang, params, pagination, sort}) {
-        return {
-            searchPath: params.searchPath,
-            nodeType: (params.searchContentType || 'jmix:searchable'),
-            searchTerms: params.searchTerms,
-            nodeNameSearchTerms: `%${params.searchTerms}%`,
-            language: lang,
-            displayLanguage: uilang,
-            offset: pagination.currentPage * pagination.pageSize,
-            limit: pagination.pageSize,
-            fieldSorter: sort.orderBy === '' ? null : {
-                sortType: sort.order === '' ? null : (sort.order === 'DESC' ? 'ASC' : 'DESC'),
-                fieldName: sort.orderBy === '' ? null : sort.orderBy,
-                ignoreCase: true
-            },
-            fieldFilter: {
-                filters: [],
-                multi: 'NONE'
-            }
-        };
-    },
+    getQueryParams: ({uilang, lang, params, pagination, sort}) => ({
+        searchPath: params.searchPath,
+        nodeType: (params.searchContentType || 'jmix:searchable'),
+        searchTerms: params.searchTerms,
+        nodeNameSearchTerms: `%${params.searchTerms}%`,
+        language: lang,
+        displayLanguage: uilang,
+        offset: pagination.currentPage * pagination.pageSize,
+        limit: pagination.pageSize,
+        fieldSorter: sort.orderBy === '' ? null : {
+            sortType: sort.order === '' ? null : (sort.order === 'DESC' ? 'ASC' : 'DESC'),
+            fieldName: sort.orderBy === '' ? null : sort.orderBy,
+            ignoreCase: true
+        },
+        fieldFilter: {
+            filters: [],
+            multi: 'NONE'
+        }
+    }),
 
-    getResultsPath(data) {
-        return data && data.jcr && data.jcr.nodesByCriteria;
-    }
+    getResults: data => data && data.jcr && data.jcr.nodesByCriteria
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/Sql2SearchQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/Sql2SearchQueryHandler.js
@@ -4,11 +4,9 @@ import {BaseQueryHandler} from '~/JContent/ContentRoute/ContentLayout/queryHandl
 export const Sql2SearchQueryHandler = {
     ...BaseQueryHandler,
 
-    getQuery() {
-        return Sql2SearchQuery;
-    },
+    getQuery: () => Sql2SearchQuery,
 
-    getQueryParams({uilang, lang, params, pagination, sort}) {
+    getQueryParams: ({uilang, lang, params, pagination, sort}) => {
         let {sql2SearchFrom, sql2SearchWhere} = params;
         let query = `SELECT * FROM [${sql2SearchFrom}] WHERE ISDESCENDANTNODE('${params.searchPath}')`;
         if (sql2SearchWhere && sql2SearchWhere !== '') {
@@ -29,7 +27,5 @@ export const Sql2SearchQueryHandler = {
         };
     },
 
-    getResultsPath(data) {
-        return data && data.jcr && data.jcr.nodesByQuery;
-    }
+    getResults: data => data && data.jcr && data.jcr.nodesByQuery
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/useLayoutQuery.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/useLayoutQuery.jsx
@@ -35,7 +35,10 @@ export function useLayoutQuery(selector, options, fragments, queryVariables) {
         fetchPolicy
     });
 
-    const result = data && queryHandler.getResults(data, selection);
+    const isStructured = queryHandler.isStructured(selection);
 
-    return {layoutQuery, layoutQueryParams, result, error, loading, refetch};
+    const queryResult = data && queryHandler.getResults(data, selection);
+    const result = isStructured ? queryHandler.structureData(selection.path, queryResult) : queryResult;
+
+    return {layoutQuery, isStructured, layoutQueryParams, result, error, loading, refetch};
 }

--- a/src/javascript/JContent/ContentRoute/ContentLayout/useLayoutQuery.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/useLayoutQuery.jsx
@@ -1,5 +1,4 @@
 import {shallowEqual, useSelector} from 'react-redux';
-import JContentConstants from '~/JContent/JContent.constants';
 import {useQuery} from 'react-apollo';
 import {registry} from '@jahia/ui-extender';
 import {replaceFragmentsInDocument} from '@jahia/data-helper';
@@ -23,31 +22,20 @@ export function useLayoutQuery(selector, options, fragments, queryVariables) {
         });
     }
 
-    const {mode, siteKey, path, lang, uilang, params, pagination, sort, tableView} = useSelector(selector, shallowEqual);
+    const selection = useSelector(selector, shallowEqual);
     const {fetchPolicy} = {...defaultOptions, ...options};
 
-    const queryHandler = registry.get('accordionItem', mode).queryHandler;
+    const queryHandler = registry.get('accordionItem', selection.mode).queryHandler;
     const layoutQuery = replaceFragmentsInDocument(queryHandler.getQuery(), [...(queryHandler.getFragments && queryHandler.getFragments()) || [], ...(fragments || [])]);
-    const rootPath = `/sites/${siteKey}`;
 
-    const isStructuredView = tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED;
-
-    let layoutQueryParams = queryHandler.getQueryParams({
-        path,
-        uilang,
-        lang,
-        params,
-        rootPath,
-        pagination,
-        sort,
-        viewType: tableView.viewType,
-        viewMode: tableView.viewMode,
-        mode
-    });
+    let layoutQueryParams = queryHandler.getQueryParams(selection);
 
     const {data, error, loading, refetch} = useQuery(layoutQuery, {
         variables: {...layoutQueryParams, ...queryVariables},
         fetchPolicy
     });
-    return {queryHandler, layoutQuery, isStructuredView, layoutQueryParams, data, error, loading, refetch};
+
+    const result = data && queryHandler.getResults(data, selection);
+
+    return {layoutQuery, layoutQueryParams, result, error, loading, refetch};
 }


### PR DESCRIPTION
…Handlers

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17381

## Description

Changed the queryHandler so that it directly returns a "result" object with formatted and structured data. Move the logic of structuring from table.container to queryHandler and useLayoutQuery.
Simplified the BaseQueryHandler.getQueryParams so that it takes the same params as the others.
Makes structureData available in BaseQueryHandler to be used in other (including content-editor) handlers.
