### PR TITLE
BACKLOG-22125 Hide 3dot actions for language visibility conditions

### DIFF
--- a/src/javascript/ContentEditor/editorTabs/AdvancedOptions/Visibility/Languages/Languages.jsx
+++ b/src/javascript/ContentEditor/editorTabs/AdvancedOptions/Visibility/Languages/Languages.jsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {useContentEditorContext, useContentEditorSectionContext} from '~/ContentEditor/contexts';
+import {useContentEditorSectionContext} from '~/ContentEditor/contexts';
 import styles from './Languages.scss';
 import stylesFieldset from '~/ContentEditor/editorTabs/EditPanelContent/FormBuilder/FieldSet/FieldSet.scss';
 import {Toggle} from '@jahia/design-system-kit';
@@ -32,7 +32,7 @@ const LanguageSection = ({fields}) => {
     return (
         <div className={stylesFieldset.fields}>
             {fields.map(field =>
-                <FieldContainer key={field.name} field={field}/>)}
+                <FieldContainer key={field.name} field={field} inputContext={{displayActions: false}}/>)}
         </div>
     );
 };
@@ -49,12 +49,11 @@ export const Languages = ({invalidLanguages}) => {
         displayLanguage: state.language,
         uiLanguage: state.uilang
     }), shallowEqual);
-    const {siteInfo, error, loading} = useSiteInfo({
+    const {error, loading} = useSiteInfo({
         siteKey: siteKey,
         displayLanguage: displayLanguage,
         uiLanguage: uiLanguage
     });
-    const {nodeData} = useContentEditorContext();
     const [activatedSection, setActivatedSection] = useState(invalidLanguages !== undefined && invalidLanguages.length > 0);
     const section = sections.filter(s => s.name === 'visibility');
     const fieldSets = filterRegularFieldSets(section[0].fieldSets);
@@ -66,7 +65,6 @@ export const Languages = ({invalidLanguages}) => {
         return null;
     }
 
-    console.log(siteInfo, nodeData);
     if (fieldSets.length === 0) {
         return null;
     }

--- a/tests/cypress/e2e/contentEditor/visibilityScreen.cy.ts
+++ b/tests/cypress/e2e/contentEditor/visibilityScreen.cy.ts
@@ -30,7 +30,6 @@ describe('Create content tests', () => {
         advancedOptions.switchToOption('Visibility');
         cy.get('[data-sel-role-dynamic-fieldset="jmix:i18n"]').should('not.exist');
         cy.get('[data-sel-role-dynamic-fieldset="jmix:conditionalVisibility"]').should('be.visible');
-        cy.get('[data-sel-role-dynamic-fieldset="jmix:channelSelection"]').should('be.visible');
         contentEditor.cancel();
     });
 

--- a/tests/provisioning-manifest-build.yml
+++ b/tests/provisioning-manifest-build.yml
@@ -1,7 +1,1 @@
-- addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/public/@snapshots@noreleases@id=JahiaPublicSnapshots'
-- installBundle:
-    - 'mvn:org.jahia.modules/channels'
-  autoStart: true
-  uninstallPreviousVersion: true
-
 - include: 'provisioning.yml'

--- a/tests/provisioning-manifest-build.yml
+++ b/tests/provisioning-manifest-build.yml
@@ -1,1 +1,7 @@
+- addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/public/@snapshots@noreleases@id=JahiaPublicSnapshots'
+- installBundle:
+    - 'mvn:org.jahia.modules/channels'
+  autoStart: true
+  uninstallPreviousVersion: true
+
 - include: 'provisioning.yml'


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22125

## Description

Hide 3dot actions for language visibility conditions

Figma mockup doesn't have 3dot menu and it would not be easy to change functionality of the one we have in place so that it can work well with inverted values.  