### PR TITLE
QA-14536: Fix error when publishing content

### DIFF
--- a/src/javascript/JContent/actions/downloadAsZip/DownloadAsZipActionComponent.jsx
+++ b/src/javascript/JContent/actions/downloadAsZip/DownloadAsZipActionComponent.jsx
@@ -27,8 +27,10 @@ export const DownloadAsZipActionComponent = ({path, paths, render: Render, loadi
 
     // This action is only available for Jahia 8.1.3.0 or higher.
     // Currently parent version is 8.0.2.0, please remove that check once the requirement higher than 8.1.3.0
-    const isVisible = compareVersions(window.contextJsParameters.dxVersion, '8.1.3.0') >= 0 && res.checksResult && (res.node ? !hasMixin(res.node, 'jmix:markedForDeletionRoot') : res.nodes.reduce((acc, node) => acc && !hasMixin(node, 'jmix:markedForDeletionRoot'), true));
-    const zipPath = `${res.node ? res.node.path : res.nodes[0].parent.path}.zip`;
+    const isNodeMarkedForDeletionFn = node => hasMixin(node, 'jmix:markedForDeletionRoot');
+    const isVisible = compareVersions(window.contextJsParameters.dxVersion, '8.1.3.0') >= 0 &&
+        res.checksResult &&
+        res.node ? !isNodeMarkedForDeletionFn(res.node) : !res.nodes.some(isNodeMarkedForDeletionFn);
     return (
         <Render
             {...others}
@@ -37,6 +39,7 @@ export const DownloadAsZipActionComponent = ({path, paths, render: Render, loadi
             onClick={() => {
                 let nodes = res.node ? [res.node] : res.nodes;
                 const filesToZip = `${btoa(JSON.stringify(nodes.map(node => node.path)))}`;
+                const zipPath = `${res.node ? res.node.path : res.nodes[0].parent.path}.zip`;
                 window.open(`${window.contextJsParameters.contextPath}/cms/export/default${zipPath}?filesToZip=${nodes.length === 1 ? '' : filesToZip}`);
             }}
         />

--- a/src/javascript/JContent/actions/downloadAsZip/DownloadAsZipActionComponent.jsx
+++ b/src/javascript/JContent/actions/downloadAsZip/DownloadAsZipActionComponent.jsx
@@ -30,7 +30,7 @@ export const DownloadAsZipActionComponent = ({path, paths, render: Render, loadi
     const isNodeMarkedForDeletionFn = node => hasMixin(node, 'jmix:markedForDeletionRoot');
     const isVisible = compareVersions(window.contextJsParameters.dxVersion, '8.1.3.0') >= 0 &&
         res.checksResult &&
-        res.node ? !isNodeMarkedForDeletionFn(res.node) : !res.nodes.some(isNodeMarkedForDeletionFn);
+        res.node ? !isNodeMarkedForDeletionFn(res.node) : !res.nodes?.some(isNodeMarkedForDeletionFn);
     return (
         <Render
             {...others}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14536

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Fix issue when state does not have any node/nodes selected e.g. during publishing, the line `res.nodes[0].parent.path` throws an error.

Move zipPath evaluation inside the `onClick` and not when initializing component