### PR TITLE
DMF-6204: check contentTypes when creating content to avoid issues

### DIFF
--- a/src/javascript/ContentEditor/registerLegacyGwt.jsx
+++ b/src/javascript/ContentEditor/registerLegacyGwt.jsx
@@ -71,7 +71,7 @@ export const registerLegacyGwt = registry => {
                 includeSubTypes,
                 name,
                 isFullscreen: false,
-                configName: contentTypes[0] === 'jnt:page' ? 'gwtcreatepage' : 'gwtcreate'
+                configName: contentTypes && contentTypes[0] === 'jnt:page' ? 'gwtcreatepage' : 'gwtcreate'
             });
         },
         delete: params => {


### PR DESCRIPTION
https://jira.jahia.org/browse/DMF-6204

Check if the contentTypes are not null before using them in the call to the legacy hook to open content editor.