### PR TITLE
BACKLOG-21892: Change label for language selector

### DIFF
--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.jsx
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.jsx
@@ -3,12 +3,14 @@ import {useTranslation} from 'react-i18next';
 import {shallowEqual, useDispatch, useSelector} from 'react-redux';
 import {useNotifications} from '@jahia/react-material';
 import {useSiteInfo} from '@jahia/data-helper';
-import {Dropdown, Typography} from '@jahia/moonstone';
+import {Dropdown, Pill} from '@jahia/moonstone';
 import styles from './LanguageSwitcher.scss';
 import {cmGoto} from '~/JContent/redux/JContent.redux';
 import PropTypes from 'prop-types';
+import {Tooltip} from '@material-ui/core';
+import clsx from 'clsx';
 
-const LanguageSwitcher = ({setLanguageAction, selector}) => {
+const LanguageSwitcher = ({setLanguageAction, selector, isFullDropdown}) => {
     const {siteKey, lang} = useSelector(selector, shallowEqual);
     const {siteInfo, error, loading} = useSiteInfo({siteKey, displayLanguage: lang});
     const {t} = useTranslation('jcontent');
@@ -32,27 +34,40 @@ const LanguageSwitcher = ({setLanguageAction, selector}) => {
             <Dropdown isDisabled
                       data={[{label: 'none', value: 'none'}]}
                       className={styles.languageSwitcher}
-                      onChange={() => {
-                      }}
-            />
+                      onChange={() => {}}/>
         );
     }
 
-    const data = siteInfo.languages.filter(l => l.activeInEdit).map(l => ({label: l.language, value: l.language}));
+    const data = siteInfo.languages
+        .filter(l => l.activeInEdit)
+        .map(l => ({
+            label: l.localizedDisplayName,
+            value: l.language,
+            iconEnd: <Pill label={l.language}/>
+        }));
 
     if (!data) {
         return null;
     }
 
+    const selectedLang = data.find(l => l.value === lang);
+
+    const LabelPill = (
+        <Tooltip title={selectedLang.label} placement="bottom-start">
+            <Pill isReversed label={selectedLang.value}/>
+        </Tooltip>
+    );
+
     return (data.length === 1) ? (
         <div className={styles.label}>
-            <Typography isUpperCase variant="body">{lang}</Typography>
+            {LabelPill}
         </div>
     ) : (
         <Dropdown
+            className={clsx(styles.languageSwitcher, {[styles.fullWidth]: isFullDropdown})}
             data-cm-role="language-switcher"
-            className={styles.languageSwitcher}
-            label={lang}
+            icon={isFullDropdown ? undefined : LabelPill}
+            label={isFullDropdown ? undefined : ' '}
             value={lang}
             data={data}
             onChange={(e, item) => {
@@ -65,7 +80,8 @@ const LanguageSwitcher = ({setLanguageAction, selector}) => {
 
 LanguageSwitcher.propTypes = {
     setLanguageAction: PropTypes.func,
-    selector: PropTypes.func
+    selector: PropTypes.func,
+    isFullDropdown: PropTypes.bool
 };
 
 LanguageSwitcher.defaultProps = {

--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.jsx
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.jsx
@@ -50,7 +50,7 @@ const LanguageSwitcher = ({setLanguageAction, selector, isFullDropdown}) => {
         return null;
     }
 
-    const selectedLang = data.find(l => l.value === lang);
+    const selectedLang = data.find(l => l.value === lang) || {value: lang};
 
     const LabelPill = (
         <Tooltip title={selectedLang.label} placement="bottom-start">

--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.scss
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.scss
@@ -1,10 +1,15 @@
 .languageSwitcher {
-    flex: 1;
+    justify-content: space-between;
 
-    text-transform: uppercase;
+    border-left: 1px solid var(--color-gray);
+}
+
+.languageSwitcher.fullWidth {
+    width: inherit;
 }
 
 .label {
-    display: flex;
-    align-items: center;
+    padding: var(--spacing-nano) var(--spacing-small);
+
+    border-left: 1px solid var(--color-gray);
 }

--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.spec.jsx
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/LanguageSwitcher.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {shallow} from '@jahia/test-framework';
+import {shallow, mount} from '@jahia/test-framework';
 import {useDispatch, useSelector} from 'react-redux';
 import LanguageSwitcher from './LanguageSwitcher';
 import {useSiteInfo} from '@jahia/data-helper';
@@ -24,7 +24,7 @@ describe('Language switcher test', () => {
     beforeEach(() => {
         siteInfo = {
             languages: [
-                {language: 'en', activeInEdit: true}
+                {language: 'en', localizedDisplayName: 'English', activeInEdit: true}
             ]
         };
         useSelector.mockImplementation(() => ({
@@ -39,16 +39,28 @@ describe('Language switcher test', () => {
 
         const cmp = shallow(<LanguageSwitcher/>);
         expect(cmp.find('Dropdown').exists()).toBeFalsy();
-        expect(cmp.find('Typography').exists()).toBeTruthy();
+        expect(cmp.find('Pill').exists()).toBeTruthy();
+        expect(cmp.find('Pill').dive().contains('en')).toBeTruthy();
     });
 
     it('should show language switcher in left nav with more than one language', () => {
         siteInfo.languages.push({language: 'fr-ca', activeInEdit: true});
         useSiteInfo.mockReturnValue({siteInfo});
 
-        const cmp = shallow(<LanguageSwitcher/>);
+        const cmp = mount(<LanguageSwitcher/>);
         expect(cmp.find('Dropdown').exists()).toBeTruthy();
-        expect(cmp.find('Typography').exists()).toBeFalsy();
+        expect(cmp.contains('en')).toBeTruthy();
+        expect(cmp.contains('English')).toBeFalsy();
+    });
+
+    it('should show full language text', () => {
+        siteInfo.languages.push({language: 'fr-ca', activeInEdit: true});
+        useSiteInfo.mockReturnValue({siteInfo});
+
+        const cmp = mount(<LanguageSwitcher isFullDropdown/>);
+        expect(cmp.find('Dropdown').exists()).toBeTruthy();
+        expect(cmp.contains('en')).toBeFalsy();
+        expect(cmp.contains('English')).toBeTruthy();
     });
 
     it('should show language label, not dropdown, in left nav with only one ACTIVE language', () => {
@@ -57,6 +69,6 @@ describe('Language switcher test', () => {
 
         const cmp = shallow(<LanguageSwitcher/>);
         expect(cmp.find('Dropdown').exists()).toBeFalsy();
-        expect(cmp.find('Typography').exists()).toBeTruthy();
+        expect(cmp.find('Pill').exists()).toBeTruthy();
     });
 });

--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SiteSwitcher.scss
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SiteSwitcher.scss
@@ -1,7 +1,5 @@
 .siteSwitcher {
-    flex: 3;
-
-    max-width: 180px;
+    flex: 1;
 
     text-transform: capitalize;
 }

--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SwitchersLayout.jsx
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SwitchersLayout.jsx
@@ -2,15 +2,18 @@ import React from 'react';
 import SiteSwitcher from './SiteSwitcher';
 import LanguageSwitcher from './LanguageSwitcher';
 import styles from './SwitchersLayout.scss';
-import {Separator} from '@jahia/moonstone';
 import PropTypes from 'prop-types';
 
 const SwitchersLayout = ({isDisplaySiteSwitcher, isDisplayLanguageSwitcher, languageSelector, setLanguageAction}) => {
     return (
         <div className={styles.root}>
             {isDisplaySiteSwitcher && <SiteSwitcher/>}
-            {isDisplaySiteSwitcher && isDisplayLanguageSwitcher && <Separator variant="vertical"/>}
-            {isDisplayLanguageSwitcher && <LanguageSwitcher setLanguageAction={setLanguageAction} selector={languageSelector}/>}
+            {isDisplayLanguageSwitcher && (
+                <LanguageSwitcher
+                    setLanguageAction={setLanguageAction}
+                    selector={languageSelector}
+                    isFullDropdown={!isDisplaySiteSwitcher}
+                />)}
         </div>
     );
 };

--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SwitchersLayout.scss
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SwitchersLayout.scss
@@ -1,5 +1,6 @@
 .root {
     display: flex;
+    align-items: center;
     width: inherit;
 
     background-color: var(--color-dark);


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21892

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

<img width="470" alt="image" src="https://github.com/Jahia/jcontent/assets/75278792/10a5c34c-ebd2-47a5-9a5c-a7c1394a5694">

- Add language labels with codes to language selector dropdown
- Use `Pill` (with tooltip) to display language code for selected value
- Use (localized) display language for selected value when in Category Manager
- Adapted jest tests for language selector