### PR TITLE
BACKLOG-19856: Allow to define a fieldFilter to filter children/descendants to be fetched. 

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileSize/FileSize.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileSize/FileSize.jsx
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 
 const FileSize = ({node}) => (
     <>
-        {node.descendant && node.descendant.data &&
-        bytes(node.descendant.data.size, {unitSeparator: ' '})}
+        {node.content && node.content.data &&
+        bytes(node.content.data.size, {unitSeparator: ' '})}
     </>
 );
 FileSize.propTypes = {

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileSize/FileSize.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileSize/FileSize.jsx
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 
 const FileSize = ({node}) => (
     <>
-        {node.children && node.children.nodes.length > 0 && node.children.nodes[0].data &&
-        bytes(node.children.nodes[0].data.size, {unitSeparator: ' '})}
+        {node.descendant && node.descendant.data &&
+        bytes(node.descendant.data.size, {unitSeparator: ' '})}
     </>
 );
 FileSize.propTypes = {

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileSize/FileSize.test.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileSize/FileSize.test.jsx
@@ -5,14 +5,10 @@ import {shallow} from '@jahia/test-framework';
 describe('FileSize', () => {
     it('should show the size', () => {
         const mockNode = {
-            children: {
-                nodes: [
-                    {
-                        data: {
-                            size: 100
-                        }
-                    }
-                ]
+            content: {
+                data: {
+                    size: 100
+                }
             }
         };
         const wrapper = shallow(<FileSize node={mockNode}/>);
@@ -22,9 +18,7 @@ describe('FileSize', () => {
 
     it('should render an empty text', () => {
         const emptyNode = {
-            children: {
-                nodes: []
-            }
+            content: {}
         };
         const wrapper = shallow(<FileSize node={emptyNode}/>);
         const text = wrapper.text();
@@ -40,14 +34,10 @@ describe('FileSize', () => {
 
     it('should show the unit', () => {
         const mockNode = {
-            children: {
-                nodes: [
-                    {
-                        data: {
-                            size: 36585
-                        }
-                    }
-                ]
+            content: {
+                data: {
+                    size: 36585
+                }
             }
         };
         const wrapper = shallow(<FileSize node={mockNode}/>);

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.gql-queries.js
@@ -99,11 +99,11 @@ export const QueryHandlersFragments = {
 };
 
 export const BaseChildrenQuery = gql`
-    query getNodeChildren($path:String!, $language:String!, $offset:Int, $limit:Int, $displayLanguage:String!, $typeFilter:[String]!, $fieldSorter: InputFieldSorterInput, $fieldGrouping: InputFieldGroupingInput) {
+    query getNodeChildren($path:String!, $language:String!, $offset:Int, $limit:Int, $displayLanguage:String!, $typeFilter:[String]!, $fieldSorter: InputFieldSorterInput, $fieldGrouping: InputFieldGroupingInput, $fieldFilter: InputFieldFiltersInput) {
         jcr {
             nodeByPath(path: $path) {
                 ...NodeFields
-                children(offset: $offset, limit: $limit, typesFilter: {types: $typeFilter, multi: ANY}, fieldSorter: $fieldSorter, fieldGrouping: $fieldGrouping) {
+                children(offset: $offset, limit: $limit, typesFilter: {types: $typeFilter, multi: ANY}, fieldSorter: $fieldSorter, fieldGrouping: $fieldGrouping, fieldFilter: $fieldFilter) {
                     pageInfo {
                         totalCount
                     }
@@ -121,11 +121,11 @@ export const BaseChildrenQuery = gql`
 `;
 
 export const BaseDescendantsQuery = gql`
-    query getNodeSubTree($path:String!, $language:String!, $offset:Int, $limit:Int, $displayLanguage:String!, $typeFilter:[String]!, $recursionTypesFilter: InputNodeTypesInput, $fieldSorter: InputFieldSorterInput, $fieldGrouping: InputFieldGroupingInput) {
+    query getNodeSubTree($path:String!, $language:String!, $offset:Int, $limit:Int, $displayLanguage:String!, $typeFilter:[String]!, $recursionTypesFilter: InputNodeTypesInput, $fieldSorter: InputFieldSorterInput, $fieldGrouping: InputFieldGroupingInput, $fieldFilter: InputFieldFiltersInput) {
         jcr {
             nodeByPath(path: $path) {
                 ...NodeFields
-                children: descendants(offset:$offset, limit:$limit, typesFilter: {types: $typeFilter, multi: ANY}, recursionTypesFilter: $recursionTypesFilter, fieldSorter: $fieldSorter, fieldGrouping: $fieldGrouping) {
+                children: descendants(offset:$offset, limit:$limit, typesFilter: {types: $typeFilter, multi: ANY}, recursionTypesFilter: $recursionTypesFilter, fieldSorter: $fieldSorter, fieldGrouping: $fieldGrouping, fieldFilter: $fieldFilter) {
                     pageInfo {
                         totalCount
                     }

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.js
@@ -53,7 +53,8 @@ export const BaseQueryHandler = {
                 fieldName: sort.orderBy === '' ? null : sort.orderBy,
                 ignoreCase: true
             },
-            recursionTypesFilter: {multi: 'NONE', types: ['nt:base']}
+            recursionTypesFilter: {multi: 'NONE', types: ['nt:base']},
+            fieldFilter: {multi: 'ANY', filters: [{evaluation: 'NOT_EMPTY', fieldName: 'uuid'}]}
         };
     },
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/FilesQueryHandler.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/FilesQueryHandler.gql-queries.js
@@ -13,15 +13,13 @@ export const imageFields = {
             title : property(name: "jcr:title", language: $language) {
                 value
             }
-            children(typesFilter: {types: ["jnt:resource"]}) {
-                nodes {
-                    ...NodeCacheRequiredFields
-                    data: property(name: "jcr:data") {
-                        size
-                    }
-                    mimeType: property(name: "jcr:mimeType") {
-                        value
-                    }
+            descendant(relPath: "jcr:content") {
+                ...NodeCacheRequiredFields
+                data: property(name: "jcr:data") {
+                    size
+                }
+                mimeType: property(name: "jcr:mimeType") {
+                    value
                 }
             }
         }

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/FilesQueryHandler.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/FilesQueryHandler.gql-queries.js
@@ -10,10 +10,10 @@ export const imageFields = {
             height: property(name: "j:height") {
                 value
             }
-            title : property(name: "jcr:title", language: $language) {
+            title: property(name: "jcr:title", language: $language) {
                 value
             }
-            descendant(relPath: "jcr:content") {
+            content: descendant(relPath: "jcr:content") {
                 ...NodeCacheRequiredFields
                 data: property(name: "jcr:data") {
                     size


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19856

## Description

Allow to define a fieldFilter to filter children/descendants to be fetched. Update ImageNodeFields fragment to use descendant as fieldFilter do not work with paginated objects

## Tests

The following are included in this PR
- [X] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
