### PR TITLE
BACKLOG-20908: Allow to clear selection at the body level

### DIFF
--- a/src/javascript/JContent/JContent.jsx
+++ b/src/javascript/JContent/JContent.jsx
@@ -1,17 +1,32 @@
-import React from 'react';
+import React, {useCallback, useEffect} from 'react';
 import {registry} from '@jahia/ui-extender';
 import {ErrorBoundary, LoaderSuspense} from '@jahia/jahia-ui-root';
 import {LayoutModule} from '@jahia/moonstone';
 import ContentNavigation from './ContentNavigation';
 import {Route, Switch} from 'react-router';
-import {shallowEqual, useSelector} from 'react-redux';
+import {shallowEqual, useDispatch, useSelector} from 'react-redux';
 import './colors.scss';
+import {cmClearSelection} from './redux/selection.redux';
 
 export const JContent = () => {
     const routes = registry.find({type: 'route', target: 'jcontent'});
     const {site, mode} = useSelector(state => ({site: state.jcontent.site, mode: state.jcontent.mode}), shallowEqual);
     const item = registry.get('accordionItem', mode);
     const itemEnabled = item && (!item.isEnabled || item.isEnabled(site));
+    const dispatch = useDispatch();
+    const clear = useCallback(() => dispatch(cmClearSelection()), [dispatch]);
+    const handleKeyboardNavigation = useCallback(event => {
+        if (event.key === 'Escape' || event.keyCode === 27) {
+            clear();
+        }
+    }, [clear]);
+
+    useEffect(() => {
+        document.querySelector('body').addEventListener('keydown', handleKeyboardNavigation);
+        return () => {
+            document.querySelector('body').removeEventListener('keydown', handleKeyboardNavigation);
+        };
+    }, [handleKeyboardNavigation]);
 
     return (
         <LayoutModule


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20908

## Description

Add a keydown listener at the body level to ensure we can press Escape after opening a dialog to clear selection

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
