### PR TITLE
BACKLOG-22397: Fix multiple refresh on create

### DIFF
--- a/src/javascript/ContentEditor/ContentEditorApi/ContentEditorModal.jsx
+++ b/src/javascript/ContentEditor/ContentEditorApi/ContentEditorModal.jsx
@@ -120,7 +120,7 @@ export const ContentEditorModal = ({editorConfig, updateEditorConfig, onExited})
             });
         } else if (!mergedConfig.isFullscreen) {
             if (newNode) {
-                Promise.all(window.contentModificationEventHandlers.map(handler => handler(newNode.uuid, newNode.path, newNode.path.split('/').pop(), 'update'))).then(() => {
+                Promise.all(window.contentModificationEventHandlers.map(handler => handler(newNode.uuid, newNode.path, newNode.path.split('/').pop(), 'create'))).then(() => {
                     // Otherwise refresh and close
                     updateEditorConfig({closed: true});
                 });

--- a/src/javascript/JContent/EditFrame/EditFrame.jsx
+++ b/src/javascript/JContent/EditFrame/EditFrame.jsx
@@ -147,7 +147,9 @@ export const EditFrame = ({isPreview, isDeviceView}) => {
         if (operation === 'create') {
             // Do nothing; refetcher should have been called already at this point
             return;
-        } else if (operation === 'delete') {
+        }
+
+        if (operation === 'delete') {
             // Clear cache entries for subnodes
             Object.keys(client.cache.idByPath)
                 .filter(p => isDescendantOrSelf(p, nodePath))

--- a/src/javascript/JContent/EditFrame/EditFrame.jsx
+++ b/src/javascript/JContent/EditFrame/EditFrame.jsx
@@ -145,7 +145,8 @@ export const EditFrame = ({isPreview, isDeviceView}) => {
         }
 
         if (operation === 'create') {
-            // Do nothing ?
+            // Do nothing; refetcher should have been called already at this point
+            return;
         } else if (operation === 'delete') {
             // Clear cache entries for subnodes
             Object.keys(client.cache.idByPath)


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22397

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Fix issue regarding multiple refreshes being triggered during create that is leading to concurrency issue when creating areas.

One is registered using new setRefetcher, and the other one using gwt contentModificationEventHandlers (both in EditFrame.jsx).

Remove refresh on contentModificationEventHandlers on create as setRefresher is already triggered beforehand.
