### PR TITLE
QA-14986: Refresh publish info for context menu

### DIFF
--- a/src/javascript/JContent/actions/publishAction.jsx
+++ b/src/javascript/JContent/actions/publishAction.jsx
@@ -88,6 +88,8 @@ export const PublishActionComponent = props => {
     const languageToUse = useSelector(state => language ? language : state.language);
     const {t} = useTranslation('jcontent');
 
+    // Publication info needs to be refreshed in case subNodes have changed
+    const queryOptions = (publishType === 'publish') ? {fetchPolicy: 'cache-and-network'} : undefined;
     const res = useNodeChecks({path, paths, language: languageToUse}, {
         getDisplayName: true,
         getProperties: ['jcr:mixinTypes'],
@@ -96,7 +98,7 @@ export const PublishActionComponent = props => {
         getOperationSupport: true,
         getPermissions: ['publish', 'publication-start'],
         ...constraintsByType[publishType]
-    });
+    }, queryOptions);
 
     useEffect(() => {
         setRefetcher(id, {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14986

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Fix issue (workaround) of fetching publication info for a node where subnodes have been modified but somehow returning as published. Still unclear exactly what root cause is as the same fetch when initializing publishAction (for selection) returns correct data.

To minimize network calls I've tried to limit refresh only to publish type actions (not publishAll or unpublish).

Also unable to create cypress test for it as cypress hover doesn't seem to work when trying to navigate through context menu.
