### PR TITLE
BACKLOG-21440: Fix url rewrite regex

### DIFF
--- a/src/main/resources/META-INF/page-composer-overrideURLs.xml
+++ b/src/main/resources/META-INF/page-composer-overrideURLs.xml
@@ -6,7 +6,7 @@
     <rule>
         <name>jContent page builder from GWT page composer</name>
         <note>Redirects old /jahia/page-composer urls</note>
-        <from>^.*/jahia/page-composer/default/(.*)/sites/(.*)/(.*)/(.*)\..*$</from>
-        <to type="redirect">%{context-path}/jahia/jcontent/$2/$1/pages/$3/$4</to>
+        <from>^.*/jahia/page-composer/default/(.*)/sites/(.*?)/(.*)\..*$</from>
+        <to type="redirect">%{context-path}/jahia/jcontent/$2/$1/pages/$3</to>
     </rule>
 </urlrewrite>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21440

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

The regex group `.../sites/(.*)/(.*)/(.*)\..*$` is doing a greedy match on the first group, except for last two groups. https://docs.oracle.com/javase/tutorial/essential/regex/quant.html

This means for url like 
```[context-root]/jahia/page-composer/default/en/sites/digitall/home/about/leadership.html```

we have 
```
$2=digitall/home
$3=about
$4=leadership
```

 instead of expected 
```
$2=digitall
$3=home/about
$4=leadership
```

Use reluctant match `(.*?)` instead, and capture the rest of the path to `$3`. so now we have:

```
$2=digitall
$3=home/about/leadership
```