### PR TITLE
BACKLOG-21108: Show import actions on more nodeTypes

### DIFF
--- a/src/javascript/JContent/actions/fileUploadAction.jsx
+++ b/src/javascript/JContent/actions/fileUploadAction.jsx
@@ -27,7 +27,8 @@ const constraintsByType = {
         requiredSitePermission: [ACTION_PERMISSIONS.replaceWithAction]
     },
     import: {
-        showOnNodeTypes: ['jnt:contentFolder', 'jnt:category'],
+        showOnNodeTypes: ['jnt:contentFolder', 'jnt:category', 'jnt:page', 'jnt:area', 'jmix:list'],
+        hideOnNodeTypes: ['jnt:folder'],
         requiredPermission: 'jcr:addChildNodes',
         requiredSitePermission: [ACTION_PERMISSIONS.importAction]
     },


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21108

## Description

Show import for jmix:list but hide on jnt:folder

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
