### PR TITLE
BACKLOG-22393: Bump jcontent-test-template parent version

### DIFF
--- a/tests/jahia-module/jcontent-test-template/pom.xml
+++ b/tests/jahia-module/jcontent-test-template/pom.xml
@@ -52,7 +52,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.2.0.0</version>
     </parent>
     <groupId>org.jahia.test</groupId>
     <artifactId>jcontent-test-template</artifactId>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22393

## Description

Fix issue with latest publish: https://github.com/Jahia/jcontent/actions/runs/9082781908/job/24960422542#step:4:2563

```
[FATAL] Non-resolvable parent POM for org.jahia.test:jcontent-test-template:3.0.0-SNAPSHOT: 
The following artifacts could not be resolved: org.jahia.modules:jahia-modules:pom:8.2.0.0-SNAPSHOT (absent): 
Could not find artifact org.jahia.modules:jahia-modules:pom:8.2.0.0-SNAPSHOT in central 
(https://repo1.maven.org/maven2/) and 'parent.relativePath' points at wrong local POM @ line 52, column 13
```