### PR TITLE
BACKLOG-20402: Add createChildrenDirectButtons.limit to configuration migration

### DIFF
--- a/src/main/resources/META-INF/patches/graphql/01-componentVisibility.started.graphql
+++ b/src/main/resources/META-INF/patches/graphql/01-componentVisibility.started.graphql
@@ -5,6 +5,7 @@ mutation {
                 pcHide: value(name:"hideLegacyPageComposer", value:"true")
                 pbShow: value(name:"showPageBuilder", value:"true")
                 catManShow: value(name:"showCatMan", value:"true")
+                newContentButtonLimit: value(name:"createChildrenDirectButtons.limit", value:"5")
             }
         }
     }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20402

## Description

Add `createChildrenDirectButtons.limit` to jcontent as it's been moved from content-editor configuration to jcontent during the merge

