### PR TITLE
QA-15042: Add cypress test for selecting jmix:mainResource as internal link target

### DIFF
--- a/tests/cypress/e2e/pickers/internalLinkPicker.cy.ts
+++ b/tests/cypress/e2e/pickers/internalLinkPicker.cy.ts
@@ -1,0 +1,71 @@
+import {ContentEditor, JContent} from '../../page-object';
+import {createSite, deleteSite, enableModule} from '@jahia/cypress';
+import gql from 'graphql-tag';
+
+describe('Internal link picker test', () => {
+    const siteKey = 'internalLinkPickerTest';
+
+    const createMainResource = gql`
+        mutation addMainResources {
+            jcr {
+                addMainResource: mutateNode(pathOrId: "/sites/${siteKey}/contents") {
+                    addChild(
+                        name: "parentMainResource"
+                        primaryNodeType: "cent:mainResourceLinkComponentTest"
+                        properties: [{name: "jcr:title", language: "en", value: "parentMainResource"}]
+                    ) {
+                        addChild(
+                            name: "mainResourceLinkTest"
+                            primaryNodeType: "cent:mainResourceLinkTest"
+                            properties: [{name: "jcr:title", language: "en", value: "mainResourceLinkTest"}]
+                        ) {
+                            uuid
+                        }
+                        uuid
+                    }
+                }
+                addInternalLink: mutateNode(pathOrId: "/sites/${siteKey}/home") {
+                    addChild(
+                        name: "myInternalLink"
+                        primaryNodeType: "jnt:nodeLink"
+                    ) {
+                        uuid
+                    }
+                }
+            }
+        }
+    `;
+
+    before(function () {
+        createSite(siteKey, {
+            templateSet: 'dx-base-demo-templates',
+            serverName: 'localhost',
+            locale: 'en'
+        });
+        enableModule('jcontent-test-module', siteKey);
+        cy.apollo({mutation: createMainResource});
+        cy.loginAndStoreSession(); // Edit in chief
+    });
+
+    after(function () {
+        deleteSite('externalPickerTest');
+    });
+
+    // Tests
+
+    it('should be able to pick jmix:mainResource as internal link', () => {
+        const jcontent = JContent.visit(siteKey, 'en', 'pages/home');
+        const pageAccordion = jcontent.getAccordionItem('pages');
+        pageAccordion.expandTreeItem('home');
+        pageAccordion.getTreeItem('myInternalLink').contextMenu().select('Edit');
+
+        const contentEditor = new ContentEditor();
+        cy.get('.moonstone-chip').contains('Internal Link');
+        const picker = contentEditor.getPickerField('jnt:nodeLink_j:node').open();
+        picker.selectTab('content');
+        picker.getTable().getRowByName('mainResourceLinkTest').get().click();
+        picker.select(); // This will fail without the fix
+
+        contentEditor.save();
+    });
+});

--- a/tests/cypress/e2e/pickers/internalLinkPicker.cy.ts
+++ b/tests/cypress/e2e/pickers/internalLinkPicker.cy.ts
@@ -48,7 +48,7 @@ describe('Internal link picker test', () => {
     });
 
     after(function () {
-        deleteSite('externalPickerTest');
+        deleteSite(siteKey);
     });
 
     // Tests

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -126,3 +126,8 @@
  extends = jnt:page, jnt:nodeLink, jnt:externalLink
  itemtype = content
  - locationValues (string, choicelist[locationValuesInitializer]) = 'default' noqueryorder nofulltext
+
+[cent:mainResourceLinkComponentTest] > jnt:content, jmix:basicContent, mix:title, jmix:editorialContent
+ + * (cent:mainResourceLinkTest) = cent:mainResourceLinkTest
+
+[cent:mainResourceLinkTest] > jnt:content, jmix:mainResource, mix:title, jmix:editorialContent


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-15042

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Fix is in https://github.com/Jahia/jahia-private/pull/2095 and https://github.com/Jahia/default/pull/89 but adding picker test in jcontent.