### PR TITLE
Fix months and day to 2 digit

### DIFF
--- a/tests/cypress/page-object/fields/dateField.ts
+++ b/tests/cypress/page-object/fields/dateField.ts
@@ -12,14 +12,19 @@ export class DateField extends Field {
         this.get().find('button').click();
     }
 
+    public close() {
+        cy.get('.DayPicker').parent().parent().parent().click({waitForAnimations: true, multiple: true});
+        cy.get('.DayPicker').should('not.exist');
+    }
+
     pickTodayDate() {
         this.open();
         cy.get('.DayPicker-Day--today').click();
-        cy.get('body').click();
+        this.close();
     }
 
     select({month = null, year = null, date = null, time = null}) {
-        this.get().find('button').click();
+        this.open();
         if (month) {
             cy.get('.DayPicker').find('#select-month').click();
             cy.get('#menu-month').find(`[data-value=${month}]`).click();
@@ -38,7 +43,7 @@ export class DateField extends Field {
             cy.get('.TimePicker').contains(time).click();
         }
 
-        cy.get('body').click();
+        this.close();
     }
 
     getTodayDate(): string {

--- a/tests/cypress/page-object/fields/dateField.ts
+++ b/tests/cypress/page-object/fields/dateField.ts
@@ -47,7 +47,11 @@ export class DateField extends Field {
         const month = date.getMonth();
         const year = date.getFullYear();
 
-        return new Date(year, month, day).toLocaleDateString();
+        return new Date(year, month, day).toLocaleDateString(undefined, {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit'
+        });
     }
 
     checkValue(expectedValue: string) {


### PR DESCRIPTION
Issue with date comparison, fixing the test  

AssertionError: Timed out retrying after 60000ms: expected '<input#qant:pickers_datepicker.jss118.jss124>' to have value '12/1/2023', but the value was '12/01/2023'