### PR TITLE
QA-14986: Use network-only to refresh cache

### DIFF
--- a/src/javascript/JContent/actions/publishAction.jsx
+++ b/src/javascript/JContent/actions/publishAction.jsx
@@ -89,7 +89,7 @@ export const PublishActionComponent = props => {
     const {t} = useTranslation('jcontent');
 
     // Publication info needs to be refreshed in case subNodes have changed
-    const queryOptions = (publishType === 'publish') ? {fetchPolicy: 'cache-and-network'} : undefined;
+    const queryOptions = (publishType === 'publish') ? {fetchPolicy: 'network-only'} : undefined;
     const res = useNodeChecks({path, paths, language: languageToUse}, {
         getDisplayName: true,
         getProperties: ['jcr:mixinTypes'],


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14986

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

`cache-and-network` seems to be causing some flickering on the publish button when hovering over elements on page builder. 

Switch to `network-only` fetch policy