### PR TITLE
BACKLOG-17504: Adapt UploadTransformComponent and empty tables

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentEmptyDropZone.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentEmptyDropZone.jsx
@@ -6,7 +6,7 @@ import {Table, TableBody, TableBodyCell, TableRow} from '@jahia/moonstone';
 import ContentTableWrapper from './ContentTableWrapper';
 import styles from './ContentEmptyDropZone.scss';
 
-export const ContentEmptyDropZone = ({path, mode}) => (
+export const ContentEmptyDropZone = ({path, uploadType}) => (
     <ContentTableWrapper>
         <Table aria-labelledby="tableTitle" data-cm-role="table-content-list">
             <TableBody>
@@ -14,10 +14,10 @@ export const ContentEmptyDropZone = ({path, mode}) => (
                     uploadTargetComponent={TableRow}
                     uploadPath={path}
                     className={styles.dragZoneContentList}
-                    mode={mode}
+                    uploadType={uploadType}
                 >
                     <TableBodyCell className={styles.dragZone}>
-                        <EmptyDropZone component="div" mode={mode}/>
+                        <EmptyDropZone component="div" uploadType={uploadType}/>
                     </TableBodyCell>
                 </UploadTransformComponent>
             </TableBody>
@@ -26,7 +26,7 @@ export const ContentEmptyDropZone = ({path, mode}) => (
 );
 
 ContentEmptyDropZone.propTypes = {
-    mode: PropTypes.string.isRequired,
+    uploadType: PropTypes.string.isRequired,
     path: PropTypes.string.isRequired
 };
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
@@ -10,7 +10,7 @@ import {cmSetPreviewSelection} from '~/JContent/preview.redux';
 import {cmSetPage, cmSetPageSize} from '../pagination.redux';
 import {cmRemoveSelection} from '../contentSelection.redux';
 import JContentConstants from '~/JContent/JContent.constants';
-import ContentListEmptyDropZone from './ContentEmptyDropZone';
+import ContentEmptyDropZone from './ContentEmptyDropZone';
 import ContentNotFound from './ContentNotFound';
 import EmptyTable from './EmptyTable';
 import {Table, TableBody, TablePagination, TableRow} from '@jahia/moonstone';
@@ -128,7 +128,8 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
         return <ContentNotFound columnSpan={columnData.length} t={t}/>;
     }
 
-    const tableHeader = registry.get('accordionItem', mode)?.tableConfig?.tableHeader;
+    const tableConfig = registry.get('accordionItem', mode)?.tableConfig;
+    const tableHeader = tableConfig?.tableHeader;
 
     if (!rows?.length && !isLoading) {
         if ((mode === JContentConstants.mode.SEARCH || mode === JContentConstants.mode.SQL2SEARCH)) {
@@ -138,7 +139,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
         return (
             <>
                 {tableHeader}
-                <ContentListEmptyDropZone mode={mode} path={path}/>
+                <ContentEmptyDropZone uploadType={tableConfig?.uploadType} path={path}/>
             </>
         );
     }
@@ -148,7 +149,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
             {tableHeader}
             <UploadTransformComponent uploadTargetComponent={ContentTableWrapper}
                                       uploadPath={path}
-                                      mode={mode}
+                                      uploadType={tableConfig?.uploadType}
                                       reference={mainPanelRef}
                                       onKeyDown={handleKeyboardNavigation}
                                       onClick={setFocusOnMainContainer}

--- a/src/javascript/JContent/ContentRoute/ContentLayout/EmptyDropZone/EmptyDropZone.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/EmptyDropZone/EmptyDropZone.jsx
@@ -8,7 +8,7 @@ import {useNodeChecks} from '@jahia/data-helper';
 import {ACTION_PERMISSIONS} from '../../../actions/actions.constants';
 import styles from './EmptyDropZone.scss';
 
-const EmptyDropZone = ({component: Component, mode}) => {
+const EmptyDropZone = ({component: Component, uploadType}) => {
     const currentState = useSelector(state => ({site: state.site, language: state.language}), shallowEqual);
     const {t} = useTranslation('jcontent');
 
@@ -23,7 +23,7 @@ const EmptyDropZone = ({component: Component, mode}) => {
         return 'Loading...';
     }
 
-    if (mode === JContentConstants.mode.MEDIA && permissions.node.site.uploadFilesAction) {
+    if (uploadType === JContentConstants.mode.UPLOAD && permissions.node.site.uploadFilesAction) {
         return (
             <Component className={styles.dropZone}>
                 <Typography variant="heading" weight="light">{t('jcontent:label.contentManager.fileUpload.dropMessage')}</Typography>
@@ -32,7 +32,7 @@ const EmptyDropZone = ({component: Component, mode}) => {
         );
     }
 
-    if (mode === JContentConstants.mode.CONTENT_FOLDERS && permissions.node.site.importAction) {
+    if (uploadType === JContentConstants.mode.IMPORT && permissions.node.site.importAction) {
         return (
             <Component className={styles.dropZone}>
                 <Typography variant="heading" weight="light">{t('jcontent:label.contentManager.import.dropMessage')}</Typography>
@@ -50,7 +50,7 @@ const EmptyDropZone = ({component: Component, mode}) => {
 
 EmptyDropZone.propTypes = {
     component: PropTypes.string.isRequired,
-    mode: PropTypes.string.isRequired
+    uploadType: PropTypes.string.isRequired
 };
 
 export default EmptyDropZone;

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.jsx
@@ -65,7 +65,7 @@ export const FilesGrid = ({isContentNotFound, totalCount, rows, isLoading}) => {
     if ((!rows || rows.length === 0) && !isLoading) {
         return (
             <React.Fragment>
-                <FilesGridEmptyDropZone mode={JContentConstants.mode.MEDIA} path={path}/>
+                <FilesGridEmptyDropZone uploadType={JContentConstants.mode.UPLOAD} path={path}/>
             </React.Fragment>
         );
     }
@@ -81,7 +81,7 @@ export const FilesGrid = ({isContentNotFound, totalCount, rows, isLoading}) => {
             >
                 <UploadTransformComponent uploadTargetComponent={Paper}
                                           uploadPath={path}
-                                          mode="media"
+                                          uploadType={JContentConstants.mode.UPLOAD}
                                           className={classNames(styles.defaultGrid, styles.detailedGrid)}
                 >
                     {rows.map((node, index) => (

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.scss
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.scss
@@ -1,7 +1,6 @@
 .grid.grid {
-    display: block;
+    display: flex;
     flex: 1 1 0;
-    margin: 0 !important;
     padding: var(--spacing-small);
 
     outline: none;

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGridEmptyDropZone.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGridEmptyDropZone.jsx
@@ -5,18 +5,18 @@ import EmptyDropZone from '../EmptyDropZone';
 import UploadTransformComponent from '../UploadTransformComponent';
 import styles from './FilesGridEmptyDropZone.scss';
 
-export const FilesGridEmptyDropZone = ({path, mode}) => (
-    <UploadTransformComponent uploadTargetComponent={Grid} uploadPath={path} mode={mode} className={styles.root}>
+export const FilesGridEmptyDropZone = ({path, uploadType}) => (
+    <UploadTransformComponent uploadTargetComponent={Grid} uploadPath={path} uploadType={uploadType} className={styles.root}>
         <Grid container className={styles.gridEmpty} data-cm-role="grid-content-list">
             <div className={styles.dragZoneRoot}>
-                <EmptyDropZone component="div" mode={mode}/>
+                <EmptyDropZone component="div" uploadType={uploadType}/>
             </div>
         </Grid>
     </UploadTransformComponent>
 );
 
 FilesGridEmptyDropZone.propTypes = {
-    mode: PropTypes.string.isRequired,
+    uploadType: PropTypes.string.isRequired,
     path: PropTypes.string.isRequired
 };
 

--- a/src/javascript/JContent/JContent.accordion-items.jsx
+++ b/src/javascript/JContent/JContent.accordion-items.jsx
@@ -59,7 +59,8 @@ export const jContentAccordionItems = registry => {
         rootPath: '/sites/{site}',
         tableConfig: {
             queryHandler: ContentFoldersQueryHandler,
-            typeFilter: ['jnt:content']
+            typeFilter: ['jnt:content'],
+            uploadType: JContentConstants.mode.IMPORT
         }
     });
 
@@ -136,7 +137,8 @@ export const jContentAccordionItems = registry => {
         tableConfig: {
             queryHandler: ContentFoldersQueryHandler,
             typeFilter: ['jnt:content'],
-            viewSelector: <ViewModeSelector/>
+            viewSelector: <ViewModeSelector/>,
+            uploadType: JContentConstants.mode.IMPORT
         }
     });
 
@@ -156,7 +158,8 @@ export const jContentAccordionItems = registry => {
         tableConfig: {
             queryHandler: FilesQueryHandler,
             typeFilter: ['jnt:file', 'jnt:folder'],
-            viewSelector: <FileModeSelector/>
+            viewSelector: <FileModeSelector/>,
+            uploadType: JContentConstants.mode.UPLOAD
         }
     });
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-17504

## Description

Adapt UploadTransformComponent and EmptyDropZone to work with "uploadType" instead of "mode", so that we can use all modes from content-editor pickers. uploadType is only "upload" (for files) or "import" (for content)
Rewrite UploadTransformComponent as functional component.
