### PR TITLE
BACKLOG-21414:  Remove deprecated showPageComposer and showCatMan properties

### DIFF
--- a/src/javascript/ContentEditor/actions/registerEditActions.js
+++ b/src/javascript/ContentEditor/actions/registerEditActions.js
@@ -10,13 +10,12 @@ import {booleanValue} from '~/ContentEditor/SelectorTypes/Picker/Picker.utils';
 
 export const registerEditActions = actionsRegistry => {
     const showPageBuilder = booleanValue(contextJsParameters.config.jcontent?.showPageBuilder);
-    const showCatMan = booleanValue(contextJsParameters.config.jcontent?.showCatMan);
 
     // Edit action button in JContent; need separate actions for content and pages
     actionsRegistry.add('action', 'edit', editContentAction, {
         buttonIcon: <Edit/>,
         buttonLabel: 'jcontent:label.contentEditor.edit.contentEdit',
-        targets: showPageBuilder || showCatMan ? ['contentActions:2', 'headerPrimaryActions:1.5', 'narrowHeaderMenu:1'] : ['contentActions:2', 'narrowHeaderMenu:1'],
+        targets: showPageBuilder ? ['contentActions:2', 'headerPrimaryActions:1.5', 'narrowHeaderMenu:1'] : ['contentActions:2', 'narrowHeaderMenu:1'],
         hideOnNodeTypes: ['jnt:virtualsite', 'jnt:page'], // For edit content
         requiredSitePermission: ['editAction'],
         getDisplayName: true

--- a/src/main/resources/META-INF/patches/graphql/01-componentVisibility.started.graphql
+++ b/src/main/resources/META-INF/patches/graphql/01-componentVisibility.started.graphql
@@ -4,8 +4,9 @@ mutation {
             configuration(pid:"org.jahia.modules.jcontent", updateOnly: true) {
                 pcHide: value(name:"hideLegacyPageComposer", value:"true")
                 pbShow: value(name:"showPageBuilder", value:"true")
-                catManShow: value(name:"showCatMan", value:"true")
                 newContentButtonLimit: value(name:"createChildrenDirectButtons.limit", value:"5")
+                removePcProp: remove(name:"showPageComposer")
+                removeCatManProp: remove(name:"showCatMan")
             }
         }
     }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21414
