### PR TITLE
BACKLOG-21096: separate useQuery calls

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/useLayoutQuery.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/useLayoutQuery.jsx
@@ -22,31 +22,31 @@ export function useLayoutQuery(options, fragments, queryVariables, accordionItem
 
     const isStructured = queryHandler.isStructured(options);
 
-    if (treeParams) {
-        // Conditional hook / branch 1 - both branches have the exact same hook structure, useTreeEntries just wraps useQuery
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const {treeEntries, error, loading, refetch} = useTreeEntries({
-            ...treeParams,
-            fragments: [...allFragments, QueryHandlersFragments.nodeFields, QueryHandlersFragments.childNodesCount],
-            queryVariables,
-            openableTypes: treeParams.openableTypes || queryVariables.typeFilter,
-            selectableTypes: treeParams.selectableTypes || queryVariables.selectableTypesTable || []
-        }, {errorPolicy: 'all'});
-
-        const result = queryHandler.structureTreeEntries(treeEntries, treeParams);
-        return {isStructured, result, error, loading, refetch};
-    }
+    const {treeEntries, error: errorTree, loading: loadingTree, refetch: refetchTree} = useTreeEntries({
+        ...treeParams,
+        fragments: [...allFragments, QueryHandlersFragments.nodeFields, QueryHandlersFragments.childNodesCount],
+        queryVariables,
+        openableTypes: treeParams?.openableTypes || queryVariables.typeFilter,
+        selectableTypes: treeParams?.selectableTypes || queryVariables.selectableTypesTable || []
+    }, {
+        errorPolicy: 'all',
+        skip: !treeParams
+    });
 
     const layoutQuery = queryHandler.getQuery && replaceFragmentsInDocument(queryHandler.getQuery(), allFragments);
 
-    // Conditional hook / branch 2 - both branches have the exact same hook structure, useTreeEntries just wraps useQuery
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const {data, error, loading, refetch} = useQuery(layoutQuery, {
+    const {data: flatData, error: errorFlat, loading: loadingFlat, refetch: refetchFlat} = useQuery(layoutQuery, {
         variables: queryVariables,
-        fetchPolicy: options.fetchPolicy
+        fetchPolicy: options.fetchPolicy,
+        skip: Boolean(treeParams)
     });
 
-    const queryResult = data && queryHandler.getResults(data, options);
+    if (treeParams) {
+        const result = queryHandler.structureTreeEntries(treeEntries, treeParams);
+        return {isStructured, result, error: errorTree, loading: loadingTree, refetch: refetchTree};
+    }
+
+    const queryResult = flatData && queryHandler.getResults(flatData, options);
     const result = isStructured ? queryHandler.structureData(options.path, queryResult) : queryResult;
-    return {isStructured, result, error, loading, refetch};
+    return {isStructured, result, error: errorFlat, loading: loadingFlat, refetch: refetchFlat};
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21096

## Description

Avoid conditional hooks, use separate entries for structured and unstructured