### PR TITLE
QA-15097: Allow tree item collapse with selection

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Jahia/jahia-modules-action/static-analysis@v2
         with:
-          node_version: 14
           auditci_level: critical
           max_warning: 8
 
@@ -37,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 'lts/*'
       - name: Run yarn test
         shell: bash
         run: |

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/JahiaPicker/SelectionHandler.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/JahiaPicker/SelectionHandler.jsx
@@ -139,7 +139,6 @@ export const SelectionHandler = ({initialSelectedItem, site, pickerConfig, accor
             .filter(accordionItem => !accordionItem.isEnabled || accordionItem.isEnabled(newState.site));
         newState.modes = accordionItems.map(item => item.key);
 
-        newState.openPaths = [...new Set([...newState.openPaths, ...getDetailedPathArray(getPathWithoutFile(newState.path), newState.site)])];
         if (selectedNode && !previousState.current.isOpen) {
             newState.openPaths = [...new Set([...newState.openPaths, ...getDetailedPathArray(getPathWithoutFile(selectedNode.path), newState.site)])];
         }

--- a/tests/cypress/e2e/pickers/pickerTree.cy.ts
+++ b/tests/cypress/e2e/pickers/pickerTree.cy.ts
@@ -1,7 +1,7 @@
 import {contentTypes} from '../../fixtures/contentEditor/pickers/contentTypes';
 import {assertUtils} from '../../utils/assertUtils';
 import {JContent} from '../../page-object/jcontent';
-import {AccordionItem} from "../../page-object";
+import {AccordionItem} from '../../page-object';
 
 describe('Picker tests - Trees', () => {
     const siteKey = 'digitall';
@@ -101,8 +101,8 @@ describe('Picker tests - Trees', () => {
         picker.getGrid().getCardByName('fans-stadium.jpg').click();
 
         // Verify tree with selection can collapse
-        mediaAccordion.getTreeItem("images").collapse()
-        mediaAccordion.getTreeItem("images").should('attr', 'aria-expanded', 'false');
-        mediaAccordion.shouldNotHaveTreeItem("backgrounds");
+        mediaAccordion.getTreeItem('images').collapse();
+        mediaAccordion.getTreeItem('images').should('attr', 'aria-expanded', 'false');
+        mediaAccordion.shouldNotHaveTreeItem('backgrounds');
     });
 });

--- a/tests/cypress/e2e/pickers/pickerTree.cy.ts
+++ b/tests/cypress/e2e/pickers/pickerTree.cy.ts
@@ -1,6 +1,7 @@
 import {contentTypes} from '../../fixtures/contentEditor/pickers/contentTypes';
 import {assertUtils} from '../../utils/assertUtils';
 import {JContent} from '../../page-object/jcontent';
+import {AccordionItem} from "../../page-object";
 
 describe('Picker tests - Trees', () => {
     const siteKey = 'digitall';
@@ -87,5 +88,21 @@ describe('Picker tests - Trees', () => {
         picker.getTable().getRows(el => expect(el).to.have.length(1));
         picker.switchToSite('Digitall');
         picker.getTableRow('ce-picker-files').should('have.class', 'moonstone-TableRow-highlighted');
+    });
+
+    it('should be able to collapse tree with selection', () => {
+        const {typeName, fieldNodeType, multiple} = contentTypes.imagepicker;
+        const picker = jcontent.createContent(typeName)
+            .getPickerField(fieldNodeType, multiple)
+            .open();
+
+        const mediaAccordion: AccordionItem = picker.getAccordionItem('picker-media');
+        picker.navigateTo(mediaAccordion, 'files/images/backgrounds');
+        picker.getGrid().getCardByName('fans-stadium.jpg').click();
+
+        // Verify tree with selection can collapse
+        mediaAccordion.getTreeItem("images").collapse()
+        mediaAccordion.getTreeItem("images").should('attr', 'aria-expanded', 'false');
+        mediaAccordion.shouldNotHaveTreeItem("backgrounds");
     });
 });

--- a/tests/cypress/page-object/pickerGrid.ts
+++ b/tests/cypress/page-object/pickerGrid.ts
@@ -4,7 +4,6 @@ export class PickerGrid extends BaseComponent {
     getCardByName(name: string) {
         return getComponentBySelector(GridCard, `[data-sel-role-card="${name}"]`, this);
     }
-
 }
 
 export class GridCard extends BaseComponent {

--- a/tests/cypress/page-object/pickerGrid.ts
+++ b/tests/cypress/page-object/pickerGrid.ts
@@ -1,5 +1,17 @@
-import {BaseComponent} from '@jahia/cypress';
+import {BaseComponent, getComponentBySelector} from '@jahia/cypress';
 
 export class PickerGrid extends BaseComponent {
+    getCardByName(name: string) {
+        return getComponentBySelector(GridCard, `[data-sel-role-card="${name}"]`, this);
+    }
 
 }
+
+export class GridCard extends BaseComponent {
+    static defaultSelector = '[data-cm-role="grid-content-list-card"]';
+
+    click() {
+        return this.get().click();
+    }
+}
+


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-15097

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Enable collapse for tree item with selection by removing auto-expand on selection (if not first time opening pickers).

Added cypress test