### PR TITLE
BACKLOG-20402: Fix provisioning for nightly

### DIFF
--- a/tests/assets/provisioning.yml
+++ b/tests/assets/provisioning.yml
@@ -16,8 +16,8 @@
     - 'mvn:org.jahia.modules/location/3.2.0'
     - 'mvn:org.jahia.modules/topstories/3.0.0'
     - 'mvn:org.jahia.modules/rating/3.2.0'
-    - 'mvn:org.jahia.modules/event/4.0.0-SNAPSHOT'
-    - 'mvn:org.jahia.modules/site-settings-seo/5.0.0-SNAPSHOT'
+    - 'mvn:org.jahia.modules/event'
+    - 'mvn:org.jahia.modules/site-settings-seo'
     - 'mvn:org.jahia.modules/bookmarks/3.1.0'
     - 'mvn:org.jahia.modules/dx-base-demo-core/2.5.0'
     - 'mvn:org.jahia.modules/dx-base-demo-templates/3.4.0'
@@ -38,6 +38,3 @@
   site: "digitall"
 
 - executeScript: "script-01-create-categories.groovy"
-
-- uninstallBundle:
-    - "org.jahia.modules/content-editor"

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -1,3 +1,11 @@
+
+# uninstall only if it exists, otherwise it throws an error
+# need to hardcode version for uninstall
+- if: org.jahia.osgi.BundleUtils.getBundleBySymbolicName('content-editor',null) != null
+  do:
+    - uninstallBundle: 'mvn:org.jahia.modules/content-editor/3.6.0'
+
+- addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/public/@snapshots@noreleases@id=JahiaPublicSnapshots'
 - installBundle:
     - 'mvn:org.jahia.modules/jcontent'
     - 'mvn:org.jahia.modules/jahia-page-composer'


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20402

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Refactor provisioning to be able to execute on both 8.1.6.0 and current 8.2-SN

- whole provisioning script fails if `uninstallBundle` fails and if the module doesn't exist, so we need to add condition in order to run on both 8.1.6.0 and 8.2-SN.