### PR TITLE
QA-14852: Redirect to parent when navigation element does not exist

### DIFF
--- a/src/javascript/JContent/ContentTree/ContentTree.jsx
+++ b/src/javascript/JContent/ContentTree/ContentTree.jsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useRef, useCallback} from 'react';
 import PropTypes from 'prop-types';
 import {shallowEqual, useDispatch, useSelector} from 'react-redux';
-import {displayName, lockInfo, useTreeEntries} from '@jahia/data-helper';
+import {displayName, lockInfo, useNodeInfo, useTreeEntries} from '@jahia/data-helper';
 import {PickerItemsFragment} from './ContentTree.gql-fragments';
 import {TreeView} from '@jahia/moonstone';
 import {ContextualMenu} from '@jahia/ui-extender';
@@ -134,6 +134,7 @@ export const ContentTree = ({setPathAction, openPathAction, closePathAction, ite
         sortBy: item.treeConfig.sortBy
     };
 
+    const nodeInfo = useNodeInfo({path}, {getParent: true});
     const {treeEntries, refetch} = useTreeEntries(useTreeEntriesOptionsJson, {errorPolicy: 'all'});
 
     if (dataRef.current === null || treeEntries.length > 0) {
@@ -170,6 +171,9 @@ export const ContentTree = ({setPathAction, openPathAction, closePathAction, ite
 
     const highlightedItem = path && (!treeEntries.find(f => f.path === path)) && treeEntries.filter(f => path.startsWith(f.path)).slice(-1)[0];
     const highlighted = highlightedItem ? [highlightedItem.path] : [];
+    if (!nodeInfo.loading && !nodeInfo.node && highlightedItem?.path) {
+        dispatch((setPathAction(highlightedItem.path)));
+    }
 
     return (
         <React.Fragment>

--- a/tests/cypress.config.common.ts
+++ b/tests/cypress.config.common.ts
@@ -6,12 +6,12 @@ export const baseConfig = {
     pageLoadTimeout: 60000,
     requestTimeout: 60000,
     responseTimeout: 60000,
-    videoUploadOnPasses: false,
     reporter: 'cypress-multi-reporters',
     reporterOptions: {
         configFile: 'reporter-config.json'
     },
     screenshotsFolder: './results/screenshots',
+    video: true,
     videosFolder: './results/videos',
     viewportWidth: 1366,
     viewportHeight: 768,
@@ -30,6 +30,18 @@ export const baseConfig = {
                     }
 
                     return null;
+                }
+            });
+            on('after:spec', (spec, results) => {
+                if (results && results.video) {
+                    // Do we have failures for any retry attempts?
+                    const failures = results.tests.some(test =>
+                        test.attempts.some(attempt => attempt.state === 'failed')
+                    );
+                    if (!failures) {
+                        // Delete the video if the spec passed and no tests retried
+                        fs.unlinkSync(results.video);
+                    }
                 }
             });
             // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/tests/cypress/e2e/jcontent/publishAcrossViews.cy.ts
+++ b/tests/cypress/e2e/jcontent/publishAcrossViews.cy.ts
@@ -42,10 +42,6 @@ describe('Test the save publish buttons flow', () => {
         deleteUser(userName);
     });
 
-    const clickPublishNow = () => {
-        cy.get('#publishNowButton').should('be.visible').find('button').contains('Publish now').click();
-    };
-
     // Implement scenario from https://jira.jahia.org/browse/BACKLOG-21685
     it('Publish deletion in structured view', () => {
         cy.log('Login with editor in chief');
@@ -57,11 +53,11 @@ describe('Test the save publish buttons flow', () => {
         contentEditor.getRichTextField('jnt:bigText_text').type('Newly Created Content');
         contentEditor.create();
         jcontent.getHeaderActionButton('publish').should('exist').and('be.visible').click(); // Verify header is loaded first
-        clickPublishNow();
+        jcontent.clickPublishNow();
         jcontent.switchToListMode().getTable().getRowByLabel('Newly Created Content').contextMenu().select('Delete');
         getComponent(DeleteDialog).markForDeletion();
         jcontent.switchToStructuredView().getTable().selectRowByLabel('Newly Created Content');
         jcontent.getHeaderActionButton('publishDeletion').click();
-        clickPublishNow();
+        jcontent.clickPublishNow();
     });
 });

--- a/tests/cypress/e2e/menuActions/delete.cy.ts
+++ b/tests/cypress/e2e/menuActions/delete.cy.ts
@@ -406,6 +406,7 @@ describe('delete tests', () => {
             }`
         });
         const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents/test-deleteContents');
+        cy.get('.moonstone-header h1').contains('Test-deleteContents').should('be.visible');
         jcontent.getTable().getRowByLabel('test 2').contextMenu().should('contain', 'Delete');
         cy.get('.moonstone-menu_overlay').click();
         jcontent.getTable().getRowByLabel('test 1').contextMenu().should('not.contain', 'Delete');
@@ -415,6 +416,7 @@ describe('delete tests', () => {
         jcontent.getHeaderActionButton('paste').click();
         jcontent.getTable().getRowByLabel('test 1').contextMenu().should('contain', 'Delete');
     });
+
     it('allows to permanently delete an autopublished node', () => {
         cy.log('Verify autopublished node exists before starting test');
         cy.apollo({

--- a/tests/cypress/fixtures/jcontent/menuActions/createDeleteContent.graphql
+++ b/tests/cypress/fixtures/jcontent/menuActions/createDeleteContent.graphql
@@ -65,7 +65,7 @@ mutation createDeleteContent {
                     primaryNodeType: "jnt:page",
                     properties: [
                         { name: "jcr:title", language: "en", value: "Page test 1" },
-                        { name: "j:templateName", value: "default" }
+                        { name: "j:templateName", value: "home" }
                     ]
                     children: [
                         {
@@ -73,7 +73,7 @@ mutation createDeleteContent {
                             primaryNodeType: "jnt:page"
                             properties: [
                                 { name: "jcr:title", language: "en", value: "Subpage test 1" },
-                                { name: "j:templateName", value: "default" }
+                                { name: "j:templateName", value: "home" }
                             ]
                         }
                         {
@@ -81,7 +81,7 @@ mutation createDeleteContent {
                             primaryNodeType: "jnt:page"
                             properties: [
                                 { name: "jcr:title", language: "en", value: "Subpage test 2" },
-                                { name: "j:templateName", value: "default" }
+                                { name: "j:templateName", value: "home" }
                             ]
                         }
                     ]
@@ -91,7 +91,25 @@ mutation createDeleteContent {
                     primaryNodeType: "jnt:page"
                     properties: [
                         { name: "jcr:title", language: "en", value: "Page test 2" },
-                        { name: "j:templateName", value: "default" }
+                        { name: "j:templateName", value: "home" }
+                    ]
+                }
+                {
+                    name: "test-pageDelete3",
+                    primaryNodeType: "jnt:page",
+                    properties: [
+                        { name: "jcr:title", language: "en", value: "Page test 3" },
+                        { name: "j:templateName", value: "home" }
+                    ]
+                    children: [
+                        {
+                            name: "test-subpage3"
+                            primaryNodeType: "jnt:page"
+                            properties: [
+                                { name: "jcr:title", language: "en", value: "Subpage test 3" },
+                                { name: "j:templateName", value: "home" }
+                            ]
+                        }
                     ]
                 }
             ]) {

--- a/tests/cypress/page-object/jcontent.ts
+++ b/tests/cypress/page-object/jcontent.ts
@@ -205,7 +205,7 @@ export class JContent extends BasePage {
 
     clickPublishNow() {
         cy.get('#publishNowButton').should('be.visible').find('button').contains('Publish now').click();
-    };
+    }
 }
 
 export class JContentPageBuilder extends JContent {
@@ -261,7 +261,7 @@ export class JContentPageBuilder extends JContent {
         cy.get('#publishNowButton').should('be.visible')
             .find('button').contains('Publish now')
             .click();
-    };
+    }
 }
 
 class PageBuilderModuleHeader extends BaseComponent {

--- a/tests/cypress/page-object/jcontent.ts
+++ b/tests/cypress/page-object/jcontent.ts
@@ -202,6 +202,10 @@ export class JContent extends BasePage {
     getHeaderActionButton(role: string): Button {
         return getComponentBySelector(Button, `.moonstone-header button[data-sel-role="${role}"]`);
     }
+
+    clickPublishNow() {
+        cy.get('#publishNowButton').should('be.visible').find('button').contains('Publish now').click();
+    };
 }
 
 export class JContentPageBuilder extends JContent {
@@ -252,6 +256,12 @@ export class JContentPageBuilder extends JContent {
         });
         return this;
     }
+
+    clickPublishNow() {
+        cy.get('#publishNowButton').should('be.visible')
+            .find('button').contains('Publish now')
+            .click();
+    };
 }
 
 class PageBuilderModuleHeader extends BaseComponent {

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -47,12 +47,15 @@ if (Cypress.browser.family === 'chromium') {
 }
 
 Cypress.on('test:after:run', (test, runnable) => {
-    let videoName = Cypress.spec.relative;
-    videoName = videoName.replace('/.cy.*', '').replace('cypress/e2e/', '');
-    const videoUrl = 'videos/' + videoName + '.mp4';
-    addContext({test}, videoUrl);
+    // Add screenshots, video only for failed tests
     if (test.state === 'failed') {
-        const screenshot = `screenshots/${Cypress.spec.relative.replace('cypress/e2e/', '')}/${runnable.parent.title} -- ${test.title} (failed).png`;
-        addContext({test}, screenshot);
+        const videoFileName = Cypress.spec.relative
+            .replace('/.cy.*', '')
+            .replace('cypress/e2e/', '');
+        addContext({test}, `videos/${videoFileName}.mp4`);
+
+        const screenshotFolderName = Cypress.spec.relative.replace('cypress/e2e/', '');
+        const screenshotFileName = `${runnable.parent.title} -- ${test.title} (failed).png`;
+        addContext({test}, `screenshots/${screenshotFolderName}/${screenshotFileName}`);
     }
 });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14852

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Add a redirect to parent when a node selection in content tree navigation does not exist; Added cypress test for scenario

Also added some fixes to cypress delete test suite:
- speed up selection of pages - use tree nav to get to context menu instead of loading table view for pages
- Fix incorrect template name on created test pages; adjust tests
- Upload video recordings on test failures 