### PR TITLE
BACKLOG:22519: fixed translations in CE

### DIFF
--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -594,7 +594,8 @@
             "unknown": "Gesperrt: aus unbekanntem Grund"
           },
           "publish": {
-            "name": "Jetzt veröffentlichen",
+            "name": "Jetzt veröffentlichen - {{language}}",
+            "shortName": "Jetzt veröffentlichen",
             "namePolling": "Veröffentlichung",
             "success": "Veröffentlichung der Warteschlange hinzugefügt",
             "error": "Fehler während Veröffentlichung",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -597,7 +597,8 @@
             "unknown": "Verrouillé pour une raison inconnue"
           },
           "publish": {
-            "name": "Publier maintenant",
+            "name": "Publier maintenant - {{language}}",
+            "shortName": "Publier maintenant",
             "namePolling": "Publication",
             "success": "La publication a été ajoutée à la file d’attente",
             "error": "Erreur durant la publication",


### PR DESCRIPTION
## Description

I fixed the translations for the "publish" button in CE in French and German. It was appearing in English.