### PR TITLE
BACKLOG-19919: Allow usage of dynamic tree in useLayoutQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     }
   },
   "dependencies": {
-    "@apollo/react-hooks": "^4.0.0",
+    "@apollo/react-hooks": "^3.1.5",
     "@babel/polyfill": "^7.0.0",
     "@jahia/data-helper": "^1.0.4",
     "@jahia/design-system-kit": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@apollo/react-hooks": "^3.1.5",
     "@babel/polyfill": "^7.0.0",
-    "@jahia/data-helper": "^1.0.4",
+    "@jahia/data-helper": "^1.0.5",
     "@jahia/design-system-kit": "^1.1.2",
     "@jahia/icons": "^1.1.1",
     "@jahia/jahia-reporter": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     }
   },
   "dependencies": {
-    "@apollo/react-hooks": "^3.1.5",
+    "@apollo/react-hooks": "^4.0.0",
     "@babel/polyfill": "^7.0.0",
     "@jahia/data-helper": "^1.0.4",
     "@jahia/design-system-kit": "^1.1.2",

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx
@@ -16,6 +16,8 @@ import ContentLayout from './ContentLayout';
 import {refetchTypes, setRefetcher, unsetRefetcher} from '~/JContent/JContent.refetches';
 import {Loader} from '@jahia/moonstone';
 import {useLayoutQuery} from '~/JContent/ContentRoute/ContentLayout/useLayoutQuery';
+import clsx from 'clsx';
+import styles from './ContentLayout.scss';
 
 let currentResult;
 
@@ -42,7 +44,7 @@ export const ContentLayoutContainer = () => {
     const removeSelection = path => dispatch(cmRemoveSelection(path));
     const switchSelection = path => dispatch(cmSwitchSelection(path));
 
-    const {layoutQuery, layoutQueryParams, isStructured, result, error, loading, refetch} = useLayoutQuery();
+    const {isStructured, result, error, loading, refetch} = useLayoutQuery();
 
     function onGwtCreate(nodePath) {
         let parentPath = nodePath.substring(0, nodePath.lastIndexOf('/'));
@@ -159,8 +161,6 @@ export const ContentLayoutContainer = () => {
 
     useEffect(() => {
         setRefetcher(refetchTypes.CONTENT_DATA, {
-            query: layoutQuery,
-            queryParams: layoutQueryParams,
             refetch: refetch
         });
 
@@ -208,9 +208,9 @@ export const ContentLayoutContainer = () => {
     }
 
     return (
-        <React.Fragment>
+        <div className="flexFluid flexCol_nowrap" style={{position: 'relative'}}>
             {loading && (
-                <div className="flexFluid flexCol_center alignCenter" style={{flex: '9999', backgroundColor: 'var(--color-light)'}}>
+                <div className={clsx('flexCol_center', 'alignCenter', styles.loader)}>
                     <Loader size="big"/>
                 </div>
             )}
@@ -224,7 +224,7 @@ export const ContentLayoutContainer = () => {
                            isStructured={isStructured}
                            totalCount={totalCount}
             />
-        </React.Fragment>
+        </div>
     );
 };
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.scss
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.scss
@@ -65,3 +65,13 @@
 
     transition: 0.15s;
 }
+
+.loader {
+    position: absolute;
+    z-index: 19999;
+
+    width: 100%;
+    height: 100%;
+
+    background-color: var(--color-light40);
+}

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
@@ -79,10 +79,10 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
             isExpanded: row => openPaths.indexOf(row.path) > -1,
             onExpand: (id, value) => {
                 const node = id.split('.').reduce((p, i) => p.subRows[i], {subRows: rows});
-                if (value !== false) {
-                    dispatch(cmOpenPaths([node.path]));
-                } else {
+                if (value === false) {
                     dispatch(cmClosePaths([node.path]));
+                } else {
+                    dispatch(cmOpenPaths([node.path]));
                 }
             },
             sort,

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
@@ -2,7 +2,7 @@ import React, {useEffect, useMemo, useRef} from 'react';
 import PropTypes from 'prop-types';
 import {ContextualMenu, registry} from '@jahia/ui-extender';
 import {useTranslation} from 'react-i18next';
-import {CM_DRAWER_STATES, cmClosePaths, cmGoto, cmOpenPaths} from '~/JContent/JContent.redux';
+import {CM_DRAWER_STATES, cmCloseTablePaths, cmGoto, cmOpenPaths, cmOpenTablePaths} from '~/JContent/JContent.redux';
 import {allowDoubleClickNavigation, extractPaths, getCanDisplayItemParams} from '~/JContent/JContent.utils';
 import {shallowEqual, useDispatch, useSelector} from 'react-redux';
 import UploadTransformComponent from '../UploadTransformComponent';
@@ -28,7 +28,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
     const {t} = useTranslation('jcontent');
     const dispatch = useDispatch();
 
-    const {mode, previewSelection, siteKey, path, pagination, previewState, selection, searchTerms, openPaths, sort} = useSelector(state => ({
+    const {mode, previewSelection, siteKey, path, pagination, previewState, selection, searchTerms, tableOpenPaths, sort} = useSelector(state => ({
         mode: state.jcontent.mode,
         previewSelection: state.jcontent.previewSelection,
         siteKey: state.site,
@@ -38,7 +38,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
         selection: state.jcontent.selection,
         tableView: state.jcontent.tableView,
         searchTerms: state.jcontent.params.searchTerms,
-        openPaths: state.jcontent.openPaths,
+        tableOpenPaths: state.jcontent.tableOpenPaths,
         sort: state.jcontent.sort
     }), shallowEqual);
 
@@ -76,13 +76,13 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
         {
             columns: allColumnData,
             data: rows,
-            isExpanded: row => openPaths.indexOf(row.path) > -1,
+            isExpanded: row => tableOpenPaths.indexOf(row.path) > -1,
             onExpand: (id, value) => {
                 const node = id.split('.').reduce((p, i) => p.subRows[i], {subRows: rows});
                 if (value === false) {
-                    dispatch(cmClosePaths([node.path]));
+                    dispatch(cmCloseTablePaths([node.path]));
                 } else {
-                    dispatch(cmOpenPaths([node.path]));
+                    dispatch(cmOpenTablePaths([node.path]));
                 }
             },
             sort,
@@ -105,16 +105,6 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
             }
         }
     }, [rows, selection, dispatch, paths]);
-
-    const firstLoad = useRef(true);
-    useEffect(() => {
-        if (isStructured && firstLoad.current) {
-            if (rows.length > 0) {
-                firstLoad.current = false;
-                dispatch(cmOpenPaths(rows.map(r => r.path)));
-            }
-        }
-    }, [dispatch, rows, isStructured, firstLoad]);
 
     const contextualMenus = useRef({});
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
@@ -1,9 +1,8 @@
 import React, {useEffect, useMemo, useRef} from 'react';
 import PropTypes from 'prop-types';
 import {ContextualMenu, registry} from '@jahia/ui-extender';
-import * as _ from 'lodash';
 import {useTranslation} from 'react-i18next';
-import {CM_DRAWER_STATES, cmGoto, cmOpenPaths} from '~/JContent/JContent.redux';
+import {CM_DRAWER_STATES, cmClosePaths, cmGoto, cmOpenPaths} from '~/JContent/JContent.redux';
 import {allowDoubleClickNavigation, extractPaths, getCanDisplayItemParams} from '~/JContent/JContent.utils';
 import {shallowEqual, useDispatch, useSelector} from 'react-redux';
 import UploadTransformComponent from '../UploadTransformComponent';
@@ -15,20 +14,21 @@ import ContentListEmptyDropZone from './ContentEmptyDropZone';
 import ContentNotFound from './ContentNotFound';
 import EmptyTable from './EmptyTable';
 import {Table, TableBody, TablePagination, TableRow} from '@jahia/moonstone';
-import {useExpanded, useTable} from 'react-table';
-import {useRowSelection, useSort} from './reactTable/plugins';
+import {useTable} from 'react-table';
+import {useExpandedControlled, useRowSelection, useSort} from './reactTable/plugins';
 import ContentListHeader from './ContentListHeader/ContentListHeader';
 import css from './ContentTable.scss';
 import {allColumnData, reducedColumnData} from './reactTable/columns';
 import ContentTableWrapper from './ContentTableWrapper';
 import {flattenTree, isInSearchMode} from '../ContentLayout.utils';
 import {useKeyboardNavigation} from '../useKeyboardNavigation';
+import {cmSetSort} from '~/JContent/ContentRoute/ContentLayout/sort.redux';
 
 export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, isStructured}) => {
     const {t} = useTranslation('jcontent');
     const dispatch = useDispatch();
 
-    const {mode, previewSelection, siteKey, path, pagination, previewState, selection, searchTerms} = useSelector(state => ({
+    const {mode, previewSelection, siteKey, path, pagination, previewState, selection, searchTerms, openPaths, sort} = useSelector(state => ({
         mode: state.jcontent.mode,
         previewSelection: state.jcontent.previewSelection,
         siteKey: state.site,
@@ -37,7 +37,9 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
         previewState: state.jcontent.previewState,
         selection: state.jcontent.selection,
         tableView: state.jcontent.tableView,
-        searchTerms: state.jcontent.params.searchTerms
+        searchTerms: state.jcontent.params.searchTerms,
+        openPaths: state.jcontent.openPaths,
+        sort: state.jcontent.sort
     }), shallowEqual);
 
     const onPreviewSelect = previewSelection => dispatch(cmSetPreviewSelection(previewSelection));
@@ -69,16 +71,28 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
         getTableBodyProps,
         headerGroups,
         rows: tableRows,
-        prepareRow,
-        toggleAllRowsExpanded
+        prepareRow
     } = useTable(
         {
             columns: allColumnData,
-            data: rows
+            data: rows,
+            isExpanded: row => openPaths.indexOf(row.path) > -1,
+            onExpand: (id, value) => {
+                const node = id.split('.').reduce((p, i) => p.subRows[i], {subRows: rows});
+                if (value !== false) {
+                    dispatch(cmOpenPaths([node.path]));
+                } else {
+                    dispatch(cmClosePaths([node.path]));
+                }
+            },
+            sort,
+            onSort: (column, order) => {
+                dispatch(cmSetSort({order, orderBy: column.property}));
+            }
         },
         useRowSelection,
         useSort,
-        useExpanded
+        useExpandedControlled
     );
 
     useEffect(() => {
@@ -92,11 +106,15 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
         }
     }, [rows, selection, dispatch, paths]);
 
+    const firstLoad = useRef(true);
     useEffect(() => {
-        if (isStructured) {
-            toggleAllRowsExpanded(true);
+        if (isStructured && firstLoad.current) {
+            if (rows.length > 0) {
+                firstLoad.current = false;
+                dispatch(cmOpenPaths(rows.map(r => r.path)));
+            }
         }
-    }, [rows, isStructured, toggleAllRowsExpanded]);
+    }, [dispatch, rows, isStructured, firstLoad]);
 
     const contextualMenus = useRef({});
 
@@ -122,7 +140,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
 
     const tableHeader = registry.get('accordionItem', mode)?.tableHeader;
 
-    if (_.isEmpty(rows) && !isLoading) {
+    if (!rows?.length && !isLoading) {
         if ((mode === JContentConstants.mode.SEARCH || mode === JContentConstants.mode.SQL2SEARCH)) {
             return <EmptyTable text={searchTerms}/>;
         }

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTypeSelector/ContentTypeSelector.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTypeSelector/ContentTypeSelector.jsx
@@ -71,10 +71,10 @@ const ContentTypeSelector = ({selector, reduxActions}) => {
 
 ContentTypeSelector.propTypes = {
     selector: PropTypes.func,
-    reduxActions: {
+    reduxActions: PropTypes.shape({
         setPageAction: PropTypes.func.isRequired,
         setTableViewTypeAction: PropTypes.func.isRequired
-    }
+    })
 };
 
 ContentTypeSelector.defaultProps = {

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/plugins/index.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/plugins/index.js
@@ -1,2 +1,3 @@
+export * from './useExpandedControlled';
 export * from './useRowSelection';
 export * from './useSort';

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/plugins/useExpandedControlled.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/plugins/useExpandedControlled.jsx
@@ -8,7 +8,7 @@ const expandRows = (rows, {manualExpandedKey, isExpanded, expandSubRows = true})
         row.isExpanded =
             (row.original && row.original[manualExpandedKey]) || isExpanded(row.original);
 
-        row.canExpand = (row.subRows && Boolean(row.subRows.length)) || row.original.hasSubRows;
+        row.canExpand = row.original.openable && ((row.subRows && Boolean(row.subRows.length)) || row.original.hasSubRows);
 
         if (addToExpandedRows) {
             expandedRows.push(row);

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/plugins/useExpandedControlled.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/plugins/useExpandedControlled.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import {ensurePluginOrder, makePropGetter} from 'react-table';
+
+const expandRows = (rows, {manualExpandedKey, isExpanded, expandSubRows = true}) => {
+    const expandedRows = [];
+
+    const handleRow = (row, addToExpandedRows = true) => {
+        row.isExpanded =
+            (row.original && row.original[manualExpandedKey]) || isExpanded(row.original);
+
+        row.canExpand = (row.subRows && Boolean(row.subRows.length)) || row.original.hasSubRows;
+
+        if (addToExpandedRows) {
+            expandedRows.push(row);
+        }
+
+        if (row.subRows && row.subRows.length && row.isExpanded) {
+            row.subRows.forEach(row => handleRow(row, expandSubRows));
+        }
+    };
+
+    rows.forEach(row => handleRow(row));
+
+    return expandedRows;
+};
+
+export const useExpandedControlled = hooks => {
+    hooks.getToggleRowExpandedProps = [defaultGetToggleRowExpandedProps];
+    hooks.useInstance.push(useInstance);
+    hooks.prepareRow.push(prepareRow);
+};
+
+useExpandedControlled.pluginName = 'useExpanded';
+
+const defaultGetToggleRowExpandedProps = (props, {row}) => [
+    props,
+    {
+        onClick: e => {
+            if (e.target.matches('.moonstone-TableCell > svg') || e.target.matches('.moonstone-TableCell > svg *')) {
+                e.preventDefault();
+                e.stopPropagation();
+                row.toggleRowExpanded(!row.isExpanded);
+            }
+        },
+        style: {
+            cursor: 'pointer'
+        },
+        title: 'Toggle Row Expanded'
+    }
+];
+
+function useInstance(instance) {
+    const {
+        rows,
+        manualExpandedKey = 'expanded',
+        paginateExpandedRows = true,
+        expandSubRows = true,
+        plugins,
+        isExpanded
+    } = instance;
+
+    ensurePluginOrder(
+        plugins,
+        ['useSortBy', 'useGroupBy', 'usePivotColumns', 'useGlobalFilter'],
+        'useExpanded'
+    );
+
+    const expandedRows = React.useMemo(() => {
+        if (paginateExpandedRows) {
+            return expandRows(rows, {manualExpandedKey, isExpanded, expandSubRows});
+        }
+
+        return rows;
+    }, [paginateExpandedRows, rows, manualExpandedKey, isExpanded, expandSubRows]);
+
+    Object.assign(instance, {
+        preExpandedRows: rows,
+        expandedRows,
+        rows: expandedRows
+    });
+}
+
+function prepareRow(row, {instance: {getHooks}, instance}) {
+    row.toggleRowExpanded = set => instance.onExpand(row.id, set);
+    row.getToggleRowExpandedProps = makePropGetter(
+        getHooks().getToggleRowExpandedProps,
+        {
+            instance,
+            row
+        }
+    );
+}

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/plugins/useSort.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/plugins/useSort.jsx
@@ -1,5 +1,3 @@
-import {useDispatch, useSelector} from 'react-redux';
-import {cmSetSort} from '../../../sort.redux';
 import {useGetLatest} from 'react-table';
 
 const DESC = 'DESC';
@@ -12,12 +10,16 @@ export const useSort = hooks => {
 
 useSort.pluginName = 'useSort';
 
+const toggleOrder = order => {
+    return order === DESC ? ASC : DESC;
+};
+
 const defaultGetSortProps = (props, {instance, column}) => {
     return [
         props,
         {
             onClick: () => {
-                instance.sortColumn(column);
+                instance.onSort(column, instance.sort.orderBy === column.property ? toggleOrder(instance.sort.order) : instance.sort.order);
             },
             style: {
                 cursor: 'pointer'
@@ -29,19 +31,6 @@ const defaultGetSortProps = (props, {instance, column}) => {
 function useInstance(instance) {
     const getInstance = useGetLatest(instance);
     const {getHooks, flatHeaders} = instance;
-    const {order, orderBy} = useSelector(state => state.jcontent.sort);
-    const dispatch = useDispatch();
-
-    const toggleOrder = order => {
-        return order === DESC ? ASC : DESC;
-    };
-
-    const sortColumn = column => {
-        dispatch(cmSetSort({
-            order: orderBy === column.property ? toggleOrder(order) : order,
-            orderBy: column.property
-        }));
-    };
 
     flatHeaders
         .forEach(column => {
@@ -53,17 +42,13 @@ function useInstance(instance) {
                     column: column
                 });
 
-                if (column.property === orderBy) {
+                if (column.property === instance.sort.orderBy) {
                     column.sorted = true;
-                    column.sortDirection = order === DESC ? 'descending' : 'ascending';
+                    column.sortDirection = instance.sort.order === DESC ? 'descending' : 'ascending';
                 } else {
                     column.sorted = false;
                 }
             }
         });
-
-    Object.assign(instance, {
-        sortColumn
-    });
 }
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.gql-queries.js
@@ -90,6 +90,10 @@ export const QueryHandlersFragments = {
             }
             ${PredefinedFragments.nodeCacheRequiredFields.gql}
         `,
+        variables: {
+            displayLanguage: 'String!',
+            language: 'String!'
+        },
         applyFor: 'node'
     }
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.js
@@ -6,7 +6,7 @@ export const BaseQueryHandler = {
     },
 
     structureData(parentPath, result) {
-        const dataForParentPath = result?.nodes || [];
+        const dataForParentPath = (result?.nodes || []).map(s => ({...s}));
         const structuredData = dataForParentPath.filter(d => d.parent.path === parentPath);
         setSubrows(structuredData, dataForParentPath);
         return {
@@ -40,7 +40,7 @@ export const BaseQueryHandler = {
         return [];
     },
 
-    getQueryParams({path, lang, uilang, pagination, sort}) {
+    getQueryVariables({path, lang, uilang, pagination, sort}) {
         return {
             path: path,
             language: lang,

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseTreeQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseTreeQueryHandler.js
@@ -1,0 +1,59 @@
+export const BaseTreeQueryHandler = {
+    structureTreeEntries: treeEntries => {
+        const stack = [];
+        const nodes = [];
+        treeEntries.forEach(entry => {
+            const node = {
+                ...entry.node,
+                subRows: [],
+                hasSubRows: entry.node.children.pageInfo.nodesCount > 0
+            };
+
+            while (entry.depth <= stack.length) {
+                stack.pop();
+            }
+
+            if (stack.length === 0) {
+                nodes.push(node);
+            } else {
+                stack[stack.length - 1].subRows.push(node);
+            }
+
+            stack.push(node);
+        });
+
+        return {
+            nodes,
+            pageInfo: {}
+        };
+    },
+
+    getTreeParams: ({path, openPaths, params, sort}) => ({
+        rootPaths: [path],
+        openPaths: [...new Set([path, ...openPaths])],
+        selectedPaths: [],
+        openableTypes: params.openableTypes,
+        selectableTypes: params.selectableTypesTable,
+        hideRoot: true,
+        sortBy: sort.orderBy === '' ? null : {
+            sortType: sort.order === '' ? null : (sort.order === 'DESC' ? 'DESC' : 'ASC'),
+            fieldName: sort.orderBy === '' ? null : sort.orderBy,
+            ignoreCase: true
+        }
+    }),
+
+    getFragments() {
+        return [];
+    },
+
+    getQueryVariables({path, lang, uilang}) {
+        return {
+            path: path,
+            language: lang,
+            displayLanguage: uilang,
+            typeFilter: ['jnt:content']
+        };
+    },
+
+    isStructured: () => true
+};

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseTreeQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseTreeQueryHandler.js
@@ -24,7 +24,9 @@ export const BaseTreeQueryHandler = {
 
         return {
             nodes,
-            pageInfo: {}
+            pageInfo: {
+                totalCount: nodes.length
+            }
         };
     },
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/ContentFoldersQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/ContentFoldersQueryHandler.js
@@ -18,20 +18,10 @@ export const ContentFoldersQueryHandler = {
         return null;
     },
 
-    getQueryVariables: selection => {
-        const queryVariables = BaseQueryHandler.getQueryVariables(selection);
-        queryVariables.typeFilter = ['jnt:content', 'jnt:contentFolder'];
-        if (selection.tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
-            queryVariables.fieldGrouping = null;
-            queryVariables.offset = 0;
-            queryVariables.limit = 10000;
-
-            queryVariables.recursionTypesFilter = {multi: 'NONE', types: ['jnt:contentFolder']};
-            queryVariables.typeFilter = ['jnt:content'];
-        }
-
-        return queryVariables;
-    },
+    getQueryVariables: selection => ({
+        ...BaseQueryHandler.getQueryVariables(selection),
+        typeFilter: ['jnt:content', 'jnt:contentFolder']
+    }),
 
     isStructured: ({tableView}) => tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/ContentFoldersQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/ContentFoldersQueryHandler.js
@@ -7,19 +7,19 @@ export const ContentFoldersQueryHandler = {
 
     getQuery: () => BaseDescendantsQuery,
 
-    getQueryParams: selection => {
-        const layoutQueryParams = BaseQueryHandler.getQueryParams(selection);
-        layoutQueryParams.typeFilter = ['jnt:content', 'jnt:contentFolder'];
+    getQueryVariables: selection => {
+        const queryVariables = BaseQueryHandler.getQueryVariables(selection);
+        queryVariables.typeFilter = ['jnt:content', 'jnt:contentFolder'];
         if (selection.tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
-            layoutQueryParams.fieldGrouping = null;
-            layoutQueryParams.offset = 0;
-            layoutQueryParams.limit = 10000;
+            queryVariables.fieldGrouping = null;
+            queryVariables.offset = 0;
+            queryVariables.limit = 10000;
 
-            layoutQueryParams.recursionTypesFilter = {multi: 'NONE', types: ['jnt:contentFolder']};
-            layoutQueryParams.typeFilter = ['jnt:content'];
+            queryVariables.recursionTypesFilter = {multi: 'NONE', types: ['jnt:contentFolder']};
+            queryVariables.typeFilter = ['jnt:content'];
         }
 
-        return layoutQueryParams;
+        return queryVariables;
     },
 
     isStructured: ({tableView}) => tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/ContentFoldersQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/ContentFoldersQueryHandler.js
@@ -1,11 +1,22 @@
 import {BaseQueryHandler} from './BaseQueryHandler';
 import JContentConstants from '~/JContent/JContent.constants';
 import {BaseDescendantsQuery} from './BaseQueryHandler.gql-queries';
+import {BaseTreeQueryHandler} from '~/JContent/ContentRoute/ContentLayout/queryHandlers/BaseTreeQueryHandler';
 
 export const ContentFoldersQueryHandler = {
     ...BaseQueryHandler,
+    ...BaseTreeQueryHandler,
 
     getQuery: () => BaseDescendantsQuery,
+
+    getTreeParams: selection => {
+        const {openPaths, tableView} = selection;
+        if (openPaths && tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
+            return BaseTreeQueryHandler.getTreeParams(selection);
+        }
+
+        return null;
+    },
 
     getQueryVariables: selection => {
         const queryVariables = BaseQueryHandler.getQueryVariables(selection);

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/FilesQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/FilesQueryHandler.js
@@ -4,8 +4,8 @@ import {imageFields} from './FilesQueryHandler.gql-queries';
 export const FilesQueryHandler = {
     ...BaseQueryHandler,
 
-    getQueryParams: selection => ({
-        ...BaseQueryHandler.getQueryParams(selection),
+    getQueryVariables: selection => ({
+        ...BaseQueryHandler.getQueryVariables(selection),
         typeFilter: ['jnt:file', 'jnt:folder']
     }),
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
@@ -7,31 +7,31 @@ export const PagesQueryHandler = {
 
     getQuery: () => BaseDescendantsQuery,
 
-    getQueryParams: selection => {
+    getQueryVariables: selection => {
         const {tableView, params} = selection;
 
-        const layoutQueryParams = BaseQueryHandler.getQueryParams(selection);
+        const queryVariables = BaseQueryHandler.getQueryVariables(selection);
 
         if (tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
-            layoutQueryParams.fieldGrouping = null;
-            layoutQueryParams.offset = 0;
-            layoutQueryParams.limit = 10000;
+            queryVariables.fieldGrouping = null;
+            queryVariables.offset = 0;
+            queryVariables.limit = 10000;
 
             if (tableView.viewType === JContentConstants.tableView.viewType.CONTENT) {
-                layoutQueryParams.recursionTypesFilter = {types: ['jnt:content']};
-                layoutQueryParams.typeFilter = ['jnt:content'];
+                queryVariables.recursionTypesFilter = {types: ['jnt:content']};
+                queryVariables.typeFilter = ['jnt:content'];
             } else if (tableView.viewType === JContentConstants.tableView.viewType.PAGES) {
-                layoutQueryParams.recursionTypesFilter = {types: ['jnt:page']};
-                layoutQueryParams.typeFilter = ['jnt:page'];
+                queryVariables.recursionTypesFilter = {types: ['jnt:page']};
+                queryVariables.typeFilter = ['jnt:page'];
             }
         } else if (params.sub) {
-            layoutQueryParams.typeFilter = ['jnt:content', 'jnt:contentFolder'];
+            queryVariables.typeFilter = ['jnt:content', 'jnt:contentFolder'];
         } else {
-            layoutQueryParams.typeFilter = JContentConstants.tableView.viewType.PAGES === tableView.viewType ? ['jnt:page'] : [JContentConstants.contentType];
-            layoutQueryParams.recursionTypesFilter = {multi: 'NONE', types: ['jnt:page', 'jnt:contentFolder']};
+            queryVariables.typeFilter = JContentConstants.tableView.viewType.PAGES === tableView.viewType ? ['jnt:page'] : [JContentConstants.contentType];
+            queryVariables.recursionTypesFilter = {multi: 'NONE', types: ['jnt:page', 'jnt:contentFolder']};
         }
 
-        return layoutQueryParams;
+        return queryVariables;
     },
 
     isStructured: ({tableView}) => tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
@@ -1,11 +1,22 @@
 import JContentConstants from '~/JContent/JContent.constants';
 import {BaseQueryHandler} from './BaseQueryHandler';
 import {BaseDescendantsQuery} from './BaseQueryHandler.gql-queries';
+import {BaseTreeQueryHandler} from '~/JContent/ContentRoute/ContentLayout/queryHandlers/BaseTreeQueryHandler';
 
 export const PagesQueryHandler = {
     ...BaseQueryHandler,
+    ...BaseTreeQueryHandler,
 
     getQuery: () => BaseDescendantsQuery,
+
+    getTreeParams: selection => {
+        const {openPaths, tableView} = selection;
+        if (openPaths && tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
+            return BaseTreeQueryHandler.getTreeParams(selection);
+        }
+
+        return null;
+    },
 
     getQueryVariables: selection => {
         const {tableView, params} = selection;

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
@@ -11,7 +11,7 @@ export const PagesQueryHandler = {
 
     getTreeParams: selection => {
         const {openPaths, tableView} = selection;
-        if (openPaths && tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
+        if (openPaths && tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED && tableView.viewType === JContentConstants.tableView.viewType.CONTENT) {
             return BaseTreeQueryHandler.getTreeParams(selection);
         }
 
@@ -39,5 +39,5 @@ export const PagesQueryHandler = {
         return queryVariables;
     },
 
-    isStructured: ({tableView}) => tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED
+    isStructured: ({tableView}) => tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED && tableView.viewType === JContentConstants.tableView.viewType.CONTENT
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
@@ -24,15 +24,9 @@ export const PagesQueryHandler = {
         const queryVariables = BaseQueryHandler.getQueryVariables(selection);
 
         if (tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
-            queryVariables.fieldGrouping = null;
-            queryVariables.offset = 0;
-            queryVariables.limit = 10000;
-
             if (tableView.viewType === JContentConstants.tableView.viewType.CONTENT) {
-                queryVariables.recursionTypesFilter = {types: ['jnt:content']};
                 queryVariables.typeFilter = ['jnt:content'];
             } else if (tableView.viewType === JContentConstants.tableView.viewType.PAGES) {
-                queryVariables.recursionTypesFilter = {types: ['jnt:page']};
                 queryVariables.typeFilter = ['jnt:page'];
             }
         } else if (params.sub) {

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/SearchQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/SearchQueryHandler.js
@@ -6,7 +6,7 @@ export const SearchQueryHandler = {
 
     getQuery: () => SearchQuery,
 
-    getQueryParams: ({uilang, lang, params, pagination, sort}) => ({
+    getQueryVariables: ({uilang, lang, params, pagination, sort}) => ({
         searchPath: params.searchPath,
         nodeType: (params.searchContentType || 'jmix:searchable'),
         searchTerms: params.searchTerms,

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/Sql2SearchQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/Sql2SearchQueryHandler.js
@@ -6,7 +6,7 @@ export const Sql2SearchQueryHandler = {
 
     getQuery: () => Sql2SearchQuery,
 
-    getQueryParams: ({uilang, lang, params, pagination, sort}) => {
+    getQueryVariables: ({uilang, lang, params, pagination, sort}) => {
         let {sql2SearchFrom, sql2SearchWhere} = params;
         let query = `SELECT * FROM [${sql2SearchFrom}] WHERE ISDESCENDANTNODE('${params.searchPath}')`;
         if (sql2SearchWhere && sql2SearchWhere !== '') {

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/index.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/index.js
@@ -1,5 +1,6 @@
 export * from './BaseQueryHandler.gql-queries';
 export * from './BaseQueryHandler';
+export * from './BaseTreeQueryHandler';
 export * from './FilesQueryHandler';
 export * from './ContentFoldersQueryHandler';
 export * from './PagesQueryHandler';

--- a/src/javascript/JContent/ContentRoute/ContentLayout/useLayoutQuery.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/useLayoutQuery.jsx
@@ -47,7 +47,9 @@ export function useLayoutQuery(selector, options, fragments, queryVariables) {
         const {treeEntries, error, loading, refetch} = useTreeEntries({
             ...treeParams,
             fragments: [...allFragments, QueryHandlersFragments.nodeFields, QueryHandlersFragments.childNodesCount],
-            queryVariables
+            queryVariables,
+            openableTypes: treeParams.openableTypes || queryVariables.typeFilter,
+            selectableTypes: treeParams.selectableTypes || []
         });
 
         const result = queryHandler.structureTreeEntries(treeEntries);

--- a/src/javascript/JContent/ContentRoute/ContentLayout/useLayoutQuery.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/useLayoutQuery.jsx
@@ -23,7 +23,7 @@ export function useLayoutQuery(selector, options, fragments, queryVariables) {
             pagination: state.jcontent.pagination,
             sort: state.jcontent.sort,
             tableView: state.jcontent.tableView,
-            openPaths: state.jcontent.openPaths
+            openPaths: state.jcontent.tableOpenPaths
         });
     }
 

--- a/src/javascript/JContent/ContentRoute/ContentRoute.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentRoute.jsx
@@ -20,7 +20,7 @@ const ContentRoute = () => {
         >
             <LoaderSuspense>
                 <ErrorBoundary>
-                    { mode.length > 0 && inEditMode ? <EditFrame isDeviceView={JContentConstants.tableView.viewType.VIEW_DEVICE === viewMode}/> : <ContentLayout key={mode + viewMode}/> }
+                    { mode.length > 0 && inEditMode ? <EditFrame isDeviceView={JContentConstants.tableView.viewType.VIEW_DEVICE === viewMode}/> : <ContentLayout/> }
                 </ErrorBoundary>
             </LoaderSuspense>
         </MainLayout>

--- a/src/javascript/JContent/ContentRoute/ContentRoute.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentRoute.jsx
@@ -20,7 +20,7 @@ const ContentRoute = () => {
         >
             <LoaderSuspense>
                 <ErrorBoundary>
-                    { mode.length > 0 && inEditMode ? <EditFrame isDeviceView={JContentConstants.tableView.viewType.VIEW_DEVICE === viewMode}/> : <ContentLayout/> }
+                    { mode.length > 0 && inEditMode ? <EditFrame isDeviceView={JContentConstants.tableView.viewType.VIEW_DEVICE === viewMode}/> : <ContentLayout key={mode + viewMode}/> }
                 </ErrorBoundary>
             </LoaderSuspense>
         </MainLayout>

--- a/src/javascript/JContent/ContentTree/ContentTree.jsx
+++ b/src/javascript/JContent/ContentTree/ContentTree.jsx
@@ -87,7 +87,6 @@ export const accordionPropType = PropTypes.shape({
         hideRoot: PropTypes.bool,
         rootPath: PropTypes.node.isRequired,
         selectableTypes: PropTypes.arrayOf(PropTypes.string),
-        type: PropTypes.string.isRequired,
         openableTypes: PropTypes.arrayOf(PropTypes.string),
         rootLabel: PropTypes.string,
         sortBy: PropTypes.shape({

--- a/src/javascript/JContent/JContent.redux.js
+++ b/src/javascript/JContent/JContent.redux.js
@@ -57,8 +57,8 @@ export const buildUrl = ({site, language, mode, path, params}) => {
     return '/jcontent/' + [site, language, mode].join('/') + path + queryString;
 };
 
-export const {cmOpenPaths, cmClosePaths, cmPreSearchModeMemo, cmReplaceOpenedPaths} =
-    createActions('CM_OPEN_PATHS', 'CM_CLOSE_PATHS', 'CM_PRE_SEARCH_MODE_MEMO', 'CM_REPLACE_OPENED_PATHS');
+export const {cmOpenPaths, cmClosePaths, cmPreSearchModeMemo, cmReplaceOpenedPaths, cmOpenTablePaths, cmCloseTablePaths} =
+    createActions('CM_OPEN_PATHS', 'CM_CLOSE_PATHS', 'CM_PRE_SEARCH_MODE_MEMO', 'CM_REPLACE_OPENED_PATHS', 'CM_OPEN_TABLE_PATHS', 'CM_CLOSE_TABLE_PATHS');
 
 export const cmGoto = data => (
     (dispatch, getStore) => {
@@ -110,11 +110,17 @@ export const jContentRedux = registry => {
         [cmClosePaths]: (state, action) => _.difference(state, action.payload)
     }, _.dropRight(extractPaths(currentValueFromUrl.site, currentValueFromUrl.path, currentValueFromUrl.mode), 1));
 
+    const tableOpenPathsReducer = handleActions({
+        [cmOpenTablePaths]: (state, action) => _.union(state, action.payload),
+        [cmCloseTablePaths]: (state, action) => _.difference(state, action.payload)
+    }, []);
+
     registry.add('redux-reducer', 'mode', {targets: ['jcontent'], reducer: modeReducer});
     registry.add('redux-reducer', 'preSearchModeMemo', {targets: ['jcontent'], reducer: preSearchModeMemoReducer});
     registry.add('redux-reducer', 'path', {targets: ['jcontent'], reducer: pathReducer});
     registry.add('redux-reducer', 'params', {targets: ['jcontent'], reducer: paramsReducer});
     registry.add('redux-reducer', 'openPaths', {targets: ['jcontent'], reducer: openPathsReducer});
+    registry.add('redux-reducer', 'tableOpenPaths', {targets: ['jcontent'], reducer: tableOpenPathsReducer});
     registry.add('redux-reducer', 'jContentSite', {targets: ['site:2'], reducer: siteReducer});
     registry.add('redux-reducer', 'jContentLanguage', {targets: ['language:2'], reducer: languageReducer});
 

--- a/src/javascript/utils/NodeIcon.jsx
+++ b/src/javascript/utils/NodeIcon.jsx
@@ -144,7 +144,7 @@ export const NodeIcon = ({node, ...props}) => {
 NodeIcon.propTypes = {
     node: PropTypes.shape({
         path: PropTypes.string,
-        primaryNodeType: PropTypes.string
+        primaryNodeType: PropTypes.object
     }).isRequired
 };
 

--- a/tests/cypress/page-object/basicSearch.ts
+++ b/tests/cypress/page-object/basicSearch.ts
@@ -50,6 +50,7 @@ export class BasicSearch extends BasePage {
 
     executeSearch(): BasicSearch {
         getComponentByRole(Button, 'search-submit').click()
+        cy.get('.moonstone-loader').should('not.exist')
         return this
     }
 

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -2067,7 +2067,7 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.2.3, json-schema@^0.4.0:
+json-schema@0.4.0, json-schema@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
   integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
@@ -2309,7 +2309,7 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.5:
+minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,10 +1138,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@jahia/data-helper@^1.0.4":
-  version "1.0.4"
-  resolved "https://npm.jahia.com/@jahia%2fdata-helper/-/data-helper-1.0.4.tgz#1bfd8feb4ca1d61aadbfe00605d77ae7aeb82ef7"
-  integrity sha512-a1wp2ut0iYxpkJAPwnYONaqaP5Jv4gM6PRZOht8nJU7sBHot7lSb/AXehAyqOCUuX+DBrJoK6rXGGLL7AhHaHQ==
+"@jahia/data-helper@^1.0.5":
+  version "1.0.5"
+  resolved "https://npm.jahia.com/@jahia%2fdata-helper/-/data-helper-1.0.5.tgz#d788046594a2b3b7c38971c3c298ba2a349a0667"
+  integrity sha512-WCcQVgV9PEvb7Tbg6A9N804CI2mYWPdKFFSx45ez5Vaq+ESJIDUy9hNlyIltkk5gND3vWmZnJ4R+MVApq2aY+w==
   dependencies:
     apollo-cache "^1.3.4"
     apollo-client "^2.6.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,24 +10,6 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@apollo/client@latest":
-  version "3.6.9"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.9.tgz#ad0ee2e3a3c92dbed4acd6917b6158a492739d94"
-  integrity sha512-Y1yu8qa2YeaCUBVuw08x8NHenFi0sw2I3KCu7Kw9mDSu86HmmtHJkCAifKVrN2iPgDTW/BbP3EpSV8/EQCcxZA==
-  dependencies:
-    "@graphql-typed-document-node/core" "^3.1.1"
-    "@wry/context" "^0.6.0"
-    "@wry/equality" "^0.5.0"
-    "@wry/trie" "^0.3.0"
-    graphql-tag "^2.12.6"
-    hoist-non-react-statics "^3.3.2"
-    optimism "^0.16.1"
-    prop-types "^15.7.2"
-    symbol-observable "^4.0.0"
-    ts-invariant "^0.10.3"
-    tslib "^2.3.0"
-    zen-observable-ts "^1.2.5"
-
 "@apollo/react-common@^3.1.4":
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/@apollo/react-common/-/react-common-3.1.4.tgz#ec13c985be23ea8e799c9ea18e696eccc97be345"
@@ -67,13 +49,6 @@
     "@wry/equality" "^0.1.9"
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
-
-"@apollo/react-hooks@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@apollo/react-hooks/-/react-hooks-4.0.0.tgz#7bf7b320c90d276f637d9a84b503e17b840dd4e6"
-  integrity sha512-fCu0cbne3gbUl0QbA8X4L33iuuFVQbC5Jo2MIKRK8CyawR6PoxDpFdFA1kc6033ODZuZZ9Eo4RdeJFlFIIYcLA==
-  dependencies:
-    "@apollo/client" latest
 
 "@apollo/react-ssr@^3.1.5":
   version "3.1.5"
@@ -1149,11 +1124,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@graphql-typed-document-node/core@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
-  integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
-
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -2192,33 +2162,12 @@
     "@types/node" ">=6"
     tslib "^1.9.3"
 
-"@wry/context@^0.6.0":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.1.tgz#c3c29c0ad622adb00f6a53303c4f965ee06ebeb2"
-  integrity sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==
-  dependencies:
-    tslib "^2.3.0"
-
 "@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.11.tgz#35cb156e4a96695aa81a9ecc4d03787bc17f1790"
   integrity sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==
   dependencies:
     tslib "^1.9.3"
-
-"@wry/equality@^0.5.0":
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.3.tgz#fafebc69561aa2d40340da89fa7dc4b1f6fb7831"
-  integrity sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==
-  dependencies:
-    tslib "^2.3.0"
-
-"@wry/trie@^0.3.0":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.2.tgz#a06f235dc184bd26396ba456711f69f8c35097e6"
-  integrity sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==
-  dependencies:
-    tslib "^2.3.0"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -5007,7 +4956,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.5
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graphql-tag@^2.11.0, graphql-tag@^2.12.6:
+graphql-tag@^2.11.0:
   version "2.12.6"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
   integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
@@ -7272,14 +7221,6 @@ optimism@^0.10.0:
   dependencies:
     "@wry/context" "^0.4.0"
 
-optimism@^0.16.1:
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.16.1.tgz#7c8efc1f3179f18307b887e18c15c5b7133f6e7d"
-  integrity sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==
-  dependencies:
-    "@wry/context" "^0.6.0"
-    "@wry/trie" "^0.3.0"
-
 option@~0.2.1:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/option/-/option-0.2.4.tgz#fd475cdf98dcabb3cb397a3ba5284feb45edbfe4"
@@ -9336,11 +9277,6 @@ symbol-observable@1.2.0, symbol-observable@^1.0.2, symbol-observable@^1.0.4, sym
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
-symbol-observable@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
-  integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
-
 symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -9595,13 +9531,6 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
-ts-invariant@^0.10.3:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.10.3.tgz#3e048ff96e91459ffca01304dbc7f61c1f642f6c"
-  integrity sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==
-  dependencies:
-    tslib "^2.1.0"
-
 ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
@@ -9632,7 +9561,7 @@ tslib@^1, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.0, tslib@^2.3.1:
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
@@ -10302,14 +10231,7 @@ zen-observable-ts@^0.8.21:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
-zen-observable-ts@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz#6c6d9ea3d3a842812c6e9519209365a122ba8b58"
-  integrity sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==
-  dependencies:
-    zen-observable "0.8.15"
-
-zen-observable@0.8.15, zen-observable@^0.8.0:
+zen-observable@^0.8.0:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,24 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@apollo/client@latest":
+  version "3.6.9"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.9.tgz#ad0ee2e3a3c92dbed4acd6917b6158a492739d94"
+  integrity sha512-Y1yu8qa2YeaCUBVuw08x8NHenFi0sw2I3KCu7Kw9mDSu86HmmtHJkCAifKVrN2iPgDTW/BbP3EpSV8/EQCcxZA==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    "@wry/context" "^0.6.0"
+    "@wry/equality" "^0.5.0"
+    "@wry/trie" "^0.3.0"
+    graphql-tag "^2.12.6"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.16.1"
+    prop-types "^15.7.2"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.10.3"
+    tslib "^2.3.0"
+    zen-observable-ts "^1.2.5"
+
 "@apollo/react-common@^3.1.4":
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/@apollo/react-common/-/react-common-3.1.4.tgz#ec13c985be23ea8e799c9ea18e696eccc97be345"
@@ -49,6 +67,13 @@
     "@wry/equality" "^0.1.9"
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
+
+"@apollo/react-hooks@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@apollo/react-hooks/-/react-hooks-4.0.0.tgz#7bf7b320c90d276f637d9a84b503e17b840dd4e6"
+  integrity sha512-fCu0cbne3gbUl0QbA8X4L33iuuFVQbC5Jo2MIKRK8CyawR6PoxDpFdFA1kc6033ODZuZZ9Eo4RdeJFlFIIYcLA==
+  dependencies:
+    "@apollo/client" latest
 
 "@apollo/react-ssr@^3.1.5":
   version "3.1.5"
@@ -1124,6 +1149,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@graphql-typed-document-node/core@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
+  integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -2162,12 +2192,33 @@
     "@types/node" ">=6"
     tslib "^1.9.3"
 
+"@wry/context@^0.6.0":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.1.tgz#c3c29c0ad622adb00f6a53303c4f965ee06ebeb2"
+  integrity sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==
+  dependencies:
+    tslib "^2.3.0"
+
 "@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.11.tgz#35cb156e4a96695aa81a9ecc4d03787bc17f1790"
   integrity sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==
   dependencies:
     tslib "^1.9.3"
+
+"@wry/equality@^0.5.0":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.3.tgz#fafebc69561aa2d40340da89fa7dc4b1f6fb7831"
+  integrity sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/trie@^0.3.0":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.2.tgz#a06f235dc184bd26396ba456711f69f8c35097e6"
+  integrity sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==
+  dependencies:
+    tslib "^2.3.0"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -4956,7 +5007,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.5
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graphql-tag@^2.11.0:
+graphql-tag@^2.11.0, graphql-tag@^2.12.6:
   version "2.12.6"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
   integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
@@ -7221,6 +7272,14 @@ optimism@^0.10.0:
   dependencies:
     "@wry/context" "^0.4.0"
 
+optimism@^0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.16.1.tgz#7c8efc1f3179f18307b887e18c15c5b7133f6e7d"
+  integrity sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==
+  dependencies:
+    "@wry/context" "^0.6.0"
+    "@wry/trie" "^0.3.0"
+
 option@~0.2.1:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/option/-/option-0.2.4.tgz#fd475cdf98dcabb3cb397a3ba5284feb45edbfe4"
@@ -9277,6 +9336,11 @@ symbol-observable@1.2.0, symbol-observable@^1.0.2, symbol-observable@^1.0.4, sym
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
+symbol-observable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
+  integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
+
 symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -9531,6 +9595,13 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
+ts-invariant@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.10.3.tgz#3e048ff96e91459ffca01304dbc7f61c1f642f6c"
+  integrity sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==
+  dependencies:
+    tslib "^2.1.0"
+
 ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
@@ -9561,7 +9632,7 @@ tslib@^1, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.1:
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.0, tslib@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
@@ -10231,7 +10302,14 @@ zen-observable-ts@^0.8.21:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
-zen-observable@^0.8.0:
+zen-observable-ts@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz#6c6d9ea3d3a842812c6e9519209365a122ba8b58"
+  integrity sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==
+  dependencies:
+    zen-observable "0.8.15"
+
+zen-observable@0.8.15, zen-observable@^0.8.0:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19919

## Description

The main changes are in useLayoutQuery. It can now rely on useTreeEntries instead of useQuery if the handler returns getTreeParams(). A "conditional switch" is used inside the hook to go into one path or the other without bothering react (although we must ensure the component calling the hook never switch "mode").
A BaseTreeQueryHandler defines the basic functions to use the tree, it is used in PagesQueryHandler for structured view.
The useExpandedControlled plugin replaces useExpanded and allow to fully control expansion with an external state. Here the state comes from redux and is used in getTreeParams() to load the "expanded" levels.

- Ensure we don't modify nodes from inside apollo's cache, added some copy in strcutureData
- Removed layoutQuery / layoutQueryParams that were unused by refetcher
- Renamed useQueryParams to useQueryVariables for consistency/clarity
- Fixed the loading panel on top of the table (should be transparent)
- Fixed some invalid prop-types
