### PR TITLE
BACKLOG-21523: Add z-index for page builder create buttons

### DIFF
--- a/src/javascript/JContent/EditFrame/Create.scss
+++ b/src/javascript/JContent/EditFrame/Create.scss
@@ -17,6 +17,8 @@
         flex: 1;
         overflow: hidden;
 
+        z-index: 10000;
+
         margin: 0 4px;
 
         & > svg {

--- a/src/javascript/JContent/EditFrame/Create.scss
+++ b/src/javascript/JContent/EditFrame/Create.scss
@@ -14,10 +14,10 @@
     flex-wrap: nowrap;
 
     & > button {
+        z-index: 10000;
+
         flex: 1;
         overflow: hidden;
-
-        z-index: 10000;
 
         margin: 0 4px;
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21523

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Add a high index for create buttons in page builder to override (hopefully) any template stylings.

In this case, `templates-web-blue` had a `#content` z-index of 700 which was preventing clicking on the create button in page builder.

