### PR TITLE
QA-14979 Do not check for undefined permissions

### DIFF
--- a/src/javascript/JContent.register.jsx
+++ b/src/javascript/JContent.register.jsx
@@ -48,7 +48,7 @@ export default function () {
             path: `/sites/${site}`,
             language: language
         }, {
-            requiredSitePermission: [...new Set(accordions.map(acc => acc.requiredSitePermission))],
+            requiredSitePermission: [...new Set(accordions.filter(acc => acc.requiredSitePermission).map(acc => acc.requiredSitePermission))],
             getSiteLanguages: true
         });
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14979

## Description

Do not check for undefined permissions

This makes it possible to have accordionItems without required permission and prevents jcontent from breaking silently if an item like that is registered.