### PR TITLE
BACKLOG-20010: Improve card grid layout

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.scss
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.scss
@@ -17,6 +17,8 @@
     background: #fdfdfd;
     box-shadow: 0 4px 8px rgba(19, 28, 33, 0.2);
 
+    transition: all 0.2s ease-out;
+
     &:hover {
         box-shadow: 0 8px 20px rgba(19, 28, 33, 0.4);
 
@@ -27,7 +29,8 @@
 }
 
 .card.selected {
-    border: 4px solid var(--color-accent);
+    outline: 4px solid var(--color-accent);
+    outline-offset: -4px;
 }
 
 .cardPreviewAndIcon {

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.scss
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.scss
@@ -34,7 +34,7 @@
 
 .detailedGrid.detailedGrid {
     grid-auto-rows: 360px;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 350px));
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
 }
 
 .empty.empty {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20010

## Description
- Change the grid layout to display cards in all the available space
- Avoid a little "jump" with the card when we select a card in preview mode
- Add a small transition on the card