### PR TITLE
BACKLOG-21949 Remove jmix:mainResource from selectableTypes

### DIFF
--- a/src/javascript/JContent/JContent.accordion-items.jsx
+++ b/src/javascript/JContent/JContent.accordion-items.jsx
@@ -129,7 +129,7 @@ export const jContentAccordionItems = registry => {
         requiredSitePermission: JContentConstants.accordionPermissions.pagesAccordionAccess,
         treeConfig: {
             hideRoot: true,
-            selectableTypes: ['jnt:page', 'jnt:virtualsite', 'jnt:externalLink', 'jnt:nodeLink', 'jnt:navMenuText', 'jmix:visibleInPagesTree', 'jmix:mainResource'],
+            selectableTypes: ['jnt:page', 'jnt:virtualsite', 'jnt:externalLink', 'jnt:nodeLink', 'jnt:navMenuText', 'jmix:visibleInPagesTree'],
             openableTypes: ['jnt:page', 'jnt:virtualsite', 'jnt:navMenuText', 'jmix:visibleInPagesTree'],
             rootLabel: 'jcontent:label.contentManager.browsePages',
             dnd: {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21949

## Description

Remove jmix:mainResource from selectableTypes