### PR TITLE
BACKLOG-22904: Fix publish job dependency on merge workflow

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -89,7 +89,7 @@ jobs:
 
   publish:
     name: Publish module
-    needs: [integration-tests-standalone]
+    needs: [build]
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/2_x'
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22904

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Use same workflow dependency as on master branch