### PR TITLE
BACKLOG-21998: Add pinned property when element is clicked in Page Builder

### DIFF
--- a/src/javascript/JContent/EditFrame/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes.jsx
@@ -94,9 +94,10 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
         const target = event.currentTarget;
         window.clearTimeout(timeout);
         timeout = window.setTimeout(() => {
-            let moduleElement = getModuleElement(currentDocument, target);
+            const moduleElement = getModuleElement(currentDocument, target);
             setCurrentElement(current => (
-                (current && current.breadcrumb && isDescendantOrSelf(moduleElement.getAttribute('path'), current.path)) ? current : {element: moduleElement, path: moduleElement.getAttribute('path')}
+                (current && (current.breadcrumb || current.pinned) && isDescendantOrSelf(moduleElement.getAttribute('path'), current.path)) ?
+                    current : {element: moduleElement, path: moduleElement.getAttribute('path')}
             ));
         }, 10);
     }, [setCurrentElement, currentDocument]);
@@ -150,6 +151,7 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
             if (isMultipleSelectionMode) {
                 onSelect(event);
             } else {
+                setCurrentElement(current => ({...current, pinned: true}));
                 setHeader(true);
             }
         } else if (event.detail === 2) {


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21998

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Add pinned property to clicked elements so that we keep current element when hovering over descendants (This is the same behavior as clicking an area from footer breadcrumb).

## Tests

Needs manual testing
