### PR TITLE
BACKLOG-20366: Fix react state issue in PublishAction

### DIFF
--- a/src/javascript/JContent/actions/publishAction.jsx
+++ b/src/javascript/JContent/actions/publishAction.jsx
@@ -56,7 +56,7 @@ const mergeChecks = (v1, v2) => {
 };
 
 function getButtonLabelParams(paths, language, res, t) {
-    if (!res.nodes || res.nodes.length === 0) {
+    if (!res.nodes || res.nodes.length === 0 || !paths?.length) {
         return {
             displayName: t('jcontent:label.contentManager.selection.items', {count: 0}),
             language

--- a/tests/cypress/e2e/multiselection.cy.ts
+++ b/tests/cypress/e2e/multiselection.cy.ts
@@ -1,0 +1,47 @@
+import {JContent} from '../page-object'
+import {Button, getComponentByRole, getComponentBySelector} from '@jahia/cypress';
+
+describe('Multi-selection tests', () => {
+
+    beforeEach(function () {
+        cy.login() // edit in chief
+    })
+
+    afterEach(function () {
+        cy.logout()
+    })
+
+    const checkToolbar = () => {
+        getComponentBySelector(Button,
+            '[role="toolbar"] [data-sel-role="publishAll"]',
+            null,
+            e => expect(e).to.be.visible);
+    }
+
+    const checkSelectionCount = count => {
+        cy.get('[data-cm-role="selection-infos"]')
+            .should('have.attr', 'data-cm-selection-size')
+            .and('equal', count.toString());
+    }
+
+    it('Can select/de-select items in list mode', () => {
+        const jcontent = JContent.visit('digitall', 'en', 'media/files')
+        jcontent.switchToListMode();
+
+        cy.log('selection: 1')
+        jcontent.getTable().selectRowByLabel('images');
+        checkSelectionCount(1);
+        checkToolbar();
+
+        cy.log('selection: 2')
+        jcontent.getTable().selectRowByLabel('video');
+        checkSelectionCount(2);
+        checkToolbar();
+
+        // unselect item
+        cy.log('unselecting item')
+        jcontent.getTable().selectRowByLabel('images', false);
+        checkSelectionCount(1);
+        checkToolbar();
+    })
+})

--- a/tests/cypress/page-object/contentTable.ts
+++ b/tests/cypress/page-object/contentTable.ts
@@ -1,0 +1,19 @@
+import {Table} from '@jahia/cypress';
+
+export class ContentTable extends Table {
+
+    getRowByLabel(label: string) {
+        return cy.contains('[data-cm-role="table-content-list-row"]', label)
+            .first()
+            .scrollIntoView()
+            .should('be.visible');
+    }
+
+    selectRowByLabel(label: string, isSelected: boolean = true) {
+        return this.getRowByLabel(label)
+            .find('[data-cm-role="table-content-list-cell-selection"] input')
+            .click()
+            .should('have.attr', 'aria-checked', Boolean(isSelected).toString());
+    }
+
+}

--- a/tests/cypress/page-object/jcontent.ts
+++ b/tests/cypress/page-object/jcontent.ts
@@ -12,6 +12,7 @@ import {
 import { BasicSearch } from './basicSearch'
 import { CreateContent } from './createContent'
 import { Media } from "./media";
+import {ContentTable} from "./contentTable";
 
 export class JContent extends BasePage {
     secondaryNav: SecondaryNav
@@ -52,8 +53,8 @@ export class JContent extends BasePage {
         return this.languageSwitcher
     }
 
-    getTable(): Table {
-        return getComponent(Table, null, (el) => expect(el).to.be.visible)
+    getTable(): ContentTable {
+        return getComponent(ContentTable, null, (el) => expect(el).to.be.visible)
     }
 
     getBasicSearch(): BasicSearch {
@@ -74,7 +75,7 @@ export class JContent extends BasePage {
     }
 
     switchToMode(name: string): JContent {
-        getComponentByRole(Dropdown, `sel-view-mode-dropdown`).select(name)
+        getComponentByRole(Dropdown, `sel-view-mode-dropdown`).select(name).get().should('contain', name);
         return this
     }
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20366

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Added extra check during redux state changes when nodes selected (in `res.nodes`) is not in sync with the `paths` (still has old data) to avoid undefined error. Display no count while in state transition.

Added cypress test for the scenario
