### PR TITLE
QA-14594: Fix breadcrumb selection query param

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentPath/ContentPath.container.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentPath/ContentPath.container.jsx
@@ -68,12 +68,13 @@ const ContentPathContainer = ({selector}) => {
             <ContentPath items={items} onItemClick={handleNavigation}/>
             <ContentPathDialog isOpen={Boolean(currentItem)}
                                handleParentNavigation={() => {
-                                   dispatch(setPathAction(mode, currentItem.path.substring(0, currentItem.path.lastIndexOf('/'))));
+                                   const path = currentItem.path.substring(0, currentItem.path.lastIndexOf('/'));
+                                   dispatch(cmGoto({mode, path}));
                                    setCurrentItem(null);
                                }}
                                handleClose={() => setCurrentItem(null)}
                                handleListNavigation={() => {
-                                   dispatch(setPathAction(mode, currentItem.path));
+                                   dispatch(cmGoto({mode, path: currentItem.path}));
                                    setCurrentItem(null);
                                }}
             />

--- a/src/javascript/JContent/ContentRoute/ContentPath/ContentPath.container.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentPath/ContentPath.container.jsx
@@ -40,7 +40,7 @@ function getItems(node = {}) {
     return ancestors;
 }
 
-const ContentPathContainer = ({setPathAction, selector}) => {
+const ContentPathContainer = ({selector}) => {
     const dispatch = useDispatch();
     const [currentItem, setCurrentItem] = useState(null);
 
@@ -54,7 +54,7 @@ const ContentPathContainer = ({setPathAction, selector}) => {
         if (item.primaryNodeType?.name === 'jnt:contentList' && mode === JContentConstants.mode.PAGES && viewMode === JContentConstants.tableView.viewMode.PAGE_BUILDER) {
             setCurrentItem(item);
         } else {
-            dispatch(setPathAction(mode, item.path));
+            dispatch(cmGoto({mode, path: item.path, params: {sub: false}}));
         }
     };
 
@@ -82,8 +82,7 @@ const ContentPathContainer = ({setPathAction, selector}) => {
 };
 
 ContentPathContainer.propTypes = {
-    selector: PropTypes.func,
-    setPathAction: PropTypes.func
+    selector: PropTypes.func
 };
 
 ContentPathContainer.defaultProps = {
@@ -92,8 +91,7 @@ ContentPathContainer.defaultProps = {
         viewMode: state.jcontent.tableView.viewMode,
         path: state.jcontent.path,
         language: state.language
-    }),
-    setPathAction: (mode, path) => cmGoto({mode, path})
+    })
 };
 
 export default ContentPathContainer;

--- a/src/javascript/JContent/ContentRoute/ContentPath/ContentPath.container.test.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentPath/ContentPath.container.test.jsx
@@ -99,7 +99,7 @@ describe('ContentPathContainer', () => {
         wrapper.invoke('onItemClick')({path: '/x/y/z'});
 
         expect(dispatch).toHaveBeenCalledTimes(1);
-        expect(cmGoto).toHaveBeenCalledWith({mode: 'foo', path: '/x/y/z'});
+        expect(cmGoto).toHaveBeenCalledWith({mode: 'foo', path: '/x/y/z', params: {sub: false}});
     });
 
     it('starts from the closest ancestor visible in Content tree if node is not visible Content tree', () => {

--- a/tests/cypress/e2e/jcontent/breadcrumbs.cy.ts
+++ b/tests/cypress/e2e/jcontent/breadcrumbs.cy.ts
@@ -41,4 +41,28 @@ describe('Breadcrumb navigation test', () => {
         Breadcrumb.findByContent('CEOs of The Digital Roundtable').click();
         cy.get('.moonstone-chip').find('span').contains('Event').should('be.visible');
     });
+
+    it('Display same items as tree content selection', () => {
+        const jcontent = JContent.visit('digitall', 'en', 'pages/home');
+        jcontent.switchToListMode();
+
+        // Get total rows
+        cy.get('[data-sel-role="table-pagination-total-rows"]')
+            .invoke('text')
+            .then(e => {
+                // Get total rows through regex e.g. extract 21 from "1-21 of 21"
+                const totalRows = e.match(/of (.*)$/)?.[1];
+                cy.wrap(totalRows).as('totalRows');
+            });
+
+        JContent.visit('digitall', 'en', 'pages/home/area-main/highlights');
+        Breadcrumb.findByContent('Home').click();
+        cy.get('.moonstone-loader', {timeout: 5000}).should('not.exist');
+
+        cy.get('@totalRows').then(totalRows => {
+            cy.get('[data-sel-role="table-pagination-total-rows"]')
+                .invoke('text')
+                .should('contain', totalRows);
+        });
+    });
 });

--- a/tests/cypress/page-object/jcontent.ts
+++ b/tests/cypress/page-object/jcontent.ts
@@ -142,6 +142,7 @@ export class JContent extends BasePage {
 
     switchToListMode(): JContent {
         this.switchToMode('List');
+        cy.get('.moonstone-loader', {timeout: 5000}).should('not.exist');
         return this;
     }
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14594

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Refactor/remove `setPathAction` prop since it's not used anymore
* Add param `{sub: false}` to match it with tree selection
* Add cypress test