### PR TITLE
BACKLOG-21955: Do not display footer if not currently hovered, and display bigger header when hovered

### DIFF
--- a/src/javascript/JContent/EditFrame/Box.jsx
+++ b/src/javascript/JContent/EditFrame/Box.jsx
@@ -175,7 +175,7 @@ export const Box = React.memo(({
 
     // Display current header through portal to be able to always position it on top of existing selection(s)
     const headerProps = {
-        className: clsx(styles.sticky, 'flexRow_nowrap', 'alignCenter', editStyles.enablePointerEvents)
+        className: clsx(styles.sticky, 'flexRow_nowrap', 'alignCenter', editStyles.enablePointerEvents, isCurrent ? styles.bigheader : '')
     };
 
     const Header = (
@@ -195,7 +195,7 @@ export const Box = React.memo(({
         </div>
     );
 
-    const boxStyle = !isAnythingDragging && breadcrumbs.length > 0 ? styles.relHeaderAndFooter : styles.relHeader;
+    const boxStyle = !isAnythingDragging && isCurrent && breadcrumbs.length > 0 ? styles.relHeaderAndFooter : styles.relHeader;
 
     return (
         <div ref={rootDiv}
@@ -210,7 +210,7 @@ export const Box = React.memo(({
             >
                 {isHeaderDisplayed && Header}
 
-                {!isAnythingDragging && breadcrumbs.length > 0 &&
+                {!isAnythingDragging && isCurrent && breadcrumbs.length > 0 &&
                     <div className={clsx(styles.relFooter)}
                          data-current={isCurrent}
                          data-jahia-id={element.getAttribute('id')}

--- a/src/javascript/JContent/EditFrame/Box.scss
+++ b/src/javascript/JContent/EditFrame/Box.scss
@@ -80,6 +80,10 @@
     overflow: hidden;
 }
 
+.bigheader {
+    height: 48px;
+}
+
 .absolute {
     position: absolute;
     z-index: 15000;


### PR DESCRIPTION


<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21955

## Description

Do not render footer if mouse is not over the content
If mouse is over the content make the header 48px instead of 32px

