### PR TITLE
BACKLOG-21065 Don't show selection removal notification unless it is associated with tableViewMode change

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
@@ -33,6 +33,7 @@ import {useFileDrop} from '~/JContent/dnd/useFileDrop';
 import styles from './ContentTable.scss';
 import {pathExistsInTree} from '../../../JContent.utils';
 import {useNotifications} from '@jahia/react-material';
+import {TableViewModeChangeCounter} from '../../ToolBar/ViewModeSelector/tableViewChangeCounter';
 
 export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, isStructured, columns, selector}) => {
     const {t} = useTranslation('jcontent');
@@ -90,9 +91,16 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
         if (selection.length > 0 && !isLoading && rows?.length > 0) {
             const toRemove = selection.filter(path => !pathExistsInTree(path, rows));
             if (toRemove.length > 0) {
-                notify(t('jcontent:label.contentManager.selection.removed', {count: toRemove.length}), ['closeButton', 'closeAfter5s']);
+                if (TableViewModeChangeCounter.modeChanged) {
+                    notify(t('jcontent:label.contentManager.selection.removed', {count: toRemove.length}), ['closeButton', 'closeAfter5s']);
+                }
+
                 dispatch(cmRemoveSelection(toRemove));
             }
+
+            TableViewModeChangeCounter.resetModeChanged();
+        } else if (!isLoading && rows?.length > 0) {
+            TableViewModeChangeCounter.resetModeChanged();
         }
     }, [rows, selection, dispatch, paths, isLoading, notify, t]);
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/tableViewChangeCounter.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/tableViewChangeCounter.js
@@ -1,0 +1,6 @@
+export const ChangeCounter = {
+    count: 0,
+    increment: function() {
+        this.count++;
+    }
+};

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/tableViewChangeCounter.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/tableViewChangeCounter.js
@@ -1,6 +1,0 @@
-export const ChangeCounter = {
-    count: 0,
-    increment: function() {
-        this.count++;
-    }
-};

--- a/src/javascript/JContent/ContentRoute/ToolBar/ViewModeSelector/ViewModeSelector.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/ViewModeSelector/ViewModeSelector.jsx
@@ -9,6 +9,7 @@ import classes from './ViewModeSelector.scss';
 import {booleanValue} from '~/JContent/JContent.utils';
 import {useQuery} from '@apollo/client';
 import {GetContentType} from './ViewModeSelector.gql-queries';
+import {TableViewModeChangeCounter} from './tableViewChangeCounter';
 
 const localStorage = window.localStorage;
 
@@ -59,6 +60,7 @@ export const ViewModeSelector = ({selector, setTableViewModeAction}) => {
     const onChange = vm => dispatch(setTableViewModeAction(vm));
 
     const handleChange = selectedViewMode => {
+        TableViewModeChangeCounter.increment();
         onChange(selectedViewMode);
         localStorage.setItem(VIEW_MODE, selectedViewMode);
     };

--- a/src/javascript/JContent/ContentRoute/ToolBar/ViewModeSelector/tableViewChangeCounter.js
+++ b/src/javascript/JContent/ContentRoute/ToolBar/ViewModeSelector/tableViewChangeCounter.js
@@ -1,0 +1,11 @@
+export const TableViewModeChangeCounter = {
+    count: 0,
+    modeChanged: false,
+    increment: function () {
+        this.count++;
+        this.modeChanged = true;
+    },
+    resetModeChanged: function () {
+        this.modeChanged = false;
+    }
+};

--- a/src/javascript/JContent/PageComposerRoute/EditFrame/Boxes.jsx
+++ b/src/javascript/JContent/PageComposerRoute/EditFrame/Boxes.jsx
@@ -15,6 +15,7 @@ import {pathExistsInTree} from '../../JContent.utils';
 import {useTranslation} from 'react-i18next';
 import {useNotifications} from '@jahia/react-material';
 import {refetchTypes, setRefetcher, unsetRefetcher} from '~/JContent/JContent.refetches';
+import {TableViewModeChangeCounter} from '~/JContent/ContentRoute/ToolBar/ViewModeSelector/tableViewChangeCounter';
 
 const getModuleElement = (currentDocument, target) => {
     let element = target;
@@ -170,10 +171,15 @@ export const Boxes = ({currentDocument, currentFrameRef, addIntervalCallback, on
         if (selection.length > 0) {
             const toRemove = selection.filter(path => !pathExistsInTree(path, modules, node => node.dataset.jahiaPath));
             if (toRemove.length > 0) {
-                notify(t('jcontent:label.contentManager.selection.removed', {count: toRemove.length}), ['closeButton', 'closeAfter5s']);
+                if (TableViewModeChangeCounter.modeChanged) {
+                    notify(t('jcontent:label.contentManager.selection.removed', {count: toRemove.length}), ['closeButton', 'closeAfter5s']);
+                }
+
                 dispatch(cmRemoveSelection(toRemove));
             }
         }
+
+        TableViewModeChangeCounter.resetModeChanged();
 
         setModules(modules);
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21065

## Description

Don't show selection removal notification unless it is associated with tableViewMode change