### PR TITLE
BACKLOG-20526: Fixes in delete overlays and boxes

### DIFF
--- a/src/javascript/JContent/PageComposerRoute/EditFrame/Box.jsx
+++ b/src/javascript/JContent/PageComposerRoute/EditFrame/Box.jsx
@@ -8,10 +8,9 @@ import {useNodeDrag} from '~/JContent/dnd/useNodeDrag';
 import editStyles from './EditFrame.scss';
 import {useNodeDrop} from '~/JContent/dnd/useNodeDrop';
 import {DefaultBar} from '~/JContent/PageComposerRoute/EditFrame/DefaultBar';
-import {useQuery} from '@apollo/react-hooks';
-import {BoxQuery} from '~/JContent/PageComposerRoute/EditFrame/Box.gql-queries';
 
 export const Box = React.memo(({
+    node,
     isVisible,
     element,
     entries,
@@ -27,13 +26,16 @@ export const Box = React.memo(({
     const rect = element.getBoundingClientRect();
     const scrollLeft = element.ownerDocument.documentElement.scrollLeft;
     const scrollTop = element.ownerDocument.documentElement.scrollTop;
-    const path = element.getAttribute('path');
 
-    const {data} = useQuery(BoxQuery, {
-        variables: {path, language, displayLanguage}
-    });
+    useEffect(() => {
+        element.addEventListener('mouseover', onMouseOver);
+        element.addEventListener('mouseout', onMouseOut);
 
-    const node = data?.jcr?.nodeByPath;
+        return () => {
+            element.removeEventListener('mouseover', onMouseOver);
+            element.removeEventListener('mouseout', onMouseOut);
+        };
+    }, [element, node, onMouseOut, onMouseOver]);
 
     element.dataset.current = isVisible;
 
@@ -145,6 +147,8 @@ Box.propTypes = {
     isVisible: PropTypes.bool,
 
     element: PropTypes.any,
+
+    node: PropTypes.any,
 
     entries: PropTypes.array,
 

--- a/src/javascript/JContent/PageComposerRoute/EditFrame/Box.scss
+++ b/src/javascript/JContent/PageComposerRoute/EditFrame/Box.scss
@@ -29,9 +29,6 @@ $color-accent: rgb(0, 160, 227);
     top: 0;
     left: 0;
 
-    display: flex;
-
-    gap: var(--spacing-small);
     width: 100%;
     height: 32px;
 
@@ -43,6 +40,7 @@ $color-accent: rgb(0, 160, 227);
 }
 
 .header {
+    gap: var(--spacing-small);
     align-self: stretch;
     width: 100%;
 

--- a/src/javascript/JContent/PageComposerRoute/EditFrame/Boxes.gql-queries.js
+++ b/src/javascript/JContent/PageComposerRoute/EditFrame/Boxes.gql-queries.js
@@ -1,10 +1,10 @@
 import gql from 'graphql-tag';
 import {QueryHandlersFragments} from '~/JContent/ContentRoute/ContentLayout/queryHandlers';
 
-export const BoxQuery = gql`
-    query getNode($path:String!, $language:String!, $displayLanguage:String!) {
+export const BoxesQuery = gql`
+    query getNodes($paths:[String!]!, $language:String!, $displayLanguage:String!) {
         jcr {
-            nodeByPath(path: $path) {
+            nodesByPath(paths: $paths) {
                 ...NodeFields
             }
         }

--- a/src/javascript/JContent/PageComposerRoute/EditFrame/Create.jsx
+++ b/src/javascript/JContent/PageComposerRoute/EditFrame/Create.jsx
@@ -6,12 +6,11 @@ import {DisplayAction} from '@jahia/ui-extender';
 import {getButtonRenderer} from '~/utils/getButtonRenderer';
 import clsx from 'clsx';
 import {useNodeDrop} from '~/JContent/dnd/useNodeDrop';
-import {useNodeInfo} from '@jahia/data-helper';
 import editStyles from './EditFrame.scss';
 import {useDragLayer} from 'react-dnd';
 import {useSelector} from 'react-redux';
 
-export const Create = React.memo(({element, onMouseOver, onMouseOut, onSaved}) => {
+export const Create = React.memo(({element, node, onMouseOver, onMouseOut, onSaved}) => {
     const rect = element.getBoundingClientRect();
     const scrollLeft = element.ownerDocument.documentElement.scrollLeft;
     const scrollTop = element.ownerDocument.documentElement.scrollTop;
@@ -19,24 +18,12 @@ export const Create = React.memo(({element, onMouseOver, onMouseOut, onSaved}) =
     const ButtonRenderer = getButtonRenderer({defaultButtonProps: {color: 'default'}});
 
     let parent = element.dataset.jahiaParent && element.ownerDocument.getElementById(element.dataset.jahiaParent);
-    if (!parent) {
-        parent = element.parentElement;
-        while (parent.getAttribute('jahiatype') !== 'module') {
-            parent = parent.parentElement;
-        }
-
-        element.dataset.jahiaParent = parent.id;
-    }
 
     useEffect(() => {
         element.style.height = '28px';
     });
 
     const parentPath = parent.getAttribute('path');
-
-    const {node} = useNodeInfo({path: parentPath}, {
-        getPrimaryNodeType: true
-    });
 
     const [{isCanDrop}, drop] = useNodeDrop({dropTarget: parent && node, onSaved});
 
@@ -85,6 +72,7 @@ export const Create = React.memo(({element, onMouseOver, onMouseOut, onSaved}) =
 
 Create.propTypes = {
     element: PropTypes.any,
+    node: PropTypes.any,
     onMouseOver: PropTypes.func,
     onMouseOut: PropTypes.func,
     onSaved: PropTypes.func

--- a/src/javascript/JContent/PageComposerRoute/EditFrame/Deleted.jsx
+++ b/src/javascript/JContent/PageComposerRoute/EditFrame/Deleted.jsx
@@ -1,22 +1,43 @@
-import React, {useRef} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import styles from './Deleted.scss';
 import {Delete, Typography} from '@jahia/moonstone';
+import {useTranslation} from 'react-i18next';
 
 export const Deleted = ({element}) => {
+    const {t} = useTranslation('jcontent');
     const rect = element.getBoundingClientRect();
     const scrollLeft = element.ownerDocument.documentElement.scrollLeft;
     const scrollTop = element.ownerDocument.documentElement.scrollTop;
-
-    const ref = useRef();
-
-    const currentOffset = {
+    const [currentOffset, setCurrentOffset] = useState({
         top: rect.top + scrollTop,
         left: rect.left + scrollLeft,
         width: rect.width,
         height: rect.height
-    };
+    });
+
+    const ref = useRef();
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            const rect = element.getBoundingClientRect();
+            const scrollLeft = element.ownerDocument.documentElement.scrollLeft;
+            const scrollTop = element.ownerDocument.documentElement.scrollTop;
+            const box = {
+                top: rect.top + scrollTop,
+                left: rect.left + scrollLeft,
+                width: rect.width,
+                height: rect.height
+            };
+            if (box.top !== currentOffset.top || box.left !== currentOffset.left || box.width !== currentOffset.width || box.height !== currentOffset.height) {
+                setCurrentOffset(box);
+            }
+        }, 100);
+        return () => {
+            clearInterval(interval);
+        };
+    });
 
     const iconWidth = Math.min(currentOffset.width / 3, 64) + 'px';
     const iconHeight = Math.min(currentOffset.height / 3, 64) + 'px';
@@ -31,7 +52,7 @@ export const Deleted = ({element}) => {
             >
                 <div className={styles.label}>
                     <Delete size="big" style={{width: iconWidth, height: iconHeight}}/>
-                    {showLabel && <Typography variant="subheading" weight="bold">DELETED</Typography>}
+                    {showLabel && <Typography variant="subheading" weight="bold">{t('label.contentManager.contentStatus.deleted')}</Typography>}
                 </div>
             </div>
         </>

--- a/src/javascript/JContent/PageComposerRoute/EditFrame/Deleted.jsx
+++ b/src/javascript/JContent/PageComposerRoute/EditFrame/Deleted.jsx
@@ -5,31 +5,28 @@ import styles from './Deleted.scss';
 import {Delete, Typography} from '@jahia/moonstone';
 import {useTranslation} from 'react-i18next';
 
-export const Deleted = ({element}) => {
-    const {t} = useTranslation('jcontent');
+function getBoundingBox(element) {
     const rect = element.getBoundingClientRect();
     const scrollLeft = element.ownerDocument.documentElement.scrollLeft;
     const scrollTop = element.ownerDocument.documentElement.scrollTop;
-    const [currentOffset, setCurrentOffset] = useState({
+    const box = {
         top: rect.top + scrollTop,
         left: rect.left + scrollLeft,
         width: rect.width,
         height: rect.height
-    });
+    };
+    return box;
+}
+
+export const Deleted = ({element}) => {
+    const {t} = useTranslation('jcontent');
+    const [currentOffset, setCurrentOffset] = useState(getBoundingBox(element));
 
     const ref = useRef();
 
     useEffect(() => {
         const interval = setInterval(() => {
-            const rect = element.getBoundingClientRect();
-            const scrollLeft = element.ownerDocument.documentElement.scrollLeft;
-            const scrollTop = element.ownerDocument.documentElement.scrollTop;
-            const box = {
-                top: rect.top + scrollTop,
-                left: rect.left + scrollLeft,
-                width: rect.width,
-                height: rect.height
-            };
+            const box = getBoundingBox(element);
             if (box.top !== currentOffset.top || box.left !== currentOffset.left || box.width !== currentOffset.width || box.height !== currentOffset.height) {
                 setCurrentOffset(box);
             }
@@ -37,7 +34,7 @@ export const Deleted = ({element}) => {
         return () => {
             clearInterval(interval);
         };
-    });
+    }, [currentOffset, element]);
 
     const iconWidth = Math.min(currentOffset.width / 3, 64) + 'px';
     const iconHeight = Math.min(currentOffset.height / 3, 64) + 'px';

--- a/src/javascript/JContent/PageComposerRoute/EditFrame/Deleted.scss
+++ b/src/javascript/JContent/PageComposerRoute/EditFrame/Deleted.scss
@@ -22,6 +22,8 @@
 
     color: var(--color-light);
 
+    text-transform: uppercase;
+
     & p {
         color: var(--color-light);
     }

--- a/src/javascript/JContent/PageComposerRoute/EditFrame/Infos.jsx
+++ b/src/javascript/JContent/PageComposerRoute/EditFrame/Infos.jsx
@@ -3,7 +3,7 @@ import {useSelector} from 'react-redux';
 import {useNodeInfo} from '@jahia/data-helper';
 import {Deleted} from './Deleted';
 import PropTypes from 'prop-types';
-import {isMarkedForDeletion} from '~/JContent/JContent.utils';
+import {hasMixin} from '~/JContent/JContent.utils';
 
 export const Infos = ({currentDocument}) => {
     const language = useSelector(state => state.language);
@@ -12,6 +12,7 @@ export const Infos = ({currentDocument}) => {
 
     useEffect(() => {
         const paths = [];
+        paths.push(currentDocument.querySelector('[jahiatype=mainmodule]').getAttribute('path'));
         currentDocument.querySelectorAll('[jahiatype=module]').forEach(elem => {
             if (elem.getAttribute('path') !== '*') {
                 paths.push(elem.getAttribute('path'));
@@ -29,7 +30,7 @@ export const Infos = ({currentDocument}) => {
     });
 
     return Boolean(nodes) && nodes
-        .filter(n => isMarkedForDeletion(n))
+        .filter(n => hasMixin(n, 'jmix:markedForDeletionRoot'))
         .map(n => currentDocument.querySelector(`[jahiatype][path="${n.path}"]`))
         .filter(e => e)
         .map(e => (

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -357,6 +357,7 @@
       "contentStatus": {
         "locked": "Gesperrt",
         "markedForDeletion": "Zur Löschung markiert",
+        "deleted": "Gelöscht",
         "modified": "Geändert",
         "new": "Neu",
         "notPublished": "Nicht veröffentlicht",

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -364,6 +364,7 @@
       "contentStatus": {
         "locked": "Locked",
         "markedForDeletion": "Marked for deletion",
+        "deleted": "Deleted",
         "modified": "Modified",
         "new": "New",
         "notPublished": "Not published",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -357,6 +357,7 @@
       "contentStatus": {
         "locked": "Verrouillé",
         "markedForDeletion": "Marqué pour suppression",
+        "deleted": "Supprimé",
         "modified": "Modifié",
         "new": "Nouveau",
         "notPublished": "Non publié",


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20526

## Description

Load all nodes in Boxes instead of Box/Create components, in order to get deleted status prior to display sub components.
Removed mouse events and overlay on sub deleted contents.
Remove Create buttons when parent is deleted
Add overlay on page
Follow components in deleted overlay
Translate labels