### PR TITLE
BACKLOG-21017: Fix header stickiness on hover

### DIFF
--- a/src/javascript/JContent/EditFrame/Box.jsx
+++ b/src/javascript/JContent/EditFrame/Box.jsx
@@ -9,7 +9,6 @@ import editStyles from './EditFrame.scss';
 import {useNodeDrop} from '~/JContent/dnd/useNodeDrop';
 import {DefaultBar} from '~/JContent/EditFrame/DefaultBar';
 import {getCoords} from '~/JContent/EditFrame/EditFrame.utils';
-import {Portal} from './Portal';
 
 function getBoundingBox(element) {
     const rect = getCoords(element);
@@ -27,8 +26,6 @@ const reposition = function (element, currentOffset, setCurrentOffset) {
         setCurrentOffset(box);
     }
 };
-
-const HEADER_HEIGHT = 32;
 
 export const Box = React.memo(({
     node,
@@ -141,10 +138,7 @@ export const Box = React.memo(({
     const Bar = (customBarItem && customBarItem.component) || DefaultBar;
 
     // Display current header through portal to be able to always position it on top of existing selection(s)
-    const headerProps = isCurrent ? {
-        className: clsx(styles.absolute, 'flexRow_nowrap', 'alignCenter', editStyles.enablePointerEvents),
-        style: {...currentOffset, top: currentOffset.top - HEADER_HEIGHT, height: HEADER_HEIGHT}
-    } : {
+    const headerProps = {
         className: clsx(styles.sticky, 'flexRow_nowrap', 'alignCenter', editStyles.enablePointerEvents)
     };
     const Header = (
@@ -168,15 +162,13 @@ export const Box = React.memo(({
         </div>
     );
 
-    const ResolvedHeader = isCurrent ? <Portal target={rootElementRef.current}>{Header}</Portal> : Header;
-
     return (
         <div ref={rootDiv}
              className={styles.root}
              style={currentOffset}
         >
             <div className={clsx(styles.rel, isHeaderDisplayed ? styles.relHeader : styles.relNoHeader)}>
-                {isHeaderDisplayed && ResolvedHeader}
+                {isHeaderDisplayed && Header}
             </div>
         </div>
     );


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21017

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Remove `position: absolute` styling to make sticky header behave properly. 

Clarified requirement that current header does NOT need to be on top of existing selection (it should be other way around), so we should be ok without absolute styling