### PR TITLE
BACKLOG-21534 Allow for always present field set, add test

### DIFF
--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
@@ -218,8 +218,8 @@ public class EditorFormServiceImpl implements EditorFormService {
                 // Remove empty fieldSets - only keep empty dynamic field set which do not have matching mixin in another section
                 // (if the dynamic mixin is present in multiple sections, keep only the non-empty ones)
                 section.setFieldSets(section.getFieldSets().stream()
-                    .filter(FieldSet::isVisible)
-                    .filter(fs -> (fs.isDynamic() && fieldSetsMap.get(fs.getName()).size() == 1) || !fs.getFields().isEmpty())
+                    .filter(fs -> fs.isAlwaysPresent() != null && fs.isAlwaysPresent() || fs.isVisible())
+                    .filter(fs -> (fs.isDynamic() && fieldSetsMap.get(fs.getName()).size() == 1) || !fs.getFields().isEmpty() || (fs.isAlwaysPresent() != null && fs.isAlwaysPresent()))
                     .collect(Collectors.toList()));
 
                 section.setVisible(section.isVisible() && section.getFieldSets().stream().anyMatch(FieldSet::isVisible));

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/model/FieldSet.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/model/FieldSet.java
@@ -38,6 +38,8 @@ public class FieldSet implements DefinitionRegistryItem, Ranked {
     private boolean hasEnableSwitch = false;
     private boolean activated = true;
     private boolean visible = true;
+    // Fieldset will be included in section even if it is invisible
+    private Boolean alwaysPresent;
 
     public String getName() {
         return name;
@@ -182,6 +184,14 @@ public class FieldSet implements DefinitionRegistryItem, Ranked {
         this.visible = visible;
     }
 
+    public Boolean isAlwaysPresent() {
+        return alwaysPresent;
+    }
+
+    public void setAlwaysPresent(Boolean alwaysPresent) {
+        this.alwaysPresent = alwaysPresent;
+    }
+
     @JsonIgnore
     public ExtendedNodeType getNodeType() {
         if (nodeType == null) {
@@ -229,7 +239,7 @@ public class FieldSet implements DefinitionRegistryItem, Ranked {
         setRequiredPermission(otherFieldSet.getRequiredPermission() != null ? otherFieldSet.getRequiredPermission() : requiredPermission);
         setHide(otherFieldSet.isHide() != null ? otherFieldSet.isHide() : hide);
         setRank(otherFieldSet.getRank() != null ? otherFieldSet.getRank() : rank);
-
+        setAlwaysPresent(otherFieldSet.isAlwaysPresent() != null ? otherFieldSet.isAlwaysPresent() : alwaysPresent);
         mergeFields(otherFieldSet.getFields(), form);
     }
 

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_createdFromPageModel.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_createdFromPageModel.json
@@ -1,0 +1,15 @@
+{
+  "nodeType": "jmix:createdFromPageModel",
+  "priority": 2.0,
+  "sections": [
+    {
+      "name": "content",
+      "fieldSets": [
+        {
+          "name": "jmix:createdFromPageModel",
+          "alwaysPresent": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/cypress/e2e/contentEditor/pageAsModel.cy.ts
+++ b/tests/cypress/e2e/contentEditor/pageAsModel.cy.ts
@@ -1,0 +1,43 @@
+import {ContentEditor, JContent} from '../../page-object';
+import {Field} from '../../page-object/fields';
+import {getComponentBySelector, Menu} from '@jahia/cypress';
+
+describe('Page as model', () => {
+    const siteKey = 'digitall';
+    const model = 'Testmodel';
+
+    beforeEach(() => {
+        cy.login(); // Edit in chief
+    });
+
+    afterEach(() => {
+        cy.logout();
+    });
+
+    it('Creates and uses page as model successfully', () => {
+        // Create model page
+        const jcontent = JContent.visit(siteKey, 'en', 'pages/home');
+        jcontent.getAccordionItem('pages').getTreeItem('home').contextMenu().select('New Page');
+        let contentEditor = ContentEditor.getContentEditor();
+        contentEditor.getSmallTextField('jnt:page_jcr:title').addNewValue('modeled-page');
+        let templateField = contentEditor.getField(Field, 'jmix:hasTemplateNode_j:templateName');
+        templateField.get().click();
+        getComponentBySelector(Menu, '[role="listbox"]').select('simple');
+        contentEditor.openSection('Options');
+        contentEditor.toggleOption('jmix:canBeUseAsTemplateModel', 'Page Model name');
+        cy.get('input[name="jmix:canBeUseAsTemplateModel_j:pageTemplateTitle"]').type(model);
+        contentEditor.create();
+
+        // Use page as model
+        jcontent.getAccordionItem('pages').getTreeItem('home').contextMenu().select('New Page');
+        contentEditor = ContentEditor.getContentEditor();
+        contentEditor.getSmallTextField('jnt:page_jcr:title').addNewValue('use-model');
+        templateField = contentEditor.getField(Field, 'jmix:hasTemplateNode_j:templateName');
+        templateField.get().click();
+        getComponentBySelector(Menu, '[role="listbox"]').select(model);
+        contentEditor.create();
+
+        const pageBuilder = jcontent.switchToPageBuilder();
+        pageBuilder.getModule('/sites/digitall/home/use-model/landing').should('exist');
+    });
+});


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21534

## Description

Allow for always present field set so that we can match a key in "values" with a fieldset name when deciding if mixin needs to be created or not.
 
Add test