### PR TITLE
Cypress fixes

### DIFF
--- a/tests/cypress/e2e/contentEditor/editorUrl.cy.ts
+++ b/tests/cypress/e2e/contentEditor/editorUrl.cy.ts
@@ -60,6 +60,7 @@ describe('Editor url test', () => {
     it('Should create hash', function () {
         cy.login();
         jcontent = JContent.visit('digitall', 'en', 'pages/home');
+        jcontent.switchToListMode();
         contentEditor = jcontent.editComponentByText('People First');
         contentEditor.switchToAdvancedMode();
         cy.hash().should('contain', 'contentEditor:');
@@ -69,6 +70,7 @@ describe('Editor url test', () => {
     it('History is handled consistently', function () {
         cy.login();
         jcontent = JContent.visit('digitall', 'en', 'pages/home');
+        jcontent.switchToListMode();
         contentEditor = jcontent.editComponentByText('People First');
         contentEditor.switchToAdvancedMode();
         cy.get('h1').contains('People First').should('exist');

--- a/tests/cypress/e2e/contentEditor/pickers/search.cy.ts
+++ b/tests/cypress/e2e/contentEditor/pickers/search.cy.ts
@@ -62,7 +62,7 @@ describe('Picker tests - Search', () => {
         const contentEditor = jcontent.editComponentByText('Leading by Example');
         const picker = contentEditor.getPickerField('jdmix:hasLink_internalLink').open();
         picker.search('t');
-        picker.verifyResultsLength(82);
+        picker.verifyResultsAtLeast(82);
         picker.search('a');
         picker.verifyResultsLength(19);
         picker.search('b');

--- a/tests/cypress/e2e/jcontent/pageComposer.cy.ts
+++ b/tests/cypress/e2e/jcontent/pageComposer.cy.ts
@@ -116,6 +116,10 @@ describe('Page builder', () => {
         it('should show paste button when we copy', function () {
             jcontent.refresh();
 
+            // Context menu does not show up; wait necessary
+            // eslint-disable-next-line cypress/no-unnecessary-waiting
+            cy.wait(1000);
+
             const menu = jcontent.getModule('/sites/jcontentSite/home/area-main/test-content1').contextMenu();
             menu.select('Copy');
 
@@ -127,6 +131,10 @@ describe('Page builder', () => {
 
         it('remove paste button when we clear clipboard', function () {
             jcontent.refresh();
+
+            // Context menu does not show up; wait necessary
+            // eslint-disable-next-line cypress/no-unnecessary-waiting
+            cy.wait(1000);
 
             const menu = jcontent.getModule('/sites/jcontentSite/home/area-main/test-content1').contextMenu();
             menu.select('Copy');

--- a/tests/cypress/page-object/picker.ts
+++ b/tests/cypress/page-object/picker.ts
@@ -166,6 +166,19 @@ export class Picker extends BaseComponent {
         this.get().find('[data-sel-role="table-pagination-total-rows"]').should('be.visible').and('contain', `of ${length}`);
     }
 
+    verifyResultsAtLeast(length: number) {
+        const totalRowsSelector = '[data-sel-role="table-pagination-total-rows"]';
+        this.get().find(totalRowsSelector).should('be.visible');
+        this.get().find(totalRowsSelector)
+            .invoke('text')
+            .then(e => {
+                // Get total rows through regex e.g. extract 21 from "1-21 of 21"
+                const totalRows = e.match(/of (.*)$/)?.[1];
+                const totalRowsNum = Number(totalRows);
+                expect(totalRowsNum).to.be.at.least(length, `Verifying picker result rows to at least be ${length}`);
+            });
+    }
+
     switchSearchContext(context: string) {
         getComponentBySelector(Dropdown, '.moonstone-searchContextInput_element').select(context);
     }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->


## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Trying to fix common failures in jcontent:

* search.cy.ts
```
 |   | - Picker tests - Search
 |   |    | - FAIL: Picker tests - Search Editorial Picker- Search for tab - letter by letter
```
`pdf.cy.ts` generates `/sites/digitall/home/investors/events/relatedPeople` node when visiting `pages/home/investors/events` in jcontent.

 This creates an extra search result (from 82 to 83) when searching 't'. (extra relatedPeople search result).
 
 need to adjust check to >= 82 to account for this extra search result, depending on if pdf is ran first or not

* pageComposer.cy.ts
```
 | Suite: Mocha Tests - Total tests: 22 - Failure: 2 - Executed in 246s
 |   | - clipboard
 |   |    | - FAIL: Page builder clipboard should show paste button when we copy
 |   |    | - FAIL: Page builder clipboard remove paste button when we clear clipboard
```

It looks like context menu to select copy is not showing up for both test cases. I'm not sure exactly though what it's waiting for to load, so I had to force `cy.wait`.

* editorUrl.cy.ts

```
 | Suite: Mocha Tests - Total tests: 12 - Failure: 2 - Executed in 155s
 |   | - Editor url test
 |   |    | - FAIL: Editor url test Should create hash
 |   |    | - FAIL: Editor url test History is handled consistently
```

calls to `JContent.visit` loads page builder by default but test is expecting list view instead. need to explicitly call `JContent.switchToListMode()`