### PR TITLE
BACKLOG-20623: Disable create/upload actions on lock

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/EmptyDropZone/EmptyDropZone.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/EmptyDropZone/EmptyDropZone.jsx
@@ -8,13 +8,12 @@ import {useNodeChecks, useNodeInfo} from '@jahia/data-helper';
 import {ACTION_PERMISSIONS} from '../../../actions/actions.constants';
 import styles from './EmptyDropZone.scss';
 import clsx from 'clsx';
-import {isMarkedForDeletion} from '~/JContent/JContent.utils';
 
 const EmptyDropZone = ({component: Component, isCanDrop, uploadType}) => {
     const currentState = useSelector(state => ({
         site: state.site,
         language: state.language,
-        path: state.jcontent.path,
+        path: state.jcontent.path
     }), shallowEqual);
     const {t} = useTranslation('jcontent');
 
@@ -25,7 +24,7 @@ const EmptyDropZone = ({component: Component, isCanDrop, uploadType}) => {
         requiredSitePermission: [ACTION_PERMISSIONS.uploadFilesAction, ACTION_PERMISSIONS.importAction]
     });
 
-    // check lock status for node
+    // Check lock status for node
     const nodeInfo = useNodeInfo(
         {path: currentState.path},
         {getLockInfo: true, getIsNodeTypes: ['jmix:markedForDeletion']},

--- a/src/javascript/JContent/ContentRoute/ContentLayout/EmptyDropZone/EmptyDropZone.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/EmptyDropZone/EmptyDropZone.jsx
@@ -2,15 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {useTranslation} from 'react-i18next';
 import JContentConstants from '~/JContent/JContent.constants';
-import {Download, Typography} from '@jahia/moonstone';
+import {Download, Lock, Typography} from '@jahia/moonstone';
 import {shallowEqual, useSelector} from 'react-redux';
-import {useNodeChecks} from '@jahia/data-helper';
+import {useNodeChecks, useNodeInfo} from '@jahia/data-helper';
 import {ACTION_PERMISSIONS} from '../../../actions/actions.constants';
 import styles from './EmptyDropZone.scss';
 import clsx from 'clsx';
+import {isMarkedForDeletion} from '~/JContent/JContent.utils';
 
 const EmptyDropZone = ({component: Component, isCanDrop, uploadType}) => {
-    const currentState = useSelector(state => ({site: state.site, language: state.language}), shallowEqual);
+    const currentState = useSelector(state => ({
+        site: state.site,
+        language: state.language,
+        path: state.jcontent.path,
+    }), shallowEqual);
     const {t} = useTranslation('jcontent');
 
     const permissions = useNodeChecks({
@@ -20,8 +25,34 @@ const EmptyDropZone = ({component: Component, isCanDrop, uploadType}) => {
         requiredSitePermission: [ACTION_PERMISSIONS.uploadFilesAction, ACTION_PERMISSIONS.importAction]
     });
 
-    if (permissions.loading) {
+    // check lock status for node
+    const nodeInfo = useNodeInfo(
+        {path: currentState.path},
+        {getLockInfo: true, getIsNodeTypes: ['jmix:markedForDeletion']},
+        {fetchPolicy: 'network-only'}
+    );
+
+    if (permissions.loading || nodeInfo.loading) {
         return 'Loading...';
+    }
+
+    if (nodeInfo.node.lockOwner) {
+        let lockReason = '';
+        if (nodeInfo.node['jmix:markedForDeletion']) {
+            lockReason = t('label.contentManager.contentStatus.markedForDeletion');
+        } else {
+            lockReason = t('label.contentManager.lockedBy', {userName: nodeInfo.node.lockOwner.value});
+        }
+
+        return (
+            <Component data-type="emptyZone" className={styles.emptyZone}>
+                <Typography variant="heading">
+                    {t('jcontent:label.contentManager.fileUpload.locked')}
+                    { lockReason ? `: ${lockReason}` : ''}
+                </Typography>
+                <Lock/>
+            </Component>
+        );
     }
 
     if (uploadType === JContentConstants.mode.UPLOAD && permissions.node.site.uploadFilesAction) {

--- a/src/javascript/JContent/actions/createFolderAction/createFolderAction.jsx
+++ b/src/javascript/JContent/actions/createFolderAction/createFolderAction.jsx
@@ -30,7 +30,7 @@ export const CreateFolderActionComponent = ({path, createFolderType, render: Ren
         {
             ...constraintsByType[createFolderType || 'contentFolder'],
             getLockInfo: true
-        },
+        }
     );
 
     if (res.loading) {

--- a/src/javascript/JContent/actions/createFolderAction/createFolderAction.jsx
+++ b/src/javascript/JContent/actions/createFolderAction/createFolderAction.jsx
@@ -28,8 +28,9 @@ export const CreateFolderActionComponent = ({path, createFolderType, render: Ren
     const res = useNodeChecks(
         {path},
         {
-            ...constraintsByType[createFolderType || 'contentFolder']
-        }
+            ...constraintsByType[createFolderType || 'contentFolder'],
+            getLockInfo: true
+        },
     );
 
     if (res.loading) {
@@ -43,6 +44,7 @@ export const CreateFolderActionComponent = ({path, createFolderType, render: Ren
     return (
         <Render
             {...others}
+            enabled={!res.node?.lockOwner}
             isVisible={res.checksResult}
             onClick={() => {
                 componentRenderer.render('createFolderDialog', CreateFolderDialog, {path, contentType: nodeType[createFolderType || 'contentFolder'], onExit});

--- a/src/javascript/JContent/actions/fileUploadAction.jsx
+++ b/src/javascript/JContent/actions/fileUploadAction.jsx
@@ -56,7 +56,8 @@ export const FileUploadActionComponent = props => {
     const res = useNodeChecks(
         {path},
         {
-            ...constraintsByType[uploadType || 'upload']
+            ...constraintsByType[uploadType || 'upload'],
+            getLockInfo: true
         }
     );
 
@@ -86,7 +87,7 @@ export const FileUploadActionComponent = props => {
         <Render
             {...props}
             isVisible={isVisible}
-            enabled={isVisible}
+            enabled={isVisible && !res.node?.lockOwner}
             onClick={handleClick}
         />
     );

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -42,6 +42,7 @@
       "fileUpload": {
         "nothingToDisplay": "Nichts anzuzeigen",
         "nothingToDisplay2": "Nicht-auswählbare Elemente werden in dieser Anzeige nicht gelistet",
+        "locked": "This empty folder is locked",
         "selectMessage": "Datei von meinem Computer wählen",
         "uploadingActionMessage": "Es gibt Fehler, die Ihre Aufmerksamkeit benötigen",
         "or": "oder",

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -42,6 +42,7 @@
       "fileUpload": {
         "nothingToDisplay": "Nothing to display",
         "nothingToDisplay2": "Non-selectable items are not listed in this view",
+        "locked": "This empty folder is locked",
         "selectMessage": "Select files from my computer",
         "uploadingActionMessage": "There are error(s) which need your attention",
         "or": "or",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -42,6 +42,7 @@
       "fileUpload": {
         "nothingToDisplay": "Rien à afficher",
         "nothingToDisplay2": "Les éléments non selectionables n'apparaissent pas dans cette vue",
+        "locked": "Ce dossier vide est vérouillé",
         "selectMessage": "Sélectionner des fichiers depuis mon ordinateur",
         "uploadingActionMessage": "Il y a des erreurs qui nécessitent votre attention.",
         "or": "ou",


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20623

- Add lock info checks to enable/disable create folder action
- Add lock info checks to enable/disable upload action
- Add check on upload drop zone and disable when locked, display appropriate message, reason for lock