### PR TITLE
QA-14806 - Disabled cache for delete actions to fix stale data

### DIFF
--- a/src/javascript/JContent/actions/deleteActions/deleteAction.jsx
+++ b/src/javascript/JContent/actions/deleteActions/deleteAction.jsx
@@ -24,6 +24,9 @@ export const DeleteActionComponent = ({path, paths, buttonProps, onDeleted, rend
             requiredPermission: ['jcr:removeNode'],
             hideOnNodeTypes: ['jnt:virtualsite', 'jmix:hideDeleteAction'],
             hideForPaths: [PATH_FILES_ITSELF, PATH_CONTENTS_ITSELF]
+        },
+        {
+            fetchPolicy: 'network-only'
         }
     );
 

--- a/src/javascript/JContent/actions/deleteActions/deletePermanentlyAction.jsx
+++ b/src/javascript/JContent/actions/deleteActions/deletePermanentlyAction.jsx
@@ -35,6 +35,9 @@ export const DeletePermanentlyActionComponent = ({path, paths, buttonProps, onDe
             requiredPermission: ['jcr:removeNode'],
             hideOnNodeTypes: ['jnt:virtualsite'],
             hideForPaths: [PATH_FILES_ITSELF, PATH_CONTENTS_ITSELF]
+        },
+        {
+            fetchPolicy: 'network-only'
         }
     );
 

--- a/src/javascript/JContent/actions/deleteActions/undeleteAction.jsx
+++ b/src/javascript/JContent/actions/deleteActions/undeleteAction.jsx
@@ -24,6 +24,9 @@ export const UndeleteActionComponent = ({path, paths, buttonProps, onDeleted, re
             requiredPermission: ['jcr:removeNode'],
             hideOnNodeTypes: ['jnt:virtualsite'],
             hideForPaths: [PATH_FILES_ITSELF, PATH_CONTENTS_ITSELF]
+        },
+        {
+            fetchPolicy: 'network-only'
         }
     );
 

--- a/src/javascript/JContent/actions/publishDeletionAction.jsx
+++ b/src/javascript/JContent/actions/publishDeletionAction.jsx
@@ -23,6 +23,8 @@ export const PublishDeletionActionComponent = ({path, paths, isAllSubTree, isPub
         getOperationSupport: true,
         requiredPermission: ['publish'],
         hideOnNodeTypes: ['jnt:virtualsite']
+    }, {
+        fetchPolicy: 'network-only'
     });
 
     if (res.loading) {

--- a/tests/cypress/e2e/menuActions/delete.cy.ts
+++ b/tests/cypress/e2e/menuActions/delete.cy.ts
@@ -446,4 +446,31 @@ describe('delete tests', () => {
         });
         jcontent.checkSelectionCount(0);
     });
+    it('allows to mark node for deletion and context menu updates', () => {
+        cy.log('Verify node exists before starting test');
+        cy.apollo({
+            query: gql`query { jcr { nodeByPath(path: "/sites/${siteKey}/contents/test-deleteContents/test-delete5") {uuid}}}`
+        }).should(resp => {
+            expect(resp?.data.jcr.nodeByPath).not.to.be.null;
+        });
+
+        cy.log('Try marking node for deletion');
+
+        const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents/test-deleteContents');
+
+        jcontent.getTable()
+            .getRowByLabel('test 5')
+            .contextMenu()
+            .select('Delete');
+
+        const dialogCss = '[data-sel-role="delete-mark-dialog"]';
+        cy.get(dialogCss)
+            .find('[data-sel-role="delete-mark-button"]')
+            .click();
+
+        cy.log('Verify context menu updates');
+        const contextMenu = jcontent.getTable().getRowByLabel('test 5').contextMenu();
+        contextMenu.shouldHaveItem('Undelete');
+        contextMenu.shouldHaveItem('Delete (permanently)');
+    });
 });

--- a/tests/cypress/fixtures/jcontent/menuActions/createDeleteContent.graphql
+++ b/tests/cypress/fixtures/jcontent/menuActions/createDeleteContent.graphql
@@ -46,6 +46,11 @@ mutation createDeleteContent {
                             properties: [{ name: "text", language: "en", value: "test 4" }]
                             mixins: ["jmix:autoPublish"]
                         }
+                        {
+                            name: "test-delete5"
+                            primaryNodeType: "jnt:bigText"
+                            properties: [{ name: "text", language: "en", value: "test 5" }]
+                        }
                     ]
                 ) {
                     uuid


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14806

## Description

This PR disables caching for delete context actions to get rid of the stale data problem.
<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [x] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [x] Migration
- [x] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
