### PR TITLE
BACKLOG-21944: Firefox workaround to cancel DND operation when dragend event is lost or not sent

### DIFF
--- a/src/javascript/JContent/EditFrame/EditFrame.jsx
+++ b/src/javascript/JContent/EditFrame/EditFrame.jsx
@@ -7,7 +7,7 @@ import {
     registerContentModificationEventHandler,
     unregisterContentModificationEventHandler
 } from '~/JContent/eventHandlerRegistry';
-import {isDescendantOrSelf, extractPaths} from '~/JContent/JContent.utils';
+import {extractPaths, isDescendantOrSelf} from '~/JContent/JContent.utils';
 import {useApolloClient} from '@apollo/client';
 import {prefixCssSelectors} from './EditFrame.utils';
 import {Boxes} from './Boxes';
@@ -28,7 +28,7 @@ function addEventListeners(target, manager, iframeRef) {
         return;
     }
 
-    const {backend} = manager;
+    const {backend, monitor} = manager;
 
     target.addEventListener('dragover', () => {
         const clientRect = iframeRef.current.getBoundingClientRect();
@@ -47,6 +47,18 @@ function addEventListeners(target, manager, iframeRef) {
     target.addEventListener('dragover', backend.handleTopDragOverCapture, true);
     target.addEventListener('drop', backend.handleTopDrop);
     target.addEventListener('drop', backend.handleTopDropCapture, true);
+    target.addEventListener('mouseup', event => {
+        if (monitor.isDragging()) {
+            console.debug('Mouse up event happened while monitor is still dragging, cancelling previous DND operation', event, monitor.isDragging());
+            backend.handleTopDragEndCapture(event);
+        }
+    });
+    target.addEventListener('mousemove', event => {
+        if (monitor.isDragging() && event.buttons === 0) {
+            console.debug('Mouse move event happened while monitor is still dragging, cancelling previous DND operation', event, monitor.isDragging());
+            backend.handleTopDragEndCapture(event);
+        }
+    });
 }
 
 export const EditFrame = ({isPreview, isDeviceView}) => {


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21944

## Description

Issue seems to arise only Firefox (quite easily)

Issue really seems related to the browser more than our implementation or teh framework we use (still think dnd-kit might be better for this purpose vs react-dnd)

Workaround is as follow:
We register 2 extra event listener on mouse up and mouse move.
We use the DND monitoring to check if a dragging is still ongoing if yes we cancel the ongoing Drag if we receive mouse move and no button is pressed anymore or if we receive a mouse up (after a click)
The mouse move give the better user experience as it happens right away.

## Tests

Still no automated tests on DND


