### PR TITLE
QA-14687: Exclude users and groups folder when traversing page tree

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
@@ -33,7 +33,9 @@ export const PagesQueryHandler = {
             queryVariables.typeFilter = ['jnt:content', 'jnt:contentFolder'];
         } else {
             queryVariables.typeFilter = JContentConstants.tableView.viewType.PAGES === tableView.viewType ? ['jnt:page'] : [JContentConstants.contentType];
-            queryVariables.recursionTypesFilter = {multi: 'NONE', types: ['jnt:page', 'jnt:contentFolder', 'jnt:folder']};
+            queryVariables.recursionTypesFilter = {
+                multi: 'NONE',
+                types: ['jnt:page', 'jnt:contentFolder', 'jnt:folder', 'jnt:usersFolder', 'jnt:groupsFolder']};
         }
 
         return queryVariables;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14687

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Related PR: https://github.com/Jahia/content-editor/pull/1525

Improve loading times by excluding users and groups folders when loading pages accordion.

This does seem to have performance impact only on the first time loading jcontent pages accordion, as root path immediately switches from `sites/{site}` to `sites/{site}/home`

