### PR TITLE
Add translations in French and German

### DIFF
--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -222,6 +222,7 @@
         "publishedBy": "Veröffentlicht von {{userName}} am",
         "advancedPublish": "Erweiterte Veröffentlichung...",
         "cut": "Ausschneiden",
+        "clear": "Clipboard leeren",
         "lockNode": "Content sperren",
         "noViewAvailable": "Keine Vorschau verfügbar",
         "noContentSelected": "Wählen Sie einen Content, um die Vorschau zu aktivieren",
@@ -262,7 +263,8 @@
       },
       "copyPaste": {
         "success": "Element erfolgreich kopiert",
-        "error": "Beim Kopieren des Elements ist ein Fehler aufgetreten"
+        "error": "Beim Kopieren des Elements ist ein Fehler aufgetreten",
+        "clear": "Clipboard erfolgreich geleert"
       },
       "move": {
         "success": "{{count}} Element wurde nach {{dest}} verschoben",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -222,6 +222,7 @@
         "publishedBy": "Publié par {{userName}} le",
         "advancedPublish": "Publication avancée...",
         "cut": "Couper",
+        "clear": "Vider le presse-papier",
         "lockNode": "Verrouiller le contenu",
         "noViewAvailable": "Aperçu non disponible",
         "noContentSelected": "Sélectionnez un contenu pour le prévisualiser",
@@ -262,7 +263,8 @@
       },
       "copyPaste": {
         "success": "L'élément a été collé avec succès",
-        "error": "Une erreur s'est produite lors du collage de l'élément"
+        "error": "Une erreur s'est produite lors du collage de l'élément",
+        "clear": "Le presse-papier a été vidé"
       },
       "move": {
         "success": "{{count}} élément a été déplacé dans {{dest}}",


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-20649

## Description

Added translations in French and German for "clear clipboard" and "clipboard successfully emptied".