### PR TITLE
BACKLOG-20881: Close dialog and refetch data upon error

### DIFF
--- a/src/javascript/JContent/actions/deleteActions/Delete/Delete.jsx
+++ b/src/javascript/JContent/actions/deleteActions/Delete/Delete.jsx
@@ -178,8 +178,8 @@ const Delete = ({dialogType, node, nodes, onExit}) => {
             notificationContext.notify(t('jcontent:label.contentManager.deleteAction.error'), ['closeButton']);
             paths.forEach(path => client.cache.flushNodeEntryByPath(path));
             triggerRefetchAll();
-            setOpen(false)
-        })
+            setOpen(false);
+        });
     };
 
     return (

--- a/src/javascript/JContent/actions/deleteActions/Delete/Delete.jsx
+++ b/src/javascript/JContent/actions/deleteActions/Delete/Delete.jsx
@@ -19,6 +19,7 @@ import {Info} from '~/JContent/actions/deleteActions/Delete/Info';
 import {getName} from '~/JContent';
 import {TransparentLoaderOverlay} from '../../../TransparentLoaderOverlay';
 import {isPathChildOfAnotherPath} from '../../../JContent.utils';
+import {useNotifications} from '@jahia/react-material';
 
 let getLabel = ({dialogType, locked, count, data, firstNode, pages, folders, t}) => {
     if (locked) {
@@ -143,7 +144,8 @@ const Delete = ({dialogType, node, nodes, onExit}) => {
     }), shallowEqual);
     const paths = node ? [node.path] : (nodes.map(node => node.path).sort().filter((path, index, array) => array.find(parentPath => isPathChildOfAnotherPath(path, parentPath)) === undefined));
     const client = useApolloClient();
-
+    const notificationContext = useNotifications();
+    const {t} = useTranslation('jcontent');
     const [mutation, {called: mutationLoading}] = useMutation(getMutation(dialogType));
 
     const {data, error, loading} = useQuery(DeleteQueries, {
@@ -172,7 +174,12 @@ const Delete = ({dialogType, node, nodes, onExit}) => {
         }).then(() => {
             paths.forEach(path => client.cache.flushNodeEntryByPath(path));
             triggerRefetchAll();
-        });
+        }).catch(() => {
+            notificationContext.notify(t('jcontent:label.contentManager.deleteAction.error'), ['closeButton']);
+            paths.forEach(path => client.cache.flushNodeEntryByPath(path));
+            triggerRefetchAll();
+            setOpen(false)
+        })
     };
 
     return (

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -450,7 +450,8 @@
             "content": "Das Element <strong>{{name}}</strong> kann aktuell nicht allein wiederhergestellt werden. Bitte stellen Sie das übergeordnete Element <strong>{{parentName}}</strong> wieder her, welches zuerst zur Löschung markiert wurde.",
             "content_plural": "Die {{count}} Elemente <strong>{{name}}</strong> können aktuell nicht allein wiederhergestellt werden. Bitte stellen Sie das übergeordnete Element <strong>{{parentName}}</strong> wieder her, welches zuerst zur Löschung markiert wurde."
           }
-        }
+        },
+        "error": "Die angeforderte Operation konnte am ausgewählten Content nicht durchgeführt werden. Dialog wird geschlossen und Daten werden neu geladen."
       },
       "links": {
         "external": {

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -458,7 +458,8 @@
             "content_plural": "{{count}} items <strong>{{name}}</strong> cannot currently be undeleted on their own. Please undelete their parent content <strong>{{parentName}}</strong> which was the one initially marked for deletion."
           }
         },
-        "details": "DETAILS"
+        "details": "DETAILS",
+        "error": "Could not perform the requested operation on selected content. Closing dialog and refreshing data."
       },
       "links":{
         "external": {

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -451,7 +451,8 @@
             "content": "Il n’est actuellement pas possible d’annuler la seule suppression de l’élément <strong>{{name}}</strong>. Merci d’annuler la suppression de son contenu parent <strong>{{parentName}}</strong>, qui est le contenu initialement marqué pour suppression. ",
             "content_plural": "Il y a ${count} elements <strong>{{name}}</strong> qui ne peuvent pas être restaurés. Veuillez restaurer, ou supprimer définitivement le contenu parent <strong>{{parentName}}</strong> qui est le contenu initialement marqué pour suppression."
           }
-        }
+        },
+        "error": "Impossible d'exécuter l'opération demandée. Fermeture de la fenêtre et rafraîchissement des données."
       },
       "links": {
         "external": {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20881

## Description

Close dialog and display notifications when error occurred during a deletion

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
