### PR TITLE
BACKLOG-20414: Improve dragndrop design

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
@@ -1,4 +1,5 @@
 import React, {useEffect, useMemo, useRef} from 'react';
+import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import {registry} from '@jahia/ui-extender';
 import {useTranslation} from 'react-i18next';
@@ -148,10 +149,9 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
     }
 
     return (
-        <>
+        <div ref={dropReference} className={clsx({'moonstone-drop_card': isCanDrop}, 'flexFluid', 'flexCol')}>
             {tableHeader}
             <ContentTableWrapper isCanDrop={isCanDrop}
-                                 dropReference={dropReference}
                                  reference={mainPanelRef}
                                  uploadType={tableConfig?.uploadType}
                                  onKeyDown={handleKeyboardNavigation}
@@ -196,7 +196,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
                              onPageChange={setCurrentPage}
                              onRowsPerPageChange={setPageSize}
             />}
-        </>
+        </div>
     );
 };
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTableWrapper.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTableWrapper.jsx
@@ -1,26 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import clsx from 'clsx';
 import css from './ContentTable.scss';
-import EmptyDropZone from '~/JContent/ContentRoute/ContentLayout/EmptyDropZone';
 
 const ContentTableWrapper = ({children, reference, dropReference, uploadType, onClick = () => {}, onKeyDown = () => {}, isCanDrop, ...rest}) => {
     return (
-        <>
-            <div ref={reference}
-                 className={css.tableWrapper}
-                 tabIndex="1"
-                 onClick={onClick}
-                 onKeyDown={onKeyDown}
-                 {...rest}
-            >
-                {children}
-            </div>
-            <div ref={dropReference} className="flexRow flexFluid">
-                {isCanDrop && (
-                    <EmptyDropZone component="div" isCanDrop={isCanDrop} uploadType={uploadType}/>
-                )}
-            </div>
-        </>
+        <div ref={reference}
+             className={clsx(css.tableWrapper, 'flexFluid')}
+             tabIndex="1"
+             onClick={onClick}
+             onKeyDown={onKeyDown}
+             {...rest}
+        >
+            {children}
+        </div>
     );
 };
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/EmptyDropZone/EmptyDropZone.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/EmptyDropZone/EmptyDropZone.jsx
@@ -26,8 +26,8 @@ const EmptyDropZone = ({component: Component, isCanDrop, uploadType}) => {
 
     if (uploadType === JContentConstants.mode.UPLOAD && permissions.node.site.uploadFilesAction) {
         return (
-            <Component className={clsx(styles.dropZone, isCanDrop && styles.dropZoneEnabled)}>
-                {!isCanDrop && <Typography variant="heading" weight="light">{t('jcontent:label.contentManager.fileUpload.dropMessage')}</Typography>}
+            <Component data-type="upload" className={clsx(styles.dropZone, isCanDrop && styles.dropZoneEnabled)}>
+                {!isCanDrop && <Typography variant="heading">{t('jcontent:label.contentManager.fileUpload.dropMessage')}</Typography>}
                 {isCanDrop && <Typography variant="heading">{t('jcontent:label.contentManager.fileUpload.drop')}</Typography>}
                 <Download/>
             </Component>
@@ -36,8 +36,8 @@ const EmptyDropZone = ({component: Component, isCanDrop, uploadType}) => {
 
     if (uploadType === JContentConstants.mode.IMPORT && permissions.node.site.importAction) {
         return (
-            <Component className={clsx(styles.dropZone, isCanDrop && styles.dropZoneEnabled)}>
-                {!isCanDrop && <Typography variant="heading" weight="light">{t('jcontent:label.contentManager.import.dropMessage')}</Typography>}
+            <Component data-type="import" className={clsx(styles.dropZone, isCanDrop && styles.dropZoneEnabled)}>
+                {!isCanDrop && <Typography variant="heading">{t('jcontent:label.contentManager.import.dropMessage')}</Typography>}
                 {isCanDrop && <Typography variant="heading">{t('jcontent:label.contentManager.import.drop')}</Typography>}
                 <Download/>
             </Component>
@@ -45,9 +45,9 @@ const EmptyDropZone = ({component: Component, isCanDrop, uploadType}) => {
     }
 
     return (
-        <Component className={styles.emptyZone}>
-            <Typography variant="heading" weight="light">{t('jcontent:label.contentManager.fileUpload.nothingToDisplay')}</Typography>
-            <Typography weight="light">{t('jcontent:label.contentManager.fileUpload.nothingToDisplay2')}</Typography>
+        <Component data-type="emptyZone" className={styles.emptyZone}>
+            <Typography variant="heading">{t('jcontent:label.contentManager.fileUpload.nothingToDisplay')}</Typography>
+            <Typography>{t('jcontent:label.contentManager.fileUpload.nothingToDisplay2')}</Typography>
         </Component>
     );
 };

--- a/src/javascript/JContent/PageComposerRoute/EditFrame/Box.scss
+++ b/src/javascript/JContent/PageComposerRoute/EditFrame/Box.scss
@@ -1,3 +1,6 @@
+$color-accent_light: rgba(99, 209, 255, 0.6);
+$color-accent: rgb(0, 160, 227);
+
 .root {
     position: absolute;
     z-index: 9999;
@@ -84,31 +87,27 @@
 }
 
 :global(.noprefix) .dropTarget {
-    border: 2px dashed gray;
+    outline: 4px solid $color-accent_light;
+    outline-offset: 4px;
 }
 
-:global(.noprefix) .dropTarget_insertBefore {
-    &::before {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        width: 100%;
-        height: 50px;
+:global(.noprefix) .dropTarget_insertBefore::before,
+:global(.noprefix) .dropTarget_insertAfter::after {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 50px;
 
-        border: 2px dashed gray;
-        content: var(--droplabel);
-    }
+    font-size: 16px;
+    color: $color-accent;
+
+    outline: 4px dashed $color-accent_light;
+    outline-offset: 4px;
+
+    content: var(--droplabel);
 }
 
-:global(.noprefix) .dropTarget_insertAfter {
-    &::after {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        width: 100%;
-        height: 50px;
-
-        border: 2px dashed gray;
-        content: var(--droplabel);
-    }
+:global .moonstone-tableHead {
+    background-color: transparent;
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20414

## Description
- Design the target element for drop/insertion in Page Composer. Use the same design as other drag-and-drop styles.
- Render the jContent table as a target for dropping instead of a `div`  below the table
- Use the same typography weight in the empty area for the default state and the "drop target" state

