### PR TITLE
BACKLOG-21012: Fix issue in EmptyDropZone.jsx when node is not existing (creation of content reference for example)

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/EmptyDropZone/EmptyDropZone.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/EmptyDropZone/EmptyDropZone.jsx
@@ -35,7 +35,7 @@ const EmptyDropZone = ({component: Component, isCanDrop, uploadType}) => {
         return 'Loading...';
     }
 
-    if (nodeInfo.node.lockOwner) {
+    if (nodeInfo.node?.lockOwner) {
         let lockReason = '';
         if (nodeInfo.node['jmix:markedForDeletion']) {
             lockReason = t('label.contentManager.contentStatus.markedForDeletion');


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21012


