### PR TITLE
BACKLOG-23059 Fixed permissions on lock context action

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@apollo/react-components": "^4.0.0",
     "@apollo/react-hoc": "^4.0.0",
     "@babel/polyfill": "^7.11.5",
-    "@jahia/data-helper": "^1.1.12",
+    "@jahia/data-helper": "^1.1.13",
     "@jahia/design-system-kit": "^1.1.8",
     "@jahia/icons": "^1.1.2",
     "@jahia/jahia-reporter": "^1.0.3",

--- a/src/javascript/JContent/actions/lockAction.jsx
+++ b/src/javascript/JContent/actions/lockAction.jsx
@@ -10,6 +10,7 @@ export const LockActionComponent = ({path, render: Render, loading: Loading, ...
         {path},
         {
             getLockInfo: true,
+            getCanLockUnlock: true,
             getOperationSupport: true,
             requiredPermission: 'jcr:lockManagement',
             hideOnNodeTypes: ['jnt:navMenuText', 'jnt:category'],
@@ -24,7 +25,8 @@ export const LockActionComponent = ({path, render: Render, loading: Loading, ...
     const isVisible = res.checksResult &&
         res.node.operationsSupport.lock &&
         res.node.lockTypes === null &&
-        (!res.node['jnt:page'] || res.node.lockPageAction);
+        (!res.node['jnt:page'] || res.node.lockPageAction) &&
+        res.node.lockInfo && res.node.lockInfo.canLock;
 
     return (
         <Render

--- a/src/javascript/JContent/actions/lockAction.jsx
+++ b/src/javascript/JContent/actions/lockAction.jsx
@@ -12,7 +12,8 @@ export const LockActionComponent = ({path, render: Render, loading: Loading, ...
             getLockInfo: true,
             getOperationSupport: true,
             requiredPermission: 'jcr:lockManagement',
-            hideOnNodeTypes: ['jnt:navMenuText', 'jnt:category']
+            hideOnNodeTypes: ['jnt:navMenuText', 'jnt:category'],
+            getPermissions: ['lockPageAction']
         }
     );
 
@@ -20,7 +21,10 @@ export const LockActionComponent = ({path, render: Render, loading: Loading, ...
         return (Loading && <Loading {...others}/>) || false;
     }
 
-    const isVisible = res.checksResult && res.node.operationsSupport.lock && res.node.lockTypes === null;
+    const isVisible = res.checksResult &&
+        res.node.operationsSupport.lock &&
+        res.node.lockTypes === null &&
+        (!res.node['jnt:page'] || res.node.lockPageAction);
 
     return (
         <Render

--- a/src/javascript/JContent/actions/unlockAction.jsx
+++ b/src/javascript/JContent/actions/unlockAction.jsx
@@ -10,6 +10,7 @@ export const UnlockActionComponent = ({path, render: Render, loading: Loading, .
         {path},
         {
             getLockInfo: true,
+            getCanLockUnlock: true,
             getOperationSupport: true,
             requiredPermission: 'jcr:lockManagement'
         }
@@ -19,7 +20,11 @@ export const UnlockActionComponent = ({path, render: Render, loading: Loading, .
         return (Loading && <Loading {...others}/>) || false;
     }
 
-    const isVisible = res.checksResult && res.node.operationsSupport.lock && res.node.lockTypes !== null && res.node.lockTypes.values.indexOf(' deletion :deletion') === -1;
+    const isVisible = res.checksResult &&
+        res.node.operationsSupport.lock &&
+        res.node.lockTypes !== null &&
+        res.node.lockTypes.values.indexOf(' deletion :deletion') === -1 &&
+        res.node.lockInfo && res.node.lockInfo.canUnlock;
 
     return (
         <Render

--- a/tests/cypress/fixtures/jcontent/menuActions/createLockContent.graphql
+++ b/tests/cypress/fixtures/jcontent/menuActions/createLockContent.graphql
@@ -25,6 +25,14 @@ mutation createLockContent {
                 {
                     name: "content-emptyFolderLock1"
                     primaryNodeType: "jnt:contentFolder"
+                },
+                {
+                    name: "content-lockPermissions1",
+                    primaryNodeType: "jnt:contentFolder",
+                },
+                {
+                    name: "content-lockPermissions2",
+                    primaryNodeType: "jnt:contentFolder",
                 }
             ]) {
                 uuid

--- a/yarn.lock
+++ b/yarn.lock
@@ -2478,10 +2478,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jahia/data-helper@^1.1.12":
-  version "1.1.12"
-  resolved "https://npm.jahia.com/@jahia%2fdata-helper/-/data-helper-1.1.12.tgz#3d7eee58a2617a0a083103e1bfd26c7b50a4d3ae"
-  integrity sha512-4o0QMLSnv07ADjwu2yxRJ7G5OVYLhcXDuTGyvOU6J3vBqi3iA5dwkC6F5z1vZ6pDn0dwj8V4qiA7tGa8ylixXg==
+"@jahia/data-helper@^1.1.13":
+  version "1.1.13"
+  resolved "https://npm.jahia.com/@jahia%2fdata-helper/-/data-helper-1.1.13.tgz#d02397fc6220c5e44bf59d5a17c0d44eadfdf8ce"
+  integrity sha512-4HtGh/8hZkpiqq5zyDOKegcq8Jl0o1oJlx7LkBFDFV2QLK1Sdgdpn1Q8JRh526Lxd7sQXyH2AMIEtFr3T0P2/Q==
   dependencies:
     "@apollo/client" "^3.7.14"
     "@apollo/react-components" "^4.0.0"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23059

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
This PR changes the lock and unlock context actions permission rules.
1. Lock action respects the `lockPage` permission for pages
2. Unlock action checks if you are root or the owner of the lock
Note that we need https://github.com/Jahia/javascript-components/pull/268 to be released first, and version bumped here.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
