### PR TITLE
BACKLOG-23047: return value as boolean in checkAction on delete permanently

### DIFF
--- a/src/javascript/JContent/actions/deleteActions/deletePermanentlyAction.jsx
+++ b/src/javascript/JContent/actions/deleteActions/deletePermanentlyAction.jsx
@@ -18,7 +18,7 @@ const checkAction = node => {
         node.aggregatedPublicationInfo.publicationStatus === 'NOT_PUBLISHED' &&
         (node.aggregatedPublicationInfo.existsInLive === undefined ? true : !node.aggregatedPublicationInfo.existsInLive);
     const isAutoPublish = node['jmix:autoPublish'];
-    return isCategory || isMarkForDeletionAllowed || isAutoPublish;
+    return Boolean(isCategory || isMarkForDeletionAllowed || isAutoPublish);
 };
 
 export const DeletePermanentlyActionComponent = ({path, paths, buttonProps, onDeleted, render: Render, loading: Loading, ...others}) => {


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-23047

Returns the value of the checkAction as a boolean as isAutoPublish can be undefined when the node does not have the jmix:autoPublish property.
If it's the case checkAction returns undefined so isVisible will be equals to undefined and as isVisible is equals to undefined the button will be visible even if it should not.