### PR TITLE
BACKLOG-20497: Use react-dnd connectors, avoid intermediate ref

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useMemo, useRef} from 'react';
+import React, {useEffect, useMemo} from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import {registry} from '@jahia/ui-extender';
@@ -55,7 +55,6 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
     const setPageSize = pageSize => dispatch(cmSetPageSize(pageSize));
 
     const paths = useMemo(() => flattenTree(rows).map(n => n.path), [rows]);
-    const dropReference = useRef();
     const {
         mainPanelRef,
         handleKeyboardNavigation,
@@ -127,7 +126,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
 
     const tableConfig = registry.get('accordionItem', mode)?.tableConfig;
 
-    const {isCanDrop} = useFileDrop({uploadType: tableConfig?.uploadType, uploadPath: path, ref: dropReference});
+    const [{isCanDrop}, drop] = useFileDrop({uploadType: tableConfig?.uploadType, uploadPath: path});
 
     if (isContentNotFound) {
         return <ContentNotFound columnSpan={columnData.length} t={t}/>;
@@ -143,13 +142,13 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
         return (
             <>
                 {tableHeader}
-                <ContentEmptyDropZone reference={dropReference} uploadType={tableConfig?.uploadType} isCanDrop={isCanDrop}/>
+                <ContentEmptyDropZone reference={drop} uploadType={tableConfig?.uploadType} isCanDrop={isCanDrop}/>
             </>
         );
     }
 
     return (
-        <div ref={dropReference} className={clsx({'moonstone-drop_card': isCanDrop}, 'flexFluid', 'flexCol')}>
+        <div ref={drop} className={clsx({'moonstone-drop_card': isCanDrop}, 'flexFluid', 'flexCol')}>
             {tableHeader}
             <ContentTableWrapper isCanDrop={isCanDrop}
                                  reference={mainPanelRef}

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/Row.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/Row.jsx
@@ -28,9 +28,21 @@ export const Row = ({
     const contextualMenu = useRef();
 
     const ref = useRef(null);
-    const {isCanDrop} = useNodeDrop({dropTarget: node, ref: booleanValue(tableConfig.dnd?.canDrop) && ref});
-    const {isCanDrop: isCanDropFile} = useFileDrop({uploadType: node.primaryNodeType.name === 'jnt:folder' && JContentConstants.mode.UPLOAD, uploadPath: node.path, ref: booleanValue(tableConfig.dnd?.canDropFile) && ref});
-    const {dragging} = useNodeDrag({dragSource: node, ref: booleanValue(tableConfig.dnd?.canDrag) && ref});
+    const [{isCanDrop}, drop] = useNodeDrop({dropTarget: node});
+    const [{isCanDrop: isCanDropFile}, dropFile] = useFileDrop({uploadType: node.primaryNodeType.name === 'jnt:folder' && JContentConstants.mode.UPLOAD, uploadPath: node.path});
+    const [{dragging}, drag] = useNodeDrag({dragSource: node});
+
+    if (booleanValue(tableConfig.dnd?.canDrop)) {
+        drop(ref);
+    }
+
+    if (booleanValue(tableConfig.dnd?.canDropFile)) {
+        dropFile(ref);
+    }
+
+    if (booleanValue(tableConfig.dnd?.canDrag)) {
+        drag(ref);
+    }
 
     row.ref = ref;
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.jsx
@@ -33,9 +33,21 @@ export const FileCard = ({
     const {t} = useTranslation('jcontent');
     const ref = useRef(null);
 
-    const {isCanDrop} = useNodeDrop({dropTarget: node, ref: booleanValue(tableConfig.dnd?.canDrop) && ref});
-    const {isCanDrop: isCanDropFile} = useFileDrop({uploadType: node.primaryNodeType.name === 'jnt:folder' && JContentConstants.mode.UPLOAD, uploadPath: node.path, ref: booleanValue(tableConfig.dnd?.canDropFile) && ref});
-    const {dragging} = useNodeDrag({dragSource: node, ref: booleanValue(tableConfig.dnd?.canDrag) && ref});
+    const [{isCanDrop}, drop] = useNodeDrop({dropTarget: node});
+    const [{isCanDrop: isCanDropFile}, dropFile] = useFileDrop({uploadType: node.primaryNodeType.name === 'jnt:folder' && JContentConstants.mode.UPLOAD, uploadPath: node.path});
+    const [{dragging}, drag] = useNodeDrag({dragSource: node});
+
+    if (booleanValue(tableConfig.dnd?.canDrop)) {
+        drop(ref);
+    }
+
+    if (booleanValue(tableConfig.dnd?.canDropFile)) {
+        dropFile(ref);
+    }
+
+    if (booleanValue(tableConfig.dnd?.canDrag)) {
+        drag(ref);
+    }
 
     let contextualMenu = useRef();
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.jsx
@@ -55,7 +55,7 @@ export const FilesGrid = ({isContentNotFound, totalCount, rows, isLoading}) => {
 
     const tableConfig = registry.get('accordionItem', mode)?.tableConfig;
 
-    const {isCanDrop} = useFileDrop({uploadType: JContentConstants.mode.UPLOAD, uploadPath: path, ref: mainPanelRef});
+    const [{isCanDrop}, drop] = useFileDrop({uploadType: JContentConstants.mode.UPLOAD, uploadPath: path, ref: mainPanelRef});
 
     if ((!rows || rows.length === 0) && isLoading) {
         return null;
@@ -73,13 +73,13 @@ export const FilesGrid = ({isContentNotFound, totalCount, rows, isLoading}) => {
 
     if ((!rows || rows.length === 0) && !isLoading) {
         return (
-            <FilesGridEmptyDropZone uploadType={JContentConstants.mode.UPLOAD} reference={mainPanelRef} isCanDrop={isCanDrop}/>
+            <FilesGridEmptyDropZone uploadType={JContentConstants.mode.UPLOAD} reference={drop} isCanDrop={isCanDrop}/>
         );
     }
 
     return (
         <>
-            <div ref={mainPanelRef}
+            <div ref={drop}
                  className={clsx(styles.grid, isCanDrop && styles.drop)}
                  data-cm-role="grid-content-list"
                  tabIndex="1"

--- a/src/javascript/JContent/ContentRoute/ContentLayout/UploadTransformComponent/UploadTransformComponent.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/UploadTransformComponent/UploadTransformComponent.jsx
@@ -14,7 +14,8 @@ export const UploadTransformComponent = React.forwardRef(({
     ...props
 }, ref) => {
     const rootRef = useRef();
-    useFileDrop({uploadPath, uploadType, uploadMaxSize, uploadMinSize, uploadFilter, ref: rootRef});
+    const [, drop] = useFileDrop({uploadPath, uploadType, uploadMaxSize, uploadMinSize, uploadFilter});
+    drop(rootRef);
     return (
         <RootRef rootRef={rootRef}>
             <Component ref={ref} {...props}/>

--- a/src/javascript/JContent/ContentTree/ContentTree.jsx
+++ b/src/javascript/JContent/ContentTree/ContentTree.jsx
@@ -41,23 +41,29 @@ export const accordionPropType = PropTypes.shape({
 
 const ItemComponent = ({children, node, item, treeEntries, ...props}) => {
     const ref = useRef(null);
-    const {isCanDrop, insertPosition, destParent} = useNodeDrop({
+    const [{isCanDrop, insertPosition, destParent}, drop] = useNodeDrop({
         dropTarget: node,
-        ref: item.treeConfig.dnd && booleanValue(item.treeConfig.dnd?.canDrop) && ref,
         orderable: item.treeConfig.dnd && booleanValue(item.treeConfig.dnd?.canReorder),
         entries: treeEntries,
         refetchQueries: ['PickerQuery__DisplayName_IsTreeSelectable_LockInfo_MixinTypes_ParentNodeWithName_PickerPrimaryNodeTypeName_PublicationStatus']
     });
-    const {isCanDrop: isCanDropFile} = useFileDrop({
+    const [{isCanDrop: isCanDropFile}, dropFile] = useFileDrop({
         uploadType: node.primaryNodeType.name === 'jnt:folder' && JContentConstants.mode.UPLOAD,
-        uploadPath: node.path,
-        ref: item.treeConfig.dnd && booleanValue(item.treeConfig.dnd?.canDropFile) && ref
+        uploadPath: node.path
     });
+    const [{dragging}, drag] = useNodeDrag({dragSource: node});
 
-    const {dragging} = useNodeDrag({
-        dragSource: node,
-        ref: item.treeConfig.dnd && booleanValue(item.treeConfig.dnd?.canDrag) && ref
-    });
+    if (item.treeConfig.dnd && booleanValue(item.treeConfig.dnd?.canDrop)) {
+        drop(ref);
+    }
+
+    if (item.treeConfig.dnd && booleanValue(item.treeConfig.dnd?.canDropFile)) {
+        dropFile(ref);
+    }
+
+    if (item.treeConfig.dnd && booleanValue(item.treeConfig.dnd?.canDrag)) {
+        drag(ref);
+    }
 
     const depth = (isCanDrop || isCanDropFile) ? treeEntries.find(e => e.node.path === destParent.path)?.depth : -1;
 

--- a/src/javascript/JContent/PageComposerRoute/EditFrame/Box.jsx
+++ b/src/javascript/JContent/PageComposerRoute/EditFrame/Box.jsx
@@ -78,7 +78,6 @@ export const Box = ({
     });
 
     const rootDiv = useRef();
-    const div = useRef();
 
     const left = Math.max(0, (rect.left + scrollLeft - 4));
     const width = Math.min(document.documentElement.clientWidth - left, rect.width + 8);
@@ -97,8 +96,9 @@ export const Box = ({
     const customBarItem = node && registry.get('customContentEditorBar', node.primaryNodeType.name);
     const Bar = (customBarItem && customBarItem.component) || DefaultBar;
 
-    const {dragging} = useNodeDrag({dragSource: node, ref: div});
-    const {isCanDrop, insertPosition, destParent} = useNodeDrop({dropTarget: parent && node, ref, orderable: true, entries, onSaved});
+    const [{dragging}, drag] = useNodeDrag({dragSource: node});
+    const [{isCanDrop, insertPosition, destParent}, drop] = useNodeDrop({dropTarget: parent && node, orderable: true, entries, onSaved});
+    drop(ref);
 
     useEffect(() => {
         const currentRootElement = rootElementRef.current;
@@ -145,7 +145,7 @@ export const Box = ({
                  style={currentOffset}
             >
                 <div className={styles.rel} style={{height: 24 + rect.height}}>
-                    <div ref={div}
+                    <div ref={drag}
                          className={clsx(styles.sticky, editStyles.enablePointerEvents)}
                          data-jahia-parent={element.getAttribute('id')}
                          onClick={onSelect}

--- a/src/javascript/JContent/PageComposerRoute/EditFrame/Create.jsx
+++ b/src/javascript/JContent/PageComposerRoute/EditFrame/Create.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect} from 'react';
 
 import styles from './Create.scss';
 import PropTypes from 'prop-types';
@@ -37,8 +37,7 @@ export const Create = ({element, onMouseOver, onMouseOut, onSaved}) => {
         getPrimaryNodeType: true
     });
 
-    const ref = useRef();
-    const {isCanDrop} = useNodeDrop({dropTarget: parent && node, ref, onSaved});
+    const [{isCanDrop}, drop] = useNodeDrop({dropTarget: parent && node, onSaved});
 
     const {anyDragging} = useDragLayer(monitor => ({
         anyDragging: monitor.isDragging()
@@ -65,7 +64,7 @@ export const Create = ({element, onMouseOver, onMouseOut, onSaved}) => {
     }, [isCanDrop, element]);
 
     return !anyDragging && (
-        <div ref={ref}
+        <div ref={drop}
              className={clsx(styles.root, editStyles.enablePointerEvents)}
              style={currentOffset}
              data-jahia-parent={parent.getAttribute('id')}

--- a/src/javascript/JContent/dnd/index.js
+++ b/src/javascript/JContent/dnd/index.js
@@ -2,3 +2,4 @@ export * from './DragLayer';
 export * from './useFileDrop';
 export * from './useNodeDrop';
 export * from './useNodeDrag';
+export {useConnector} from '~/JContent/dnd/useConnector';

--- a/src/javascript/JContent/dnd/useConnector.jsx
+++ b/src/javascript/JContent/dnd/useConnector.jsx
@@ -1,0 +1,27 @@
+import {useRef} from 'react';
+
+const isRef = obj => (
+    obj !== null &&
+    typeof obj === 'object' &&
+    Object.prototype.hasOwnProperty.call(obj, 'current')
+);
+
+export const useConnector = () => {
+    const current = {
+        node: null,
+        ref: useRef()
+    };
+
+    const getCurrent = () => current.node || (current.ref && current.ref.current);
+    const setCurrent = elem => {
+        if (isRef(elem)) {
+            current.ref = elem;
+        } else {
+            current.node = elem;
+        }
+    };
+
+    return {
+        getCurrent, setCurrent
+    };
+};

--- a/src/javascript/JContent/dnd/useFileDrop.jsx
+++ b/src/javascript/JContent/dnd/useFileDrop.jsx
@@ -77,7 +77,7 @@ async function scan({fileList, uploadMaxSize, uploadMinSize, uploadFilter, uploa
     return {files, directories};
 }
 
-export function useFileDrop({uploadPath, uploadType, uploadMaxSize = Infinity, uploadMinSize = 0, uploadFilter = () => true, ref}) {
+export function useFileDrop({uploadPath, uploadType, uploadMaxSize = Infinity, uploadMinSize = 0, uploadFilter = () => true}) {
     const {data, loading, error} = useQuery(UploadRequirementsQuery, {
         variables: {
             path: uploadPath,
@@ -93,7 +93,7 @@ export function useFileDrop({uploadPath, uploadType, uploadMaxSize = Infinity, u
     const client = useApolloClient();
     const dispatch = useDispatch();
 
-    const [props, drop] = useDrop(() => ({
+    return useDrop(() => ({
         accept: [NativeTypes.FILE],
         drop: (item, monitor) => {
             if (monitor.didDrop()) {
@@ -138,11 +138,5 @@ export function useFileDrop({uploadPath, uploadType, uploadMaxSize = Infinity, u
             isOver: monitor.isOver({shallow: true}),
             isCanDrop: (monitor.canDrop() && monitor.isOver({shallow: true}))
         })
-    }), [allowDrop]);
-
-    if (ref) {
-        drop(ref);
-    }
-
-    return props;
+    }), [client, dispatch, uploadFilter, uploadPath, uploadType, uploadMaxSize, uploadMinSize, allowDrop]);
 }

--- a/src/javascript/JContent/dnd/useNodeDrag.jsx
+++ b/src/javascript/JContent/dnd/useNodeDrag.jsx
@@ -6,7 +6,7 @@ import {shallowEqual, useSelector} from 'react-redux';
 import {useNodeChecks} from '@jahia/data-helper';
 import {PATH_CONTENTS_ITSELF, PATH_FILES_ITSELF} from '~/JContent/actions/actions.constants';
 
-export function useNodeDrag({dragSource, ref}) {
+export function useNodeDrag({dragSource}) {
     const {selection, language, displayLanguage} = useSelector(state => ({
         selection: state.jcontent.selection,
         language: state.language,
@@ -49,9 +49,5 @@ export function useNodeDrag({dragSource, ref}) {
         dragClasses: styles.drag
     } : props;
 
-    if (ref) {
-        drag(ref);
-    }
-
-    return enhancedProps;
+    return [enhancedProps, drag];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5045,15 +5045,10 @@ graphql-tag@^2.11.0:
   dependencies:
     tslib "^2.1.0"
 
-graphql@15.4.0:
+graphql@15.4.0, graphql@^15.4.0:
   version "15.4.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.4.0.tgz#e459dea1150da5a106486ba7276518b5295a4347"
   integrity sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==
-
-graphql@^15.4.0:
-  version "15.8.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
-  integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20497

## Description

Instead of directly wiring to a ref into the hooks, return the connector as in react-dnd hooks. Directly use the connectors on target to avoid intermediate dangling refs, which may keep a value and not reconnect even if the target has changed.

In useNodeDrop, since we need to have the ref to get bounding rects, I recreated a connector-like object which can take a ref or a direct value, as in react-dnd (code based on TargetConnector.ts).
