### PR TITLE
BACKLOG-20990: Restore paste action on jnt:page and jnt:navMenuText

### DIFF
--- a/src/javascript/JContent/actions/copyPaste/pasteAction.jsx
+++ b/src/javascript/JContent/actions/copyPaste/pasteAction.jsx
@@ -45,7 +45,6 @@ export const PasteActionComponent = withNotifications()(({path, referenceTypes, 
             requiredSitePermission: [ACTION_PERMISSIONS.pasteAction],
             getChildNodeTypes: true,
             getContributeTypesRestrictions: true,
-            hideOnNodeTypes: ['jnt:page', 'jnt:navMenuText'],
             getSubNodesCount: true,
             getIsNodeTypes: ['jmix:listSizeLimit'],
             getProperties: ['limit']


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20990

## Description

Restore paste action on jnt:page and jnt:navMenuText


