### PR TITLE
BACKLOG-21535: Restore page composer label

### DIFF
--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -293,6 +293,7 @@
       },
       "actions": {
         "openInJContent": "In einem neuen Tab öffnen",
+        "pageComposer": "Im Page Composer öffnen",
         "error": {
           "loading": "Fehler beim Abrufen der Aktionsdaten: {{details}}"
         },

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -296,6 +296,7 @@
       },
       "actions": {
         "openInJContent": "Open in a new tab",
+        "pageComposer": "Open in Page Composer",
         "error": {
           "loading": "Error retrieving action data: {{details}}"
         },

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -293,6 +293,7 @@
       },
       "actions": {
         "openInJContent": "Ouvrir dans un nouvel onglet",
+        "pageComposer": "Ouvrir dans Page Composer",
         "error": {
           "loading": "Erreur lors de l'extraction des données d'action: {{details}}"
         },


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21535

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Restore page composer action labels from https://github.com/Jahia/jcontent/pull/992 