### PR TITLE
BACKLOG-22192: Fix header blocking content issue

### DIFF
--- a/src/javascript/JContent/EditFrame/Box.jsx
+++ b/src/javascript/JContent/EditFrame/Box.jsx
@@ -175,7 +175,7 @@ export const Box = React.memo(({
 
     // Display current header through portal to be able to always position it on top of existing selection(s)
     const headerProps = {
-        className: clsx(styles.sticky, 'flexRow_nowrap', 'alignCenter', editStyles.enablePointerEvents, isCurrent ? styles.bigheader : '')
+        className: clsx(styles.sticky, 'flexRow_nowrap', 'alignCenter', editStyles.enablePointerEvents)
     };
 
     const Header = (

--- a/src/javascript/JContent/EditFrame/Box.scss
+++ b/src/javascript/JContent/EditFrame/Box.scss
@@ -80,10 +80,6 @@
     overflow: hidden;
 }
 
-.bigheader {
-    height: 48px;
-}
-
 .absolute {
     position: absolute;
     z-index: 15000;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22192

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Fix issue where header is blocking content due to bigger size when on focus/on hover.

Revert change from https://github.com/Jahia/jcontent/pull/1130 back to original size