### PR TITLE
BACKLOG-16607: Auto-add search input on dropdowns; sort systemsite to end of sites list

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@jahia/design-system-kit": "^1.1.2",
     "@jahia/icons": "^1.1.1",
     "@jahia/jahia-reporter": "^1.0.3",
-    "@jahia/moonstone": "^2.5.1",
+    "@jahia/moonstone": "^2.5.2",
     "@jahia/react-material": "^3.0.5",
     "@jahia/ui-extender": "^1.0.0",
     "@material-ui/core": "^3.6.2",

--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/NavigationHeader.scss
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/NavigationHeader.scss
@@ -7,4 +7,10 @@
     flex-direction: column;
     align-items: center;
     width: 100%;
+
+    [role="listbox"] input,
+    [role="listbox"] svg {
+        /* Reset .moonstone-reversed color scheme on dropdown search input */
+        color: initial;
+    }
 }

--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SiteSwitcher.jsx
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SiteSwitcher.jsx
@@ -39,16 +39,9 @@ const QUERY = gql`
         `;
 
 const getSites = data => {
-    let siteNodes = [];
-    if (data && data.jcr.result !== null) {
-        for (let i in data.jcr.result.siteNodes) {
-            if (data.jcr.result.siteNodes[i].hasPermission) {
-                siteNodes.push(data.jcr.result.siteNodes[i]);
-            }
-        }
-    }
-
-    return _.sortBy(siteNodes, ['displayName']);
+    let siteNodes = data?.jcr.result?.siteNodes?.filter(s => s.hasPermission) || [];
+    // Sort system site to the end of list (by returning null)
+    return _.sortBy(siteNodes, s => (s.name === 'systemsite') ? null : s.displayName);
 };
 
 const getTargetSiteLanguageForSwitch = (siteNode, currentLang) => {
@@ -101,11 +94,8 @@ const SiteSwitcher = ({selector, onSelectAction}) => {
 
                     const sites = getSites(data);
 
-                    // Lookup current site, get First site in case not found. Avoid the component to break if not site found at all.
-                    let currentSite = sites.find(site => site.name === siteKey);
-                    if (!currentSite) {
-                        currentSite = sites.length > 0 ? sites[0] : {};
-                    }
+                    // Lookup current site, get first site in case not found. Avoid the component to break if not site found at all.
+                    let currentSite = sites.find(site => site.name === siteKey) || sites?.[0] || {};
 
                     return (
                         <Dropdown

--- a/yarn.lock
+++ b/yarn.lock
@@ -1236,10 +1236,10 @@
     uuid "^8.3.1"
     xml-js "^1.6.11"
 
-"@jahia/moonstone@^2.5.1":
-  version "2.5.1"
-  resolved "https://npm.jahia.com/@jahia%2fmoonstone/-/moonstone-2.5.1.tgz#3bb19e0235cf45d91480ff9ceed2fab3d5351225"
-  integrity sha512-6RICXp/z9DTlWYfZt6sVe/GyZwAirPDa8m2S7QC6zvz+3REQJkin9ZPxogQOAL1r/dT1PF5isp4l8PI9MhY4aQ==
+"@jahia/moonstone@^2.5.2":
+  version "2.5.2"
+  resolved "https://npm.jahia.com/@jahia%2fmoonstone/-/moonstone-2.5.2.tgz#08e2d42f773dc3ceb74699c6b1db327cef7df5e1"
+  integrity sha512-1cEHFgn74GFgZ3adjtW8XTd1U2zfGiSUcmU3nxMBb6bA9ZSHCPFwA3Im3PbrRJstI0rqMYu4spmFwHvJgndAWw==
   dependencies:
     "@babel/runtime" "^7.20.13"
     clsx "^1.2.1"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16607

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Add search input automatically to site and language dropdowns when items are > 7 items
* Fix issue where side nav has a `moonstone-reversed` color scheme and making dropdown search input look like this:

![image](https://user-images.githubusercontent.com/75278792/218164953-55428cf9-5cd7-496c-922c-00bd46154eb3.png)

vs fixed:

![image](https://user-images.githubusercontent.com/75278792/218165017-b7a17a29-e0d0-420d-aa54-bab549c7497f.png)
* Sort systemsite to the end of sites list dropdown
![image](https://user-images.githubusercontent.com/75278792/218178218-70daf9a4-f158-4e0f-9e4c-66b6194199d9.png)

 
