### PR TITLE
BACKLOG-20892: prevent drop on locked items

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/UploadTransformComponent/UploadTransformComponent.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/UploadTransformComponent/UploadTransformComponent.gql-queries.js
@@ -23,6 +23,9 @@ export const UploadRequirementsQuery = gql`
                 path
                 hasPermission(permissionName: $permission)
                 acceptsFiles: isNodeType(type:{multi:ANY, types:$permittedNodeTypes})
+                lockOwner: property(name: "jcr:lockOwner") {
+                    value
+                }
                 site {
                     uuid
                     workspace

--- a/src/javascript/JContent/dnd/useFileDrop.jsx
+++ b/src/javascript/JContent/dnd/useFileDrop.jsx
@@ -87,8 +87,7 @@ export function useFileDrop({uploadPath, uploadType, uploadMaxSize = Infinity, u
         },
         skip: !uploadType
     });
-
-    const allowDrop = !loading && !error && data?.jcr?.results?.hasPermission && data?.jcr?.results?.site?.hasPermission && data?.jcr?.results?.acceptsFiles;
+    const allowDrop = !loading && !error && data?.jcr?.results?.hasPermission && data?.jcr?.results?.site?.hasPermission && data?.jcr?.results?.acceptsFiles && !data?.jcr?.results?.lockOwner;
 
     const client = useApolloClient();
     const dispatch = useDispatch();
@@ -133,10 +132,10 @@ export function useFileDrop({uploadPath, uploadType, uploadMaxSize = Infinity, u
             asyncScanAndUpload().then(() => {
             });
         },
-        canDrop: () => allowDrop,
+        canDrop: (item, monitor) => allowDrop && monitor.isOver({shallow: true}),
         collect: monitor => ({
             isOver: monitor.isOver({shallow: true}),
-            isCanDrop: (monitor.canDrop() && monitor.isOver({shallow: true}))
+            isCanDrop: monitor.canDrop()
         })
     }), [client, dispatch, uploadFilter, uploadPath, uploadType, uploadMaxSize, uploadMinSize, allowDrop]);
 }

--- a/src/javascript/JContent/dnd/useNodeDrag.jsx
+++ b/src/javascript/JContent/dnd/useNodeDrag.jsx
@@ -20,21 +20,22 @@ export function useNodeDrag({dragSource}) {
             getPrimaryNodeType: true,
             requiredPermission: ['jcr:removeNode'],
             hideOnNodeTypes: ['jnt:virtualsite'],
-            hideForPaths: [PATH_FILES_ITSELF, PATH_CONTENTS_ITSELF]
+            hideForPaths: [PATH_FILES_ITSELF, PATH_CONTENTS_ITSELF],
+            getLockInfo: true
         }
     );
 
     const [props, drag, dragPreview] = useDrag(() => selection.length === 0 ? ({
         type: 'node',
         item: dragSource,
-        canDrag: () => Boolean(res.checksResult),
+        canDrag: () => Boolean(res.checksResult) && !res.node?.lockOwner,
         collect: monitor => ({
             dragging: monitor.isDragging()
         })
     }) : ({
         type: 'nodes',
         item: res.nodes,
-        canDrag: () => res.checksResult && selection.indexOf(dragSource.path) > -1,
+        canDrag: () => res.checksResult && !res.nodes?.some(n => n.lockOwner) && selection.indexOf(dragSource.path) > -1,
         collect: monitor => ({
             dragClasses: monitor.isDragging() ? [styles.drag] : []
         })

--- a/src/javascript/JContent/dnd/useNodeDrop.jsx
+++ b/src/javascript/JContent/dnd/useNodeDrop.jsx
@@ -60,7 +60,8 @@ export function useNodeDrop({dropTarget, orderable, entries, onSaved, refetchQue
         {
             requiredPermission: 'jcr:addChildNodes',
             getChildNodeTypes: true,
-            getContributeTypesRestrictions: true
+            getContributeTypesRestrictions: true,
+            getLockInfo: true
         }
     );
 
@@ -69,7 +70,7 @@ export function useNodeDrop({dropTarget, orderable, entries, onSaved, refetchQue
     const [props, drop] = useDrop(() => ({
         accept: ['node', 'nodes'],
         collect: monitor => ({
-            isCanDrop: (monitor.canDrop() && monitor.isOver({shallow: true})),
+            isCanDrop: monitor.canDrop(),
             insertPosition,
             destParent
         }),
@@ -110,7 +111,7 @@ export function useNodeDrop({dropTarget, orderable, entries, onSaved, refetchQue
         canDrop: (dragSource, monitor) => {
             const nodes = (monitor.getItemType() === 'nodes') ? dragSource : [dragSource];
 
-            return dropTarget && res.node &&
+            return dropTarget && monitor.isOver({shallow: true}) && res.node && !res.node?.lockOwner &&
                 (insertPosition || (dragSource.path !== (destParent.path + '/' + dragSource.name))) &&
                 !isDescendantOrSelf(destParent.path, dragSource.path) &&
                 nodeTypeCheck(res.node, nodes).checkResult;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20892

## Description

add lock check on useNodeDrop / useFileDrop / useNodeDrag
fixed consistency issue with `monitor.isOver({shallow: true})` , moved test to canDrop()