### PR TITLE
BACKLOG-21438: Add tooltip to usages location

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/Picker/reactTable/columns/Cells.scss
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/reactTable/columns/Cells.scss
@@ -17,10 +17,14 @@
 
 div.cellTooltip {
     max-width: none;
-    background-color: var(--color-gray_light40);
-    color: var(--color-dark);
-    white-space: nowrap;
+
     font-size: 0.8rem;
+
+    color: var(--color-dark);
+
+    white-space: nowrap;
+
+    background-color: var(--color-gray_light40);
 }
 
 .badges {

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/reactTable/columns/Cells.scss
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/reactTable/columns/Cells.scss
@@ -15,6 +15,14 @@
     overflow: hidden;
 }
 
+div.cellTooltip {
+    max-width: none;
+    background-color: var(--color-gray_light40);
+    color: var(--color-dark);
+    white-space: nowrap;
+    font-size: 0.8rem;
+}
+
 .badges {
     & > div {
         margin-left: var(--spacing-nano);

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/reactTable/columns/LocationCell.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/reactTable/columns/LocationCell.jsx
@@ -2,6 +2,7 @@ import {Chip, TableBodyCell, Typography} from '@jahia/moonstone';
 import React from 'react';
 import {DisplayAction} from '@jahia/ui-extender';
 import {ButtonRendererNoLabel} from '~/ContentEditor/utils';
+import {Tooltip} from '@material-ui/core';
 import styles from './Cells.scss';
 import PropTypes from 'prop-types';
 import {useTranslation} from 'react-i18next';
@@ -17,7 +18,9 @@ export const LocationCell = ({row, column}) => {
     return (
         <TableBodyCell data-cm-role="location-cell" className={styles.cellLocation} width={column.width}>
             <div className={styles.location}>
-                <Typography className={styles.text} variant="body">{row.original.path}</Typography>
+                <Tooltip title={row.original.path} classes={{tooltip: styles.cellTooltip}}>
+                    <Typography isNowrap className={styles.text} variant="body">{row.original.path}</Typography>
+                </Tooltip>
                 <div className="flexFluid"/>
                 <div className={styles.badges}>
                     {sortedLanguages.map(l => <Chip key={l} color="accent" label={l}/>)}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21438

Add tooltip to location column in usages using material-ui. 

Note: I also see tooltips without usage of this Tooltip component (e.g. file name in `FileCard`) that I can't figure out, so I'm not sure if there is a different (better) way of implementing this that I'm missing.

