### PR TITLE
reverse width and height in picker card

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/mediaPicker/useMediaPickerInputData.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/mediaPicker/useMediaPickerInputData.js
@@ -21,7 +21,7 @@ export const useMediaPickerInputData = uuids => {
     }
 
     const fieldData = data.jcr.result.map(imageData => {
-        const sizeInfo = (imageData.height && imageData.width) ? ` - ${parseInt(imageData.height.value, 10)}x${parseInt(imageData.width.value, 10)}px` : '';
+        const sizeInfo = (imageData.height && imageData.width) ? ` - ${parseInt(imageData.width.value, 10)}x${parseInt(imageData.height.value, 10)}px` : '';
         return {
             uuid: imageData.uuid,
             url: `${

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/mediaPicker/useMediaPickerInputData.spec.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/mediaPicker/useMediaPickerInputData.spec.js
@@ -69,7 +69,7 @@ describe('useMediaPickerInputData', () => {
             error: undefined,
             fieldData: [{
                 uuid: 'this-is-uuid',
-                info: 'image/jpeg - 1080x1920px',
+                info: 'image/jpeg - 1920x1080px',
                 name: 'a cake',
                 path: 'placeholder.jpg',
                 url: 'localContextPath/files/defaultplaceholder.jpg?lastModified=tomorrow&t=thumbnail2'


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->
https://jira.jahia.org/browse/BACKLOG-22200

## Description
Change the order height x width to width x height for the media Picker card
<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
