### PR TITLE
BACKLOG-20417: Display language label in left nav if single language

### DIFF
--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.jsx
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.jsx
@@ -3,10 +3,9 @@ import {useTranslation} from 'react-i18next';
 import {shallowEqual, useDispatch, useSelector} from 'react-redux';
 import {useNotifications} from '@jahia/react-material';
 import {useSiteInfo} from '@jahia/data-helper';
-import {Dropdown} from '@jahia/moonstone';
+import {Dropdown, Typography} from '@jahia/moonstone';
 import styles from './LanguageSwitcher.scss';
 import {cmGoto} from '~/JContent/redux/JContent.redux';
-import {Separator} from '@jahia/moonstone';
 
 const LanguageSwitcher = () => {
     const {siteKey, lang} = useSelector(state => ({
@@ -41,23 +40,24 @@ const LanguageSwitcher = () => {
     }
 
     const data = siteInfo.languages.filter(l => l.activeInEdit).map(l => ({label: l.language, value: l.language}));
-    return data && (data.length > 1) && (
-        <>
-            <Separator variant="vertical"/>
-            <Dropdown
-                data-cm-role="language-switcher"
-                className={styles.languageSwitcher}
-                label={lang}
-                value={lang}
-                data={data}
-                onChange={(e, item) => {
-                    onSelectLanguageHandler(item.value);
-                    return true;
-                }}
-            />
-        </>
 
-    );
+    if (!data) {
+        return null;
+    }
+
+    return (data.length === 1) ?
+        <Typography isUpperCase className={styles.label} variant="caption">{lang}</Typography> :
+        <Dropdown
+            data-cm-role="language-switcher"
+            className={styles.languageSwitcher}
+            label={lang}
+            value={lang}
+            data={data}
+            onChange={(e, item) => {
+                onSelectLanguageHandler(item.value);
+                return true;
+            }}
+        />;
 };
 
 export default LanguageSwitcher;

--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.scss
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.scss
@@ -1,3 +1,7 @@
 .languageSwitcher {
     text-transform: uppercase;
 }
+
+.label {
+    padding: var(--spacing-small);
+}

--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.spec.jsx
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.spec.jsx
@@ -34,11 +34,12 @@ describe('Language switcher test', () => {
         useDispatch.mockImplementation(jest.fn());
     });
 
-    it('should NOT show language switcher in left nav with one language', () => {
+    it('should show language label, not dropdown, in left nav with one language', () => {
         useSiteInfo.mockReturnValue({siteInfo});
 
         const cmp = shallow(<LanguageSwitcher/>);
         expect(cmp.find('Dropdown').exists()).toBeFalsy();
+        expect(cmp.find('Typography').exists()).toBeTruthy();
     });
 
     it('should show language switcher in left nav with more than one language', () => {
@@ -47,13 +48,15 @@ describe('Language switcher test', () => {
 
         const cmp = shallow(<LanguageSwitcher/>);
         expect(cmp.find('Dropdown').exists()).toBeTruthy();
+        expect(cmp.find('Typography').exists()).toBeFalsy();
     });
 
-    it('should NOT show language switcher in left nav with only one ACTIVE language', () => {
+    it('should show language label, not dropdown, in left nav with only one ACTIVE language', () => {
         siteInfo.languages.push({language: 'fr-ca', activeInEdit: false});
         useSiteInfo.mockReturnValue({siteInfo});
 
         const cmp = shallow(<LanguageSwitcher/>);
         expect(cmp.find('Dropdown').exists()).toBeFalsy();
+        expect(cmp.find('Typography').exists()).toBeTruthy();
     });
 });

--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SwitchersLayout.jsx
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SwitchersLayout.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 import SiteSwitcher from './SiteSwitcher';
 import LanguageSwitcher from './LanguageSwitcher';
 import styles from './SwitchersLayout.scss';
+import {Separator} from '@jahia/moonstone';
 
 const SwitchersLayout = () => {
     return (
         <div className={styles.root}>
             <SiteSwitcher/>
+            <Separator variant="vertical"/>
             <LanguageSwitcher/>
         </div>
     );


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20417

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Switch language dropdown in left nav to a label instead for single language; updated tests