### PR TITLE
BACKLOG-19927: Fixed inverted sort order

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.js
@@ -49,7 +49,7 @@ export const BaseQueryHandler = {
             limit: pagination.pageSize,
             typeFilter: ['jnt:content'],
             fieldSorter: sort.orderBy === '' ? null : {
-                sortType: sort.order === '' ? null : (sort.order === 'DESC' ? 'ASC' : 'DESC'),
+                sortType: sort.order === '' ? null : (sort.order === 'DESC' ? 'DESC' : 'ASC'),
                 fieldName: sort.orderBy === '' ? null : sort.orderBy,
                 ignoreCase: true
             },

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/SearchQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/SearchQueryHandler.js
@@ -16,7 +16,7 @@ export const SearchQueryHandler = {
         offset: pagination.currentPage * pagination.pageSize,
         limit: pagination.pageSize,
         fieldSorter: sort.orderBy === '' ? null : {
-            sortType: sort.order === '' ? null : (sort.order === 'DESC' ? 'ASC' : 'DESC'),
+            sortType: sort.order === '' ? null : (sort.order === 'DESC' ? 'DESC' : 'ASC'),
             fieldName: sort.orderBy === '' ? null : sort.orderBy,
             ignoreCase: true
         },

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/Sql2SearchQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/Sql2SearchQueryHandler.js
@@ -20,7 +20,7 @@ export const Sql2SearchQueryHandler = {
             offset: pagination.currentPage * pagination.pageSize,
             limit: pagination.pageSize,
             fieldSorter: sort.orderBy === '' ? null : {
-                sortType: sort.order === '' ? null : (sort.order === 'DESC' ? 'ASC' : 'DESC'),
+                sortType: sort.order === '' ? null : (sort.order === 'DESC' ? 'DESC' : 'ASC'),
                 fieldName: sort.orderBy === '' ? null : sort.orderBy,
                 ignoreCase: true
             }

--- a/src/javascript/JContent/JContent.accordion-items.jsx
+++ b/src/javascript/JContent/JContent.accordion-items.jsx
@@ -88,7 +88,7 @@ export const jContentAccordionItems = registry => {
             return pages[pages.length - 1].path;
         },
         canDisplayItem: ({selectionNode, folderNode}) =>
-            selectionNode ? everythingUnderSitesRegex.test(selectionNode.path) && 
+            selectionNode ? everythingUnderSitesRegex.test(selectionNode.path) &&
                 !filesRegex.test(selectionNode.path) &&
                 !contentsRegex.test(selectionNode.path) :
                 everythingUnderSitesRegex.test(folderNode.path) &&
@@ -100,10 +100,8 @@ export const jContentAccordionItems = registry => {
             hideRoot: true,
             rootPath: '',
             selectableTypes: ['jnt:page', 'jnt:virtualsite'],
-            type: 'pages',
             openableTypes: ['jnt:page', 'jnt:virtualsite', 'jnt:navMenuText'],
-            rootLabel: 'jcontent:label.contentManager.browsePages',
-            key: 'browse-tree-pages'
+            rootLabel: 'jcontent:label.contentManager.browsePages'
         },
         queryHandler: PagesQueryHandler,
         viewSelector: <ViewModeSelector/>,
@@ -120,10 +118,8 @@ export const jContentAccordionItems = registry => {
         config: {
             rootPath: '/contents',
             selectableTypes: ['jmix:cmContentTreeDisplayable', 'jmix:visibleInContentTree', 'jnt:contentFolder'],
-            type: 'contents',
             openableTypes: ['jmix:cmContentTreeDisplayable', 'jmix:visibleInContentTree', 'jnt:contentFolder'],
-            rootLabel: 'jcontent:label.contentManager.browseFolders',
-            key: 'browse-tree-content'
+            rootLabel: 'jcontent:label.contentManager.browseFolders'
         },
         viewSelector: <ViewModeSelector/>
     });
@@ -138,10 +134,8 @@ export const jContentAccordionItems = registry => {
         config: {
             rootPath: '/files',
             selectableTypes: ['jnt:folder'],
-            type: 'files',
             openableTypes: ['jnt:folder'],
-            rootLabel: 'jcontent:label.contentManager.browseFiles',
-            key: 'browse-tree-files'
+            rootLabel: 'jcontent:label.contentManager.browseFiles'
         },
         queryHandler: FilesQueryHandler,
         viewSelector: <FileModeSelector/>

--- a/src/javascript/JContent/actions/expandTree.jsx
+++ b/src/javascript/JContent/actions/expandTree.jsx
@@ -2,7 +2,6 @@ import * as _ from 'lodash';
 import gql from 'graphql-tag';
 import {PredefinedFragments} from '@jahia/data-helper';
 import {registry} from '@jahia/ui-extender';
-import {getCanDisplayItemParams} from '~/JContent/JContent.utils';
 
 const GetAncestorsQuery = gql`
     query getAncestorsQuery($path:String!) {

--- a/src/javascript/JContent/actions/openInJcontentAction.jsx
+++ b/src/javascript/JContent/actions/openInJcontentAction.jsx
@@ -3,7 +3,6 @@ import {useNodeChecks} from '@jahia/data-helper';
 import {useSelector} from 'react-redux';
 import PropTypes from 'prop-types';
 import {registry} from '@jahia/ui-extender';
-import {getCanDisplayItemParams} from '~/JContent/JContent.utils';
 
 export const OpenInJContentActionComponent = ({path, render: Render, loading: Loading, ...others}) => {
     const {language} = useSelector(state => ({language: state.language}));


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19927

## Description

I did not find any reason why sort was inverted ( `sort.order === 'DESC' ? 'ASC' : 'DESC'` ), but it seems it's the case since quite a long time .. ?