### PR TITLE
BACKLOG-21400: Fixing selection behaviour

### DIFF
--- a/src/javascript/JContent/EditFrame/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes.jsx
@@ -122,6 +122,7 @@ export const Boxes = ({currentDocument, currentFrameRef, addIntervalCallback, on
             event.preventDefault();
             event.stopPropagation();
         }
+
         return false;
     }, [selection, currentDocument, dispatch]);
 

--- a/src/javascript/JContent/EditFrame/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/javascript/JContent/EditFrame/Breadcrumbs/Breadcrumbs.jsx
@@ -6,20 +6,20 @@ import {cmAddSelection, cmClearSelection, cmRemoveSelection} from '../../redux/s
 import {shallowEqual, useDispatch, useSelector} from 'react-redux';
 import {batchActions} from 'redux-batched-actions';
 
-const handleItemOnClick = (selection, n, dispatch) => {
+const handleItemOnClick = (selection, path, dispatch) => {
     return event => {
         event.preventDefault();
         event.stopPropagation();
+        const isSelected = selection.includes(path);
         // Meta key works without issues, ctrl key has a conflict with contextmenu
         if (event.ctrlKey || event.metaKey) {
-            const isSelected = selection.includes(n.path);
             if (isSelected) {
-                dispatch(cmRemoveSelection(n.path));
+                dispatch(cmRemoveSelection(path));
             } else {
-                dispatch(cmAddSelection(n.path));
+                dispatch(cmAddSelection(path));
             }
-        } else {
-            dispatch(batchActions([cmClearSelection(), cmAddSelection(n.path)]));
+        } else if (!isSelected) {
+            dispatch(batchActions([cmClearSelection(), cmAddSelection(path)]));
         }
 
         return false;
@@ -45,7 +45,7 @@ export const Breadcrumbs = ({nodes, responsiveMode}) => {
                       onChange={(e, v) => {
                           e.preventDefault();
                           e.stopPropagation();
-                          dispatch(cmAddSelection(v.value));
+                          handleItemOnClick(selection, v.value, dispatch)
                       }}
             />
         );
@@ -58,7 +58,7 @@ export const Breadcrumbs = ({nodes, responsiveMode}) => {
                                 label={n.name}
                                 icon={<img alt={n.name}
                                            src={`${window.contextJsParameters.contextPath}${n.primaryNodeType.icon}.png`}/>}
-                                onClick={handleItemOnClick(selection, n, dispatch)}
+                                onClick={handleItemOnClick(selection, n.path, dispatch)}
                 />
             ))}
         </Breadcrumb>

--- a/src/javascript/JContent/EditFrame/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/javascript/JContent/EditFrame/Breadcrumbs/Breadcrumbs.jsx
@@ -45,7 +45,7 @@ export const Breadcrumbs = ({nodes, responsiveMode}) => {
                       onChange={(e, v) => {
                           e.preventDefault();
                           e.stopPropagation();
-                          handleItemOnClick(selection, v.value, dispatch)
+                          handleItemOnClick(selection, v.value, dispatch);
                       }}
             />
         );

--- a/tests/cypress/e2e/jcontent/pageComposer.cy.ts
+++ b/tests/cypress/e2e/jcontent/pageComposer.cy.ts
@@ -1,6 +1,6 @@
 import {JContent, JContentPageBuilder} from '../../page-object';
 import {Dropdown, getComponentByRole} from '@jahia/cypress';
-import {ContentEditor} from '../../page-object/contentEditor';
+import {ContentEditor} from '../../page-object';
 
 describe('Page builder', () => {
     let jcontent: JContentPageBuilder;
@@ -196,21 +196,21 @@ describe('Page builder', () => {
         });
     });
 
-    describe('selection', function () {
+    describe.only('selection', function () {
         const item1 = '/sites/jcontentSite/home/area-main/test-content4';
         const item2 = '/sites/jcontentSite/home/area-main/test-content5';
         const item3 = '/sites/jcontentSite/home/area-main/lookForMeTag';
 
-        it('Selects and unselects one item', () => {
+        it('Selects and unselects one item when clicking outside the selected module', () => {
             cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
             const module = jcontent.getModule(item1);
             module.click();
             jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
-            module.click();
+            jcontent.switchToPageBuilder().iframe().get().click();
             cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
         });
 
-        it('Selects all items with meta key', () => {
+        it.only('Selects all items with meta key and deselect them with meta key', () => {
             cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
             let module = jcontent.getModule(item1);
             module.click({metaKey: true});
@@ -225,15 +225,15 @@ describe('Page builder', () => {
             jcontent.getSelectionDropdown().get().find('span').should('have.text', '3 items selected');
 
             // Unselect by clicking
-            module.click();
+            module.click({metaKey: true});
             jcontent.getSelectionDropdown().get().find('span').should('have.text', '2 items selected');
 
             module = jcontent.getModule(item2);
-            module.click();
+            module.click({metaKey: true});
             jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
 
             module = jcontent.getModule(item1);
-            module.click();
+            module.click({metaKey: true});
             cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
         });
 

--- a/tests/cypress/e2e/jcontent/pageComposer.cy.ts
+++ b/tests/cypress/e2e/jcontent/pageComposer.cy.ts
@@ -196,7 +196,7 @@ describe('Page builder', () => {
         });
     });
 
-    describe.only('selection', function () {
+    describe('selection', function () {
         const item1 = '/sites/jcontentSite/home/area-main/test-content4';
         const item2 = '/sites/jcontentSite/home/area-main/test-content5';
         const item3 = '/sites/jcontentSite/home/area-main/lookForMeTag';
@@ -210,7 +210,7 @@ describe('Page builder', () => {
             cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
         });
 
-        it.only('Selects all items with meta key and deselect them with meta key', () => {
+        it('Selects all items with meta key and deselect them with meta key', () => {
             cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
             let module = jcontent.getModule(item1);
             module.click({metaKey: true});

--- a/tests/cypress/e2e/jcontent/search.cy.ts
+++ b/tests/cypress/e2e/jcontent/search.cy.ts
@@ -113,7 +113,7 @@ describe('Search tests', () => {
         });
     });
 
-    describe.only('advanced search', {testIsolation: false}, () => {
+    describe('advanced search', {testIsolation: false}, () => {
         before(() => {
             cy.loginAndStoreSession();
             jcontent = JContent.visit('jcontentSite', 'en', 'content-folders/contents');

--- a/tests/cypress/e2e/jcontent/search.cy.ts
+++ b/tests/cypress/e2e/jcontent/search.cy.ts
@@ -113,7 +113,7 @@ describe('Search tests', () => {
         });
     });
 
-    describe('advanced search', {testIsolation: false}, () => {
+    describe.only('advanced search', {testIsolation: false}, () => {
         before(() => {
             cy.loginAndStoreSession();
             jcontent = JContent.visit('jcontentSite', 'en', 'content-folders/contents');
@@ -124,6 +124,7 @@ describe('Search tests', () => {
             basicSearch = jcontent.getBasicSearch().openSearch().switchToAdvanced()
                 .searchFrom('jnt:event')
                 .executeSearch()
+                .sortBy('name')
                 .verifyResults(['test-content5', 'test-content4'])
                 .verifyResultType('Event');
         });

--- a/tests/cypress/page-object/basicSearch.ts
+++ b/tests/cypress/page-object/basicSearch.ts
@@ -128,4 +128,9 @@ export class BasicSearch extends BasePage {
     close(): void {
         getComponentByRole(Button, 'close').click();
     }
+
+    sortBy(role: string): BasicSearch {
+        this.jcontent.getTable().getHeaderByRole(role).sort();
+        return this;
+    }
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21400

## Description

Fixing selection behaviour

As seen with @ffffffelix from now on clicking on a module/box will select it, clicking again will not unselect it.
To unselect you need to click outside the current selection
Only way to add/remove selection is to use the meta/ctrl key

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
