### PR TITLE
BACKLOG-20010: Improve cards and thumbnail layout

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.scss
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.scss
@@ -7,8 +7,6 @@
     flex-direction: column;
     align-items: flex-start;
 
-    min-width: 200px;
-    max-width: 340px;
     height: 350px;
     padding: 0;
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.scss
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.scss
@@ -1,11 +1,9 @@
 .grid.grid {
     display: flex;
     flex: 1 1 0;
-    padding: var(--spacing-small);
 
     outline: none;
-    overflow-y: auto;
-    overflow-x: hidden;
+    overflow: hidden;
 
     background-color: var(--color-gray_light);
 }
@@ -21,20 +19,16 @@
     display: grid;
     flex: 1;
     gap: var(--spacing-medium);
-    justify-content: start;
-    align-content: start;
-    align-items: start;
-    justify-items: stretch;
-
-    margin: var(--spacing-small);
 
     background-color: var(--color-gray_light);
     box-shadow: none;
 }
 
 .detailedGrid.detailedGrid {
-    grid-auto-rows: 360px;
     grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    padding: 0 var(--spacing-medium) var(--spacing-medium);
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
 .empty.empty {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20010

## Description

- Add padding-bottom in the grid to avoid having the last row of cards stuck in the pagination, to do that I changed the overflow management.
- Display the same vertical and horizontal gap in the grid