### PR TITLE
BACKLOG-21773 Fix crash when a parent for a placeholder couldn't be found

### DIFF
--- a/src/javascript/JContent/EditFrame/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes.jsx
@@ -171,7 +171,7 @@ export const Boxes = ({currentDocument, currentFrameRef, addIntervalCallback, on
                     if (parent) {
                         element.dataset.jahiaParent = parent.id;
                     } else {
-                        console.warn('Couldn\'t find parent element with jahiatype=module for element ',element);
+                        console.warn('Couldn\'t find parent element with jahiatype=module for element ', element);
                         placeholders.pop();
                     }
                 }

--- a/src/javascript/JContent/EditFrame/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes.jsx
@@ -164,11 +164,16 @@ export const Boxes = ({currentDocument, currentFrameRef, addIntervalCallback, on
                 let parent = element.dataset.jahiaParent && element.ownerDocument.getElementById(element.dataset.jahiaParent);
                 if (!parent) {
                     parent = element.parentElement;
-                    while (parent.getAttribute('jahiatype') !== 'module') {
+                    while (parent && parent.getAttribute('jahiatype') !== 'module') {
                         parent = parent.parentElement;
                     }
 
-                    element.dataset.jahiaParent = parent.id;
+                    if (parent) {
+                        element.dataset.jahiaParent = parent.id;
+                    } else {
+                        console.warn('Couldn\'t find parent element with jahiatype=module for element ',element);
+                        placeholders.pop();
+                    }
                 }
             }
         });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21773

## Description

This fix is there to help while developing templates. Currently, the npm-templates-web-blue are crashing because of this, rendering further development impossible.

