### PR TITLE
TECH-1224: Fix sync-pom execution on release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
-                    <preparationGoals>clean frontend:yarn@sync-pom verify</preparationGoals>
+                    <preparationGoals>clean install frontend:yarn@sync-pom verify</preparationGoals>
                     <completionGoals>frontend:yarn@sync-pom</completionGoals>
                 </configuration>
             </plugin>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-1224

Hitting error:
https://app.circleci.com/pipelines/github/Jahia/JahiaReleaseTool/1545/workflows/f74e5d6e-8f8b-46fe-98c0-ba55fec1522e/jobs/3074

```
[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.12.1:yarn (sync-pom) on project jcontent: Failed to run task: 'yarn sync-pom' failed. java.io.IOException: Cannot run program "/home/circleci/automated_jahia_releases/jahia-build-dir/jcontent/node/yarn/dist/bin/yarn" (in directory "/home/circleci/automated_jahia_releases/jahia-build-dir/jcontent"): error=2, No such file or directory -> [Help 1]
```

Fix by adding `install` goal to install yarn first.