### PR TITLE
CI/CD: Fixed incorrect path in the HTML tests report

### DIFF
--- a/tests/cypress.config-categoryManager.ts
+++ b/tests/cypress.config-categoryManager.ts
@@ -2,5 +2,6 @@ import {defineConfig} from 'cypress';
 import {baseConfig} from './cypress.config.common';
 
 baseConfig.e2e.specPattern = ['cypress/e2e/jcontent/categoryManager.cy.ts'];
+baseConfig.videosFolder = './results/videos';
 
 export default defineConfig(baseConfig);

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,7 +8,7 @@
     "e2e:debug": "cypress open",
     "lint": "eslint . -c .eslintrc.json --ext .ts",
     "report:merge": "mochawesome-merge results/reports/mochawesome*.json > results/reports/report.json && rm results/reports/mochawesome*.json",
-    "report:html": "marge --inline results/reports/report.json --reportDir results/reports/",
+    "report:html": "marge results/reports/report.json --reportDir results --assetsDir results/assets",
     "build": "tsc -p ./lib-tsconfig.json",
     "publish-tests": "yarn version --prerelease --preid=tests && git push --follow-tags && npm publish --access public",
     "lint:js": "eslint --ext js,ts cypress",


### PR DESCRIPTION
This is a part of a change done in CE: https://github.com/Jahia/content-editor/commit/bec3ef0225c61b9832f73aa1366b1648461d9ebe#diff-c7273ca77f452520adba2dfb738cd146b83110e7faa7b861318e89b2b56b5d56

As-is, the videos can't load because the path is incorrect
![Screenshot 2024-01-15 at 15 10 28](https://github.com/Jahia/jcontent/assets/5667028/27adb95a-2d19-4d9b-b458-cb9985a0de40)
