### PR TITLE
BACKLOG-22654: Add missing Maven server for the test module release

### DIFF
--- a/.github/maven.settings.xml
+++ b/.github/maven.settings.xml
@@ -60,6 +60,11 @@
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
         <server>
+            <id>jahia-releases</id>
+            <username>${env.NEXUS_USERNAME}</username>
+            <password>${env.NEXUS_PASSWORD}</password>
+        </server>
+        <server>
             <id>jahia-internal</id>
             <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22654

## Description

To fix this issue (seen [here](https://github.com/Jahia/jcontent/actions/runs/8798690144/job/24146218589#step:6:4189)): 
`Error:  Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:3.1.0:deploy (default-deploy) on project jcontent-test-module-root: Failed to deploy artifacts: Could not transfer artifact org.jahia.test:jcontent-test-module-root:pom:3.0.1 from/to jahia-releases (https://devtools.jahia.com/nexus/content/repositories/jahia-releases): status code: 401, reason phrase: Unauthorized (401) -> [Help 1]`