### PR TITLE
BACKLOG-21015: Check that target can be content type restricted before returning contributeTypes

### DIFF
--- a/src/javascript/JContent/actions/copyPaste/pasteAction.jsx
+++ b/src/javascript/JContent/actions/copyPaste/pasteAction.jsx
@@ -46,7 +46,7 @@ export const PasteActionComponent = withNotifications()(({path, referenceTypes, 
             getChildNodeTypes: true,
             getContributeTypesRestrictions: true,
             getSubNodesCount: true,
-            getIsNodeTypes: ['jmix:listSizeLimit'],
+            getIsNodeTypes: ['jmix:listSizeLimit', 'jnt:contentList', 'jnt:folder', 'jnt:contentFolder', 'jnt:area', 'jnt:mainResourceDisplay'],
             getProperties: ['limit']
         }
     );

--- a/src/javascript/JContent/hooks/useNodeTypeCheck.jsx
+++ b/src/javascript/JContent/hooks/useNodeTypeCheck.jsx
@@ -26,7 +26,8 @@ export function useNodeTypeCheck() {
         const childNodeTypes = target.allowedChildNodeTypes.map(t => t.name);
         const contributeTypesProperty = target.contributeTypes ||
             (target.ancestors && target.ancestors.length > 0 && target.ancestors[target.ancestors.length - 1].contributeTypes);
-        const contributeTypes = contributeTypesProperty ? contributeTypesProperty.values : [];
+        const targetIsContentTypeRestrictCapable = ['jnt:contentList', 'jnt:folder', 'jnt:contentFolder', 'jnt:area', 'jnt:mainResourceDisplay'].find(type => target[type]) !== undefined;
+        const contributeTypes = (targetIsContentTypeRestrictCapable && contributeTypesProperty) ? contributeTypesProperty.values : [];
 
         if (contributeTypes.length === 0 && childNodeTypes.length === 0) {
             return {loading: false, checkResult: false};


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21015

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
