### PR TITLE
BACKLOG-21458: Add requireModuleInstalledOnSite accordion prop

### DIFF
--- a/src/javascript/JContent/ContentNavigation/ContentNavigation.container.jsx
+++ b/src/javascript/JContent/ContentNavigation/ContentNavigation.container.jsx
@@ -14,26 +14,28 @@ const ContentNavigationContainer = ({handleNavigationAction, selector, accordion
     let accordionItems = getAccordionItems(accordionItemTarget, accordionItemProps);
 
     const sitePermissions = [...new Set(accordionItems.map(item => item.requiredSitePermission).filter(item => item !== undefined))];
-
-    const permissions = useNodeChecks({
+    const nodeChecks = useNodeChecks({
         path: `/sites/${siteKey}`,
         language: language
     }, {
-        requiredSitePermission: sitePermissions
+        requiredSitePermission: sitePermissions,
+        getSiteInstalledModules: true
     });
 
-    if (permissions.loading) {
+    if (nodeChecks.loading) {
         return null;
     }
 
-    accordionItems = sitePermissions.length === 0 ? accordionItems : accordionItems.filter(accordionItem =>
-        permissions.node && Object.prototype.hasOwnProperty.call(permissions.node.site, accordionItem.requiredSitePermission) && permissions.node.site[accordionItem.requiredSitePermission]
-    );
+    const installedModulesOnSite = new Set(nodeChecks.node?.site?.installedModulesWithAllDependencies);
+    const enabledAccordionItems = accordionItems
+        .filter(accordionItem => !accordionItem.requiredSitePermission || Boolean(nodeChecks.node?.site?.[accordionItem.requiredSitePermission]))
+        .filter(accordionItem => !accordionItem.requireModuleInstalledOnSite || installedModulesOnSite.has(accordionItem.requireModuleInstalledOnSite))
+        .filter(accordionItem => !accordionItem.isEnabled || accordionItem.isEnabled(siteKey))
 
     return (
         <ContentNavigation header={header}
                            accordionItemTarget={accordionItemTarget}
-                           accordionItems={accordionItems}
+                           accordionItems={enabledAccordionItems}
                            mode={mode}
                            siteKey={siteKey}
                            isReversed={isReversed}

--- a/src/javascript/JContent/ContentNavigation/ContentNavigation.container.jsx
+++ b/src/javascript/JContent/ContentNavigation/ContentNavigation.container.jsx
@@ -30,7 +30,7 @@ const ContentNavigationContainer = ({handleNavigationAction, selector, accordion
     const enabledAccordionItems = accordionItems
         .filter(accordionItem => !accordionItem.requiredSitePermission || Boolean(nodeChecks.node?.site?.[accordionItem.requiredSitePermission]))
         .filter(accordionItem => !accordionItem.requireModuleInstalledOnSite || installedModulesOnSite.has(accordionItem.requireModuleInstalledOnSite))
-        .filter(accordionItem => !accordionItem.isEnabled || accordionItem.isEnabled(siteKey))
+        .filter(accordionItem => !accordionItem.isEnabled || accordionItem.isEnabled(siteKey));
 
     return (
         <ContentNavigation header={header}

--- a/src/javascript/JContent/ContentNavigation/ContentNavigation.jsx
+++ b/src/javascript/JContent/ContentNavigation/ContentNavigation.jsx
@@ -19,10 +19,9 @@ const ContentNavigation = ({accordionItems, accordionItemTarget, mode, siteKey, 
     };
 
     // If existing mode (excluding search) is not enabled, default to the first available accordion
-    const enabledAccordionItems = accordionItems.filter(accordionItem => !accordionItem.isEnabled || accordionItem.isEnabled(siteKey));
-    const modeEnabled = enabledAccordionItems.some(item => mode === item.key);
-    if (!modeEnabled && !mode.includes('search') && !mode.includes('sql2Search') && enabledAccordionItems.length > 0) {
-        onSetOpenedItem(enabledAccordionItems[0].key);
+    const modeEnabled = accordionItems.some(item => mode === item.key);
+    if (!modeEnabled && !mode.includes('search') && !mode.includes('sql2Search') && accordionItems.length > 0) {
+        onSetOpenedItem(accordionItems[0].key);
     }
 
     return (
@@ -34,7 +33,7 @@ const ContentNavigation = ({accordionItems, accordionItemTarget, mode, siteKey, 
                        openedItem={mode}
                        onSetOpenedItem={onSetOpenedItem}
             >
-                {enabledAccordionItems.map(accordionItem => {
+                {accordionItems.map(accordionItem => {
                     let props = {
                         id: accordionItem.key,
                         label: t(accordionItem.label),

--- a/src/javascript/JContent/ContentTree/ContentTree.jsx
+++ b/src/javascript/JContent/ContentTree/ContentTree.jsx
@@ -23,6 +23,7 @@ export const accordionPropType = PropTypes.shape({
     label: PropTypes.string.isRequired,
     getRootPath: PropTypes.func,
     requiredSitePermission: PropTypes.string.isRequired,
+    requireModuleInstalledOnSite: PropTypes.string,
     treeConfig: PropTypes.shape({
         hideRoot: PropTypes.bool,
         selectableTypes: PropTypes.arrayOf(PropTypes.string),

--- a/tests/cypress/e2e/jcontent/navigation.cy.ts
+++ b/tests/cypress/e2e/jcontent/navigation.cy.ts
@@ -1,9 +1,7 @@
-import {JContent, JContentPageBuilder} from "../../page-object";
-import {createSite, deleteSite, enableModule} from "@jahia/cypress";
-
+import {JContent, JContentPageBuilder} from '../../page-object';
+import {createSite, deleteSite, enableModule} from '@jahia/cypress';
 
 describe('Content navigation', () => {
-
     before(() => {
         createSite('mySite1');
         createSite('mySite2');
@@ -16,13 +14,12 @@ describe('Content navigation', () => {
     });
 
     beforeEach(() => {
-       cy.login();
+        cy.login();
     });
-
 
     it('Should display custom accordion when enabled on site', () => {
         const jcontent = JContent.visit('mySite1', 'en', 'pages/home');
-        // tests/jahia-module/jcontent-test-module/src/main/resources/javascript/apps/accordionConfig.js
+        // Tests/jahia-module/jcontent-test-module/src/main/resources/javascript/apps/accordionConfig.js
         jcontent.getAccordionItem('accordion-config').getHeader().should('be.visible');
     });
 

--- a/tests/cypress/e2e/jcontent/navigation.cy.ts
+++ b/tests/cypress/e2e/jcontent/navigation.cy.ts
@@ -1,0 +1,33 @@
+import {JContent, JContentPageBuilder} from "../../page-object";
+import {createSite, deleteSite, enableModule} from "@jahia/cypress";
+
+
+describe('Content navigation', () => {
+
+    before(() => {
+        createSite('mySite1');
+        createSite('mySite2');
+        enableModule('jcontent-test-module', 'mySite1');
+    });
+
+    after(() => {
+        deleteSite('mySite1');
+        deleteSite('mySite2');
+    });
+
+    beforeEach(() => {
+       cy.login();
+    });
+
+
+    it('Should display custom accordion when enabled on site', () => {
+        const jcontent = JContent.visit('mySite1', 'en', 'pages/home');
+        // tests/jahia-module/jcontent-test-module/src/main/resources/javascript/apps/accordionConfig.js
+        jcontent.getAccordionItem('accordion-config').getHeader().should('be.visible');
+    });
+
+    it('Should not display custom accordion when not enabled on site', () => {
+        const jcontent = JContent.visit('mySite2', 'en', 'pages/home');
+        jcontent.getAccordionItem('accordion-config').shouldNotExist();
+    });
+});

--- a/tests/cypress/page-object/accordionItem.ts
+++ b/tests/cypress/page-object/accordionItem.ts
@@ -15,8 +15,12 @@ export class AccordionItem {
         this.itemName = itemName;
     }
 
-    getHeader() {
-        return this.accordion.get().find(`section.moonstone-accordionItem header[aria-controls="${this.itemName}"]`);
+    getHeader(options?) {
+        return this.accordion.get().find(`section.moonstone-accordionItem header[aria-controls="${this.itemName}"]`, options);
+    }
+
+    shouldNotExist() {
+        return this.getHeader({timeout: 3000}).should('not.exist');
     }
 
     click() {

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/javascript/apps/accordionConfig.js
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/javascript/apps/accordionConfig.js
@@ -1,0 +1,17 @@
+window.jahia.i18n.loadNamespaces('accordion-config');
+
+window.jahia.uiExtender.registry.add('callback', 'accordion-config', {
+    targets: ['jahiaApp-init:60'],
+    callback: function () {
+        const pageAccordion = window.jahia.uiExtender.registry.get('accordionItem', 'pages');
+        window.jahia.uiExtender.registry.add('accordionItem', 'accordion-config', pageAccordion, {
+            targets: ['jcontent:998'],
+            label: 'test1',
+            icon: window.jahia.moonstone.toIconComponent('<svg style="width:24px;height:24px" viewBox="0 0 24 24"><path fill="currentColor" d="M19 6V5A2 2 0 0 0 17 3H15A2 2 0 0 0 13 5V6H11V5A2 2 0 0 0 9 3H7A2 2 0 0 0 5 5V6H3V20H21V6M19 18H5V8H19Z" /></svg>'),
+            requireModuleInstalledOnSite: 'jcontent-test-module',
+            isEnabled: function(siteKey) {
+                return siteKey !== 'systemsite'
+            }
+        });
+    }
+});

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/javascript/apps/jahia.json
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/javascript/apps/jahia.json
@@ -1,0 +1,7 @@
+{
+  "jahia": {
+    "apps": {
+      "jahia": "javascript/apps/accordionConfig.js"
+    }
+  }
+}

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/javascript/locales/en.json
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/javascript/locales/en.json
@@ -1,0 +1,13 @@
+{
+  "label": {
+    "settings": {
+      "title": "Accordion Config setting"
+    },
+    "action": {
+      "title": "Accordion Config - How to extend the ui ?"
+    },
+    "appsAccordion": {
+      "title": "Accordion Config"
+    }
+  }
+}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21458

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Add optional `requireModuleInstalledOnSite` prop in accordion config. If enabled, displays the accordion item only if specified module is enabled for the site.
- Refactor all enable checks for the accordions to `ContentNavigation.container.jsx`; moved `isEnabled` check from `ContentNavigation.jsx`
- Add cypress test for new property