### PR TITLE
BACKLOG-21077: extend toast timeout

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/Upload/Upload.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/Upload/Upload.jsx
@@ -17,7 +17,7 @@ import UploadHeader from './UploadHeader';
 import {batchActions} from 'redux-batched-actions';
 import styles from './Upload.scss';
 
-const SNACKBAR_CLOSE_TIMEOUT = 5000;
+const SNACKBAR_CLOSE_TIMEOUT = 8000;
 
 export class Upload extends React.Component {
     constructor(props) {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21077

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

selenium tests is timing out when checking toast dialog during import, since toast auto-closes before check can be done.

I'm still not understanding what changed to cause this issue all of a sudden, but extending timeout seems to fix the issue.
