### PR TITLE
BACKLOG-21449: Filter out non-visible fields

### DIFF
--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
@@ -208,6 +208,9 @@ public class EditorFormServiceImpl implements EditorFormService {
                             }
                         }
                     }
+                    fieldSet.setFields(fieldSet.getFields().stream()
+                        .filter(Field::isVisible)
+                        .collect(Collectors.toList()));
 
                     fieldSet.setVisible(fieldSet.isVisible() && (fieldSet.isHasEnableSwitch() || fieldSet.getFields().stream().anyMatch(Field::isVisible)));
                 }
@@ -215,6 +218,7 @@ public class EditorFormServiceImpl implements EditorFormService {
                 // Remove empty fieldSets - only keep empty dynamic field set which do not have matching mixin in another section
                 // (if the dynamic mixin is present in multiple sections, keep only the non-empty ones)
                 section.setFieldSets(section.getFieldSets().stream()
+                    .filter(FieldSet::isVisible)
                     .filter(fs -> (fs.isDynamic() && fieldSetsMap.get(fs.getName()).size() == 1) || !fs.getFields().isEmpty())
                     .collect(Collectors.toList()));
 
@@ -223,6 +227,7 @@ public class EditorFormServiceImpl implements EditorFormService {
 
             // Remove empty sections
             form.setSections(form.getSections().stream()
+                .filter(Section::isVisible)
                 .filter(s -> !s.getFieldSets().isEmpty())
                 .collect(Collectors.toList()));
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21449

## Description

Performance issue is due to a bigger result in the api call - because we were returning all fields/fieldset/sections that are not "visible". Note that not-visible item cannot appear in the form - either because it's set to "hide" in an override, or because the user is not allowed to see it. Dynamic mixin, even if not displayed, are "visible".
The only possible issue is if some custom code tries to move a visible field from a non-visible section/fieldset to a visible section/fieldset, but that should actually not be possible - and it was already the case in previous content-editor.