### PR TITLE
BACKLOG-16839: Display language switcher only for multi-language sites

### DIFF
--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.jsx
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.jsx
@@ -6,8 +6,9 @@ import {useSiteInfo} from '@jahia/data-helper';
 import {Dropdown} from '@jahia/moonstone';
 import styles from './LanguageSwitcher.scss';
 import {cmGoto} from '~/JContent/redux/JContent.redux';
+import {Separator} from '@jahia/moonstone';
 
-export const LanguageSwitcher = () => {
+const LanguageSwitcher = () => {
     const {siteKey, lang} = useSelector(state => ({
         siteKey: state.site,
         lang: state.language
@@ -40,18 +41,22 @@ export const LanguageSwitcher = () => {
     }
 
     const data = siteInfo.languages.filter(l => l.activeInEdit).map(l => ({label: l.language, value: l.language}));
-    return data && (data.length > 0) && (
-        <Dropdown
-            data-cm-role="language-switcher"
-            className={styles.languageSwitcher}
-            label={lang}
-            value={lang}
-            data={data}
-            onChange={(e, item) => {
-                onSelectLanguageHandler(item.value);
-                return true;
-            }}
-        />
+    return data && (data.length > 1) && (
+        <>
+            <Separator variant="vertical"/>
+            <Dropdown
+                data-cm-role="language-switcher"
+                className={styles.languageSwitcher}
+                label={lang}
+                value={lang}
+                data={data}
+                onChange={(e, item) => {
+                    onSelectLanguageHandler(item.value);
+                    return true;
+                }}
+            />
+        </>
+
     );
 };
 

--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.spec.jsx
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.spec.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import {shallow} from '@jahia/test-framework';
+import {useDispatch, useSelector} from 'react-redux';
+import LanguageSwitcher from './LanguageSwitcher';
+import {useSiteInfo} from '@jahia/data-helper';
+
+jest.mock('react-redux', () => ({
+    shallowEqual: jest.fn(),
+    useDispatch: jest.fn(),
+    useSelector: jest.fn()
+}));
+
+jest.mock('~/JContent/redux/JContent.redux', () => ({
+    cmGoto: jest.fn()
+}));
+
+jest.mock('@jahia/data-helper', () => ({
+    useSiteInfo: jest.fn()
+}));
+
+describe('Language switcher test', () => {
+    let siteInfo;
+
+    beforeEach(() => {
+        siteInfo = {
+            languages: [
+                {language: 'en', activeInEdit: true}
+            ]
+        };
+        useSelector.mockImplementation(() => ({
+            siteKey: 'test',
+            lang: 'en'
+        }));
+        useDispatch.mockImplementation(jest.fn());
+    });
+
+    it('should NOT show language switcher in left nav with one language', () => {
+        useSiteInfo.mockReturnValue({siteInfo});
+
+        const cmp = shallow(<LanguageSwitcher/>);
+        expect(cmp.find('Dropdown').exists()).toBeFalsy();
+    });
+
+    it('should show language switcher in left nav with more than one language', () => {
+        siteInfo.languages.push({language: 'fr-ca', activeInEdit: true});
+        useSiteInfo.mockReturnValue({siteInfo});
+
+        const cmp = shallow(<LanguageSwitcher/>);
+        expect(cmp.find('Dropdown').exists()).toBeTruthy();
+    });
+
+    it('should NOT show language switcher in left nav with only one ACTIVE language', () => {
+        siteInfo.languages.push({language: 'fr-ca', activeInEdit: false});
+        useSiteInfo.mockReturnValue({siteInfo});
+
+        const cmp = shallow(<LanguageSwitcher/>);
+        expect(cmp.find('Dropdown').exists()).toBeFalsy();
+    });
+});

--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SwitchersLayout.jsx
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SwitchersLayout.jsx
@@ -2,13 +2,11 @@ import React from 'react';
 import SiteSwitcher from './SiteSwitcher';
 import LanguageSwitcher from './LanguageSwitcher';
 import styles from './SwitchersLayout.scss';
-import {Separator} from '@jahia/moonstone';
 
 const SwitchersLayout = () => {
     return (
         <div className={styles.root}>
             <SiteSwitcher/>
-            <Separator variant="vertical"/>
             <LanguageSwitcher/>
         </div>
     );


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16839

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Show language dropdown in left nav only if more than one active language
- Added LanguageSwitcher unit test