### PR TITLE
BACKLOG-21467: Make JContent 3.0 compatible 8.2 only, nightly uses matrix. Changes test-reports name

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   integration-tests-standalone:
-    name: Integration Tests (Standalone)
+    name: Integration Tests ${{ matrix.config_file }}
     runs-on: self-hosted
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jahia_image: ["jahia/jahia-ee:8", "jahia/jahia-ee-dev:8-SNAPSHOT"]
+        jahia_image: ["jahia/jahia-ee-dev:8-SNAPSHOT"]
+        config_file: [ "cypress.config-contentEditor.ts", "cypress.config-jcontent.ts", "cypress.config-menuActions.ts", "cypress.config-pickers.ts" ]
     timeout-minutes: 120
     steps:
       - uses: jahia/jahia-modules-action/helper@v2
@@ -28,6 +29,7 @@ jobs:
           jahia_image: ${{ matrix.jahia_image }}
           testrail_project: jContent Module
           tests_manifest: provisioning-manifest-snapshot.yml
+          tests_profile: ${{ matrix.config_file }}
           should_use_build_artifacts: false
           should_skip_artifacts: true
           should_skip_notifications: false
@@ -54,7 +56,7 @@ jobs:
         uses: dorny/test-reporter@v1
         if: success() || failure()
         with:
-          name: Tests Report (Standalone)
+          name: Tests Report ${{ matrix.config_file }}
           path: tests/artifacts/results/xml_reports/**/*.xml
           reporter: java-junit
           fail-on-error: 'false'

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -123,7 +123,7 @@ jobs:
         uses: dorny/test-reporter@v1
         if: success() || failure()
         with:
-          name: Tests Report (Standalone)
+          name: Tests Report ${{ matrix.config_file }}
           path: tests/artifacts/results/xml_reports/**/*.xml
           reporter: java-junit
           fail-on-error: 'false'

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -75,7 +75,7 @@ jobs:
           sonar_token: ${{ secrets.SONAR_TOKEN }}
 
   integration-tests-standalone:
-    name: Integration Tests (Standalone)
+    name: Integration Tests ${{ matrix.config_file }}
     needs: build
     runs-on: self-hosted
     strategy:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -99,7 +99,7 @@ jobs:
         uses: dorny/test-reporter@v1
         if: success() || failure()
         with:
-          name: Tests Report (Standalone)
+          name: Tests Report ${{ matrix.config_file }}
           path: tests/artifacts/results/xml_reports/**/*.xml
           reporter: java-junit
           fail-on-error: 'false'

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -53,7 +53,7 @@ jobs:
           sbom_artifacts: 'build-artifacts'
 
   integration-tests-standalone:
-    name: Integration Tests (Standalone)
+    name: Integration Tests ${{ matrix.config_file }}
     needs: build
     runs-on: self-hosted
     timeout-minutes: 45

--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
-                        <version>1.13.1</version>
+                        <version>1.12.1</version>
                         <executions>
                             <execution>
                                 <id>npm install node and npm</id>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.3.0</version>
+        <version>8.2.0.0-SNAPSHOT</version>
         <relativePath />
     </parent>
     <artifactId>jcontent</artifactId>
@@ -50,7 +50,6 @@
         <jahia-module-signature>MC0CFQCH4MIRz+IFeMQcaTYHhAP4kuSO4wIUCQYxyG5ObklzXeLFVTmenIhuWSE=</jahia-module-signature>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
         <jahia-depends>jahia-ui-root,app-shell=2.7,graphql-dxm-provider=2.20</jahia-depends>
-        <jahia-plugin-version>6.6</jahia-plugin-version>
         <import-package>
             com.fasterxml.jackson.annotation;version="[2.10,3)",
             com.fasterxml.jackson.databind;version="[2.10,3)",
@@ -140,7 +139,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>graphql-dxm-provider</artifactId>
-            <version>2.7.0</version>
+            <version>2.20.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
@@ -188,7 +187,7 @@
         <dependency>
             <groupId>io.reactivex.rxjava2</groupId>
             <artifactId>rxjava</artifactId>
-            <version>2.1.5</version>
+            <version>2.2.21</version>
             <scope>provided</scope>
         </dependency>
 
@@ -410,7 +409,7 @@
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
-                        <version>1.12.1</version>
+                        <version>1.13.1</version>
                         <executions>
                             <execution>
                                 <id>npm install node and npm</id>

--- a/pom.xml
+++ b/pom.xml
@@ -233,16 +233,6 @@
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.jahia.server</groupId>
-                    <artifactId>jahia-maven-plugin</artifactId>
-                    <version>${jahia-plugin-version}</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-
         <plugins>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/StaticDefinitionsRegistry.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/StaticDefinitionsRegistry.java
@@ -28,7 +28,6 @@ import org.jahia.modules.contenteditor.api.forms.model.*;
 import org.jahia.modules.contenteditor.utils.ContentEditorUtils;
 import org.jahia.services.content.nodetypes.ExtendedNodeType;
 import org.jahia.services.content.nodetypes.NodeTypeRegistry;
-import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-2146

## Description

Make JContent 3.0 compatible 8.2 only, nightly uses matrix. Changes test-reports name


