### PR TITLE
QA-15037: Added "Delete (permanently)" option to auto-published nodes

### DIFF
--- a/src/javascript/JContent/actions/deleteActions/deletePermanentlyAction.jsx
+++ b/src/javascript/JContent/actions/deleteActions/deletePermanentlyAction.jsx
@@ -11,10 +11,15 @@ const checkActionOnNodes = res => {
     return res.nodes ? res.nodes.reduce((acc, node) => acc && checkAction(node), true) : true;
 };
 
-const checkAction = node => (node['jnt:category'] || node.primaryNodeType?.name === 'jnt:category') || (node.operationsSupport.markForDeletion &&
-    isMarkedForDeletion(node) &&
-    node.aggregatedPublicationInfo.publicationStatus === 'NOT_PUBLISHED' &&
-    (node.aggregatedPublicationInfo.existsInLive === undefined ? true : !node.aggregatedPublicationInfo.existsInLive));
+const checkAction = node => {
+    const isCategory = (node['jnt:category'] || node.primaryNodeType?.name === 'jnt:category');
+    const isMarkForDeletionAllowed = node.operationsSupport.markForDeletion &&
+        isMarkedForDeletion(node) &&
+        node.aggregatedPublicationInfo.publicationStatus === 'NOT_PUBLISHED' &&
+        (node.aggregatedPublicationInfo.existsInLive === undefined ? true : !node.aggregatedPublicationInfo.existsInLive);
+    const isAutoPublish = node['jmix:autoPublish'];
+    return isCategory || isMarkForDeletionAllowed || isAutoPublish;
+};
 
 export const DeletePermanentlyActionComponent = ({path, paths, buttonProps, onDeleted, render: Render, loading: Loading, ...others}) => {
     const componentRenderer = useContext(ComponentRendererContext);

--- a/tests/cypress/fixtures/jcontent/menuActions/createDeleteContent.graphql
+++ b/tests/cypress/fixtures/jcontent/menuActions/createDeleteContent.graphql
@@ -40,6 +40,12 @@ mutation createDeleteContent {
                             primaryNodeType: "jnt:contentReference"
                             properties: [{ name: "j:node", language: "en", value: "/sites/jContentSite-delete/contents/test-deleteContents/test-delete3", type: REFERENCE }]
                         }
+                        {
+                            name: "test-delete4-autopublish"
+                            primaryNodeType: "jnt:bigText"
+                            properties: [{ name: "text", language: "en", value: "test 4" }]
+                            mixins: ["jmix:autoPublish"]
+                        }
                     ]
                 ) {
                     uuid

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -24,6 +24,8 @@
  - moduleI18nRBAutocreatedString (string) = resourceBundle('kiss') autocreated internationalized
  - moduleClassInitString (string) = useClass(org.jahia.modules.textfieldinitializer.InitTextValue)
 
+[cent:testTextField] > jnt:content, mix:title, jmix:basicContent, jmix:editorialContent, jmix:autoPublish
+
 [cent:defaultValueTest] > jnt:content, jmix:basicContent, jmix:editorialContent, mix:title noquery
  - defaultString (string) = 'Default string'
  - defaultI18nString (string) = 'Default i18n string' internationalized


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-15037

## Description
This PR adds "Delete (permanently)" context menu option to auto published nodes in jContent.
<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [x] Unit Tests (Most changes _should_ have unit tests)
- [x] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [x] Migration
- [x] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
