### PR TITLE
BACKLOG-20034 Switch path to first path with the same siteKey

### DIFF
--- a/src/javascript/JContent/ContentTree/ContentTree.jsx
+++ b/src/javascript/JContent/ContentTree/ContentTree.jsx
@@ -36,9 +36,11 @@ export const ContentTree = ({setPathAction, openPathAction, closePathAction, ite
     let switchPath;
     // If path is root one but root is hidden, then select its first child
     if (((path === rootPath) || (path === rootPath + '/')) && item.treeConfig.hideRoot && treeEntries.length > 0) {
-        const first = treeEntries[0];
-        first.selected = true;
-        switchPath = first.path;
+        const first = treeEntries.find(entry => entry.path.startsWith(`/sites/${siteKey}`));
+        if (first) {
+            first.selected = true;
+            switchPath = first.path;
+        }
     }
 
     useEffect(() => {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20034

## Description

It could sometimes be the case that a path for the wrong site is selected (if it is in openPaths), which may lead to either a lot of iterations or even an infinite loop which freezes the browser. 