### PR TITLE
BACKLOG-21304: Fix provisioning script

### DIFF
--- a/tests/cypress/e2e/menu.cy.ts
+++ b/tests/cypress/e2e/menu.cy.ts
@@ -43,7 +43,7 @@ describe('Menu tests', () => {
         contentEditor.getSmallTextField('jnt:page_jcr:title').get().find('input[type="text"]').should('be.visible')
             .clear({force: true}).type('New Root Level Page', {force: true})
             .should('have.value', 'New Root Level Page');
-        const templateField = contentEditor.getField(Field, 'jnt:page_j:templateName');
+        const templateField = contentEditor.getField(Field, 'jmix:hasTemplateNode_j:templateName');
         templateField.get().click();
         getComponentBySelector(Menu, '[role="listbox"]').select('3 Column');
         contentEditor.save();

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -5,4 +5,6 @@
     - 'mvn:org.jahia.modules/jahia-administration'
     - 'mvn:org.jahia.modules/graphql-dxm-provider'
     - 'mvn:org.jahia.modules/jahia-ui-root'
+  autoStart: true
+  uninstallPreviousVersion: true
 - include: 'provisioning.yml'


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21304

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Fix provisioning script to auto-start and uninstall older versions of provisioning modules
* Update one of  `menu.cy.ts` with new mixin selector (see https://github.com/Jahia/content-editor/pull/1660)