### PR TITLE
BACKLOG-21429: Fix delete modal loader overlay

### DIFF
--- a/src/javascript/JContent/actions/deleteActions/Delete/Delete.jsx
+++ b/src/javascript/JContent/actions/deleteActions/Delete/Delete.jsx
@@ -2,7 +2,7 @@ import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import {useTranslation} from 'react-i18next';
 import {Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle} from '@material-ui/core';
-import {Button} from '@jahia/moonstone';
+import {Button, Loader} from '@jahia/moonstone';
 import styles from './Delete.scss';
 import {useApolloClient, useMutation, useQuery} from '@apollo/client';
 import {useDispatch, useSelector} from 'react-redux';
@@ -17,7 +17,6 @@ import InfoTable from './InfoTable';
 import SvgInformation from '@jahia/moonstone/dist/icons/components/Information';
 import {Info} from '~/JContent/actions/deleteActions/Delete/Info';
 import {getName} from '~/JContent';
-import {TransparentLoaderOverlay} from '../../../TransparentLoaderOverlay';
 import {isPathChildOfAnotherPath} from '../../../JContent.utils';
 import {useNotifications} from '@jahia/react-material';
 import {cmRemoveSelection} from '~/JContent/redux/selection.redux';
@@ -66,7 +65,6 @@ const DeleteContent = ({data, onClose, isLoading, isMutationLoading, dialogType,
 
     return (
         <>
-            {isMutationLoading && <TransparentLoaderOverlay/>}
             <DialogTitle>
                 {t(`jcontent:label.contentManager.deleteAction.${dialogType}.title`)}
                 <Button className={styles.button}
@@ -77,16 +75,18 @@ const DeleteContent = ({data, onClose, isLoading, isMutationLoading, dialogType,
                         }}
                 />
             </DialogTitle>
-            <DialogContent>
-                <DialogContentText className={styles.content} dangerouslySetInnerHTML={{__html: label}}/>
-                {hasUsages && count === 1 &&
-                    <DialogContentText>{t('jcontent:label.contentManager.deleteAction.hasUsages.single')}</DialogContentText>}
-                {hasUsages && count > 1 &&
-                    <DialogContentText>{t('jcontent:label.contentManager.deleteAction.hasUsages.some')}</DialogContentText>}
-                {!hasUsages && usagesOverflow &&
-                    <DialogContentText>{t('jcontent:label.contentManager.deleteAction.hasUsages.tooMany')}</DialogContentText>}
-                {!locked && <InfoTable paths={paths} dialogType={dialogType}/>}
-            </DialogContent>
+            {isMutationLoading ?
+                <Loader size="big" style={{width: '100%'}}/> :
+                <DialogContent>
+                    <DialogContentText className={styles.content} dangerouslySetInnerHTML={{__html: label}}/>
+                    {hasUsages && count === 1 &&
+                        <DialogContentText>{t('jcontent:label.contentManager.deleteAction.hasUsages.single')}</DialogContentText>}
+                    {hasUsages && count > 1 &&
+                        <DialogContentText>{t('jcontent:label.contentManager.deleteAction.hasUsages.some')}</DialogContentText>}
+                    {!hasUsages && usagesOverflow &&
+                        <DialogContentText>{t('jcontent:label.contentManager.deleteAction.hasUsages.tooMany')}</DialogContentText>}
+                    {!locked && <InfoTable paths={paths} dialogType={dialogType}/>}
+                </DialogContent>}
             {(locked || isLoading || count === 0) ? (
                 <DialogActions>
                     <Button size="big"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21429

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Modify loader overlay to be able to click close button while loading