### PR TITLE
DMF-6203: pass document element in contextual menu of page builder

### DIFF
--- a/src/javascript/JContent/EditFrame/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes.jsx
@@ -414,6 +414,7 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
             <ContextualMenu
                 setOpenRef={contextualMenu}
                 currentPath={currentPath}
+                documentElement={currentDocument.documentElement}
                 {...pathObject}
             />
 


### PR DESCRIPTION
https://jira.jahia.org/browse/DMF-6203

Pass document element to contextual menu of page builder in order to have document nodes in actions of the contextual menu