### PR TITLE
BACKLOG-21532: Use separate report folders for each matrix test

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,8 +34,8 @@ jobs:
           should_skip_artifacts: true
           should_skip_notifications: false
           should_skip_testrail: false
-          should_skip_zencrepes: false
-          github_artifact_name: jcontent-standalone-artifacts-${{ github.run_number }}
+          github_artifact_name: jcontent-nightly-${{ matrix.config_file }}-${{ github.run_number }}
+          jahia_artifact_name: jcontent-nightly-${{ matrix.config_file }}-${{ github.run_number }}
           bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}
           jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}
           docker_username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -101,7 +101,8 @@ jobs:
           should_use_build_artifacts: true
           should_skip_testrail: true
           tests_profile: ${{ matrix.config_file }}
-          github_artifact_name: jcontent-standalone-artifacts-${{ github.run_number }}
+          github_artifact_name: jcontent-standalone-${{ matrix.config_file }}-${{ github.run_number }}
+          jahia_artifact_name: jcontent-standalone-${{ matrix.config_file }}-${{ github.run_number }}
           bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}
           jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}
           docker_username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -78,7 +78,8 @@ jobs:
           jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
           tests_profile: ${{ matrix.config_file }}
           should_use_build_artifacts: true
-          github_artifact_name: jcontent-standalone-${{ github.run_number }}
+          github_artifact_name: jcontent-standalone-${{ matrix.config_file }}-${{ github.run_number }}
+          jahia_artifact_name: jcontent-standalone-${{ matrix.config_file }}-${{ github.run_number }}
           bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}
           jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}
           docker_username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21532

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Github and QA CI artifacts are getting uploaded to the same folder and is overwriting reports.html across config file matrix, making the report showing only one of the config file matrix results at a time.

Use separate artifact folders for each matrix config instead.