### PR TITLE
BACKLOG-22155: update the tests library version

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jahia/jcontent-cypress",
   "private": false,
-  "version": "3.0.0-tests.2",
+  "version": "3.0.0-tests.3",
   "scripts": {
     "instrument": "nyc instrument --compact=false cypress instrumented",
     "e2e:ci": "cypress run --browser chrome",


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-22155

Update the test library version to allow to use the lastest changes in the cypress tests of other modules