### PR TITLE
QA-15105: Allow to render preview on nodes extending contentFolder or…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <properties>
         <jahia-module-type>system</jahia-module-type>
         <yarn.arguments>build:production</yarn.arguments>
-        <jahia-module-signature>MCwCFGjol1TMW5V7EhWYGhVM1EbAO+j5AhRhe9s36Wq3nn7GlQoDr8aPhpsJmg==</jahia-module-signature>
+        <jahia-module-signature>MCwCFANteBJXpTp76WmCH1Hln9Pn8SeRAhQ90nNM2Il+HLMzbU73RR07G5+wvg==</jahia-module-signature>
         <jahia-depends>jahia-ui-root</jahia-depends>
         <jahia-plugin-version>6.9</jahia-plugin-version>
     </properties>

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/Row.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/Row.jsx
@@ -50,13 +50,18 @@ export const Row = ({
         contextualMenu.current(event);
     };
 
+    function isSelectableForPreview() {
+        // Hide on page, virtualsite and navMenuText no matter what. Allow to render preview if the node extends contentFolder or folder
+        return !node.notSelectableForPreview && !['jnt:contentFolder', 'jnt:folder'].includes(node.primaryNodeType.name);
+    }
+
     return (
         <TableRow {...rowProps}
                   data-cm-role="table-content-list-row"
                   className={clsx(css.tableRow, (isCanDrop || isCanDropFile) && 'moonstone-drop_row', dragging && 'moonstone-drag')}
                   isHighlighted={isSelected}
                   onClick={() => {
-                      if (isPreviewOpened && !node.notSelectableForPreview) {
+                      if (isPreviewOpened && isSelectableForPreview()) {
                           setSelectedItemIndex(index);
                           onPreviewSelect(node.path);
                       }

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/Row.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/Row.jsx
@@ -52,7 +52,7 @@ export const Row = ({
 
     function isSelectableForPreview() {
         // Hide on page, virtualsite and navMenuText no matter what. Allow to render preview if the node extends contentFolder or folder
-        return !node.notSelectableForPreview && !['jnt:contentFolder', 'jnt:folder'].includes(node.primaryNodeType.name);
+        return node.notSelectableForPreview ? false : !['jnt:contentFolder', 'jnt:folder'].includes(node.primaryNodeType.name);
     }
 
     return (

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.jsx
@@ -60,6 +60,11 @@ export const FileCard = ({
     let encodedPath = node.path.replace(/[^/]/g, encodeURIComponent);
     let showSubNodes = node.primaryNodeType.name !== 'jnt:page' && node?.subNodes?.pageInfo?.totalCount > 0;
 
+    function isSelectableForPreview() {
+        // Hide on page, virtualsite and navMenuText no matter what. Allow to render preview if the node extends contentFolder or folder
+        return node.notSelectableForPreview ? false : !['jnt:contentFolder', 'jnt:folder'].includes(node.primaryNodeType.name);
+    }
+
     return (
         <div
             ref={ref}
@@ -81,7 +86,7 @@ export const FileCard = ({
                 }
             }}
             onClick={() => {
-                if (!node.notSelectableForPreview) {
+                if (isSelectableForPreview()) {
                     onPreviewSelect(node);
                 }
             }}

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.gql-queries.js
@@ -79,7 +79,7 @@ export const QueryHandlersFragments = {
                         value
                     }
                 }
-                notSelectableForPreview: isNodeType(type: {types:["jnt:page", "jnt:folder", "jnt:contentFolder"]})
+                notSelectableForPreview: isNodeType(type: {types: ["jnt:page", "jnt:virtualsite", "jnt:navMenuText"]})
                 site {
                     ...NodeCacheRequiredFields
                 }

--- a/src/javascript/JContent/actions/previewAction.jsx
+++ b/src/javascript/JContent/actions/previewAction.jsx
@@ -21,7 +21,7 @@ export const PreviewActionComponent = ({path, render: Render, loading: Loading, 
 
     function isVisible() {
         // Hide on page, virtualsite and navMenuText no matter what. Allow to render preview if the node extends contentFolder or folder
-        return res.checksResult || !['jnt:contentFolder', 'jnt:folder'].includes(res.node.primaryNodeType.name);
+        return res.checksResult ? !['jnt:contentFolder', 'jnt:folder'].includes(res.node.primaryNodeType?.name) : false;
     }
 
     return (

--- a/src/javascript/JContent/actions/previewAction.jsx
+++ b/src/javascript/JContent/actions/previewAction.jsx
@@ -11,7 +11,7 @@ export const PreviewActionComponent = ({path, render: Render, loading: Loading, 
     const res = useNodeChecks(
         {path},
         {
-            hideOnNodeTypes: ['jnt:page', 'jnt:folder', 'jnt:contentFolder', 'jnt:virtualsite', 'jnt:navMenuText']
+            hideOnNodeTypes: ['jnt:page', 'jnt:virtualsite', 'jnt:navMenuText']
         }
     );
 
@@ -19,11 +19,16 @@ export const PreviewActionComponent = ({path, render: Render, loading: Loading, 
         return (Loading && <Loading {...others}/>) || false;
     }
 
+    function isVisible() {
+        // Hide on page, virtualsite and navMenuText no matter what. Allow to render preview if the node extends contentFolder or folder
+        return res.checksResult || !['jnt:contentFolder', 'jnt:folder'].includes(res.node.primaryNodeType.name);
+    }
+
     return (
         <Render
             {...others}
-            isVisible={res.checksResult}
-            enabled={res.checksResult}
+            isVisible={isVisible()}
+            enabled={isVisible()}
             onClick={() => {
                 dispatch(cmSetPreviewSelection(path));
                 dispatch(cmSetPreviewState(CM_DRAWER_STATES.SHOW));

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM cypress/browsers:latest
 
-RUN apt-get update && apt-get install -y jq
+RUN apt-get update && apt-get install -y jq curl
 
 RUN adduser --disabled-password jahians
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/browsers:node-18.14.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
+FROM cypress/browsers:latest
 
 RUN apt-get update && apt-get install -y jq
 


### PR DESCRIPTION
… folder but deny for primary types

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

[QA-15105](https://jira.jahia.org/browse/QA-15105)

## Description

Hide preview only for primary type contentFolder and folder, not for nodes extending them as customers might have defined views
