### PR TITLE
fix dirty image path encoded by ckeditor for image stored in jahia

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/RichText/RichText.utils.js
+++ b/src/javascript/ContentEditor/SelectorTypes/RichText/RichText.utils.js
@@ -41,8 +41,8 @@ export function getPickerValue(dialog) {
         const contentURL = new URL(valueInInput);
         return contentURL.toString();
     } catch {
-        return valueInInput.startsWith(contentPrefix) ?
+        return decodeURIComponent(valueInInput.startsWith(contentPrefix) ?
             valueInInput.substr(contentPrefix.length).slice(0, -('.html').length) :
-            valueInInput.substr(filePrefix.length);
+            valueInInput.substr(filePrefix.length));
     }
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22495

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
