### PR TITLE
BACKLOG-22219: Hide subcontents menu in page builder view

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentRoute.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentRoute.jsx
@@ -23,13 +23,13 @@ export const ContentRoute = () => {
     const nodeTypes = ['jnt:page', 'jmix:mainResource'];
     const res = useNodeInfo({path}, {getIsNodeTypes: nodeTypes});
     const {FLAT, STRUCTURED, PAGE_BUILDER, PREVIEW} = JContentConstants.tableView.viewMode;
+    const accordionItem = registry.get('accordionItem', mode);
 
     useEffect(() => {
-        const accordionItem = registry.get('accordionItem', mode);
         if (accordionItem.tableConfig?.availableModes?.indexOf?.(viewMode) === -1) {
             dispatch(setTableViewMode(accordionItem.tableConfig.defaultViewMode || FLAT));
         }
-    }, [dispatch, mode, viewMode]);
+    }, [dispatch, mode, viewMode, FLAT, accordionItem]);
 
     if (res.loading) {
         return <LoaderOverlay/>;
@@ -49,7 +49,7 @@ export const ContentRoute = () => {
     // Update viewMode if page builder is selected but content cannot be displayed
     if (isPageBuilderView && !canShowEditFrame) {
         const {queryHandler, availableModes} = accordionItem?.tableConfig || {};
-        const isStructured = Boolean(queryHandler?.isStructured(tableView));
+        const isStructured = Boolean(tableView && queryHandler?.isStructured && queryHandler?.isStructured({tableView}));
         const viewMode = (isStructured && availableModes.includes(STRUCTURED)) ? STRUCTURED : FLAT;
         dispatch(setTableViewMode(viewMode));
     }

--- a/src/javascript/JContent/ContentRoute/ContentRoute.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentRoute.jsx
@@ -10,6 +10,7 @@ import JContentConstants from '~/JContent/JContent.constants';
 import {EditFrame} from '../EditFrame';
 import {registry} from '@jahia/ui-extender';
 import {setTableViewMode} from '~/JContent/redux/JContent.redux';
+import {isInSearchMode} from './ContentLayout/ContentLayout.utils';
 
 export const ContentRoute = () => {
     const {t} = useTranslation('jcontent');
@@ -22,7 +23,7 @@ export const ContentRoute = () => {
     const dispatch = useDispatch();
     const nodeTypes = ['jnt:page', 'jmix:mainResource'];
     const res = useNodeInfo({path}, {getIsNodeTypes: nodeTypes});
-    const {FLAT, STRUCTURED, PAGE_BUILDER, PREVIEW} = JContentConstants.tableView.viewMode;
+    const {FLAT, STRUCTURED, PAGE_BUILDER} = JContentConstants.tableView.viewMode;
     const accordionItem = registry.get('accordionItem', mode);
 
     useEffect(() => {
@@ -43,12 +44,11 @@ export const ContentRoute = () => {
         return <Error404 label={t('jcontent:label.contentManager.error.missingFolder')}/>;
     }
 
-    const isSearchMode = mode === JContentConstants.mode.SEARCH || mode === JContentConstants.mode.SQL2SEARCH;
-    const isPageBuilderView = [PAGE_BUILDER, PREVIEW].includes(viewMode);
+    const isPageBuilderView = viewMode === PAGE_BUILDER;
     const canShowEditFrame = nodeTypes.some(nt => res.node[nt]);
 
     // Update viewMode if page builder is selected but content cannot be displayed
-    if (!isSearchMode && res.node.path === path && isPageBuilderView && !canShowEditFrame) {
+    if (!isInSearchMode(mode) && (res.node.path === path) && isPageBuilderView && !canShowEditFrame) {
         const {queryHandler, availableModes} = accordionItem?.tableConfig || {};
         const isStructured = Boolean(tableView && queryHandler?.isStructured && queryHandler?.isStructured({tableView}));
         const viewMode = (isStructured && availableModes.includes(STRUCTURED)) ? STRUCTURED : FLAT;
@@ -59,7 +59,7 @@ export const ContentRoute = () => {
         <MainLayout header={<ContentHeader/>}>
             <LoaderSuspense>
                 <ErrorBoundary>
-                    { (isPageBuilderView && canShowEditFrame ? (<EditFrame isPreview={JContentConstants.tableView.viewMode.PREVIEW === viewMode}/>) : <ContentLayout/>) }
+                    {(isPageBuilderView && canShowEditFrame) ? <EditFrame/> : <ContentLayout/>}
                 </ErrorBoundary>
             </LoaderSuspense>
         </MainLayout>

--- a/src/javascript/JContent/ContentRoute/ContentRoute.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentRoute.jsx
@@ -43,11 +43,12 @@ export const ContentRoute = () => {
         return <Error404 label={t('jcontent:label.contentManager.error.missingFolder')}/>;
     }
 
+    const isSearchMode = mode === JContentConstants.mode.SEARCH || mode === JContentConstants.mode.SQL2SEARCH;
     const isPageBuilderView = [PAGE_BUILDER, PREVIEW].includes(viewMode);
     const canShowEditFrame = nodeTypes.some(nt => res.node[nt]);
 
     // Update viewMode if page builder is selected but content cannot be displayed
-    if (isPageBuilderView && !canShowEditFrame) {
+    if (!isSearchMode && res.node.path === path && isPageBuilderView && !canShowEditFrame) {
         const {queryHandler, availableModes} = accordionItem?.tableConfig || {};
         const isStructured = Boolean(tableView && queryHandler?.isStructured && queryHandler?.isStructured({tableView}));
         const viewMode = (isStructured && availableModes.includes(STRUCTURED)) ? STRUCTURED : FLAT;

--- a/src/javascript/JContent/EditFrame/EditFrame.jsx
+++ b/src/javascript/JContent/EditFrame/EditFrame.jsx
@@ -61,7 +61,7 @@ function addEventListeners(target, manager, iframeRef) {
     });
 }
 
-export const EditFrame = ({isPreview, isDeviceView}) => {
+export const EditFrame = ({isDeviceView}) => {
     const manager = useDragDropManager();
 
     const {path, site, language, template} = useSelector(state => ({
@@ -206,15 +206,15 @@ export const EditFrame = ({isPreview, isDeviceView}) => {
     const deviceParam = (isDeviceView && device) ? ('&channel=' + device) : '';
 
     useEffect(() => {
-        const renderMode = isPreview ? 'render' : 'editframe';
+        const renderMode = 'editframe';
         const encodedPath = path.replace(/[^/]/g, encodeURIComponent) + (template === '' ? '' : `.${template}`);
         const url = `${window.contextJsParameters.contextPath}/cms/${renderMode}/default/${language}${encodedPath}.html?redirect=false${deviceParam}`;
         if (currentDocument) {
             const mainModule = currentDocument.querySelector('[jahiatype=mainmodule]');
-            console.debug('Loading', url, 'in iframe', mainModule?.getAttribute('path'), path, language, deviceParam, previousDevice.current, deviceParam, isPreview, template);
+            console.debug('Loading', url, 'in iframe', mainModule?.getAttribute('path'), path, language, deviceParam, previousDevice.current, deviceParam, template);
             const framePath = mainModule?.getAttribute('path');
             const locale = mainModule?.getAttribute('locale');
-            if (!isPreview && path === framePath && locale === language && previousDevice.current === deviceParam) {
+            if (path === framePath && locale === language && previousDevice.current === deviceParam) {
                 // Clone all styles with doubled classname prefix
                 const head = currentDocument.querySelector('head');
                 iframe.current.ownerDocument.querySelectorAll('style[styleloader],style[data-jss]').forEach(s => {
@@ -232,7 +232,7 @@ export const EditFrame = ({isPreview, isDeviceView}) => {
             iframe.current.contentWindow.location.href = url;
             previousDevice.current = deviceParam;
         }
-    }, [currentDocument, path, previousDevice, deviceParam, language, isPreview, template]);
+    }, [currentDocument, path, previousDevice, deviceParam, language, template]);
 
     if (site === 'systemsite') {
         return <h2 style={{color: 'grey'}}>You need to create a site to see this page</h2>;
@@ -261,7 +261,7 @@ export const EditFrame = ({isPreview, isDeviceView}) => {
                 />
             </DeviceContainer>
             {currentDocument && <LinkInterceptor document={currentDocument}/>}
-            {currentDocument && !isPreview && (
+            {currentDocument && (
                 <Portal target={currentDocument.documentElement.querySelector('body')}>
                     <div id="jahia-portal-root" className={styles.root}>
                         <Boxes currentDocument={currentDocument}
@@ -282,6 +282,5 @@ export const EditFrame = ({isPreview, isDeviceView}) => {
 };
 
 EditFrame.propTypes = {
-    isPreview: PropTypes.bool,
     isDeviceView: PropTypes.bool
 };

--- a/src/javascript/JContent/JContent.constants.js
+++ b/src/javascript/JContent/JContent.constants.js
@@ -40,7 +40,8 @@ const JContentConstants = {
         viewMode: {
             FLAT: 'flatList',
             STRUCTURED: 'structuredView',
-            PAGE_BUILDER: 'pageBuilder'
+            PAGE_BUILDER: 'pageBuilder',
+            PREVIEW: 'preview'
         },
         viewType: {
             CONTENT: 'content',

--- a/src/javascript/JContent/JContent.constants.js
+++ b/src/javascript/JContent/JContent.constants.js
@@ -40,8 +40,7 @@ const JContentConstants = {
         viewMode: {
             FLAT: 'flatList',
             STRUCTURED: 'structuredView',
-            PAGE_BUILDER: 'pageBuilder',
-            PREVIEW: 'preview'
+            PAGE_BUILDER: 'pageBuilder'
         },
         viewType: {
             CONTENT: 'content',

--- a/src/javascript/JContent/actions/subContentsAction.jsx
+++ b/src/javascript/JContent/actions/subContentsAction.jsx
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import {useApolloClient} from '@apollo/client';
 import {useDispatch, useSelector} from 'react-redux';
 import {expandTree} from '~/JContent/JContent.utils';
+import {isInSearchMode} from '~/JContent/ContentRoute/ContentLayout/ContentLayout.utils';
 
 export const SubContentsActionComponent = ({path, render: Render, loading: Loading, ...others}) => {
     const client = useApolloClient();
@@ -27,12 +28,11 @@ export const SubContentsActionComponent = ({path, render: Render, loading: Loadi
         return (Loading && <Loading {...others}/>) || false;
     }
 
-    const isSearchMode = mode === JContentConstants.mode.SEARCH || mode === JContentConstants.mode.SQL2SEARCH;
-    const hasSubNodes = subNodesType.some(type => (res?.node[`subNodesCount_${type}`] || 0) > 0);
     const isContainerType = ['jnt:page', 'jnt:folder', 'jnt:contentFolder'].includes(res?.node?.primaryNodeType?.name);
+    const hasSubNodes = subNodesType.some(type => (res?.node[`subNodesCount_${type}`] || 0) > 0);
     const isPageBuilderView = viewMode === JContentConstants.tableView.viewMode.PAGE_BUILDER;
 
-    const isVisible = res.checksResult && !isSearchMode && (isContainerType || (hasSubNodes && !isPageBuilderView));
+    const isVisible = res.checksResult && !isInSearchMode(mode) && (isContainerType || (hasSubNodes && !isPageBuilderView));
     return (
         <Render
             {...others}
@@ -40,7 +40,7 @@ export const SubContentsActionComponent = ({path, render: Render, loading: Loadi
             enabled={isVisible}
             onClick={() => {
                 expandTree({path}, client).then(({mode, ancestorPaths}) => {
-                    dispatch(cmGoto({mode, path, params: {sub: res.node.primaryNodeType.name !== 'jnt:page' && res.node.primaryNodeType.name !== 'jnt:contentFolder'}}));
+                    dispatch(cmGoto({mode, path, params: {sub: ['jnt:page', 'jnt:contentFolder'].includes(res?.node?.primaryNodeType?.name)}}));
                     dispatch(cmOpenPaths(ancestorPaths));
                     dispatch(cmSetPreviewSelection(path));
                 });

--- a/tests/cypress/e2e/jcontent/navigation.cy.ts
+++ b/tests/cypress/e2e/jcontent/navigation.cy.ts
@@ -50,6 +50,12 @@ describe('Content navigation', () => {
         cy.get('h1').contains('special chars page');
     });
 
+    it('can open page with the correct view mode selection', () => {
+        // Highlights content cannot be displayed in page builder view, so list view mode should be activated by default
+        const jcontent = JContent.visit('digitall', 'en', 'pages/home/area-main/highlights');
+        jcontent.shouldBeInMode('List');
+    });
+
     it('can open news in page builder', () => {
         const jc = JContent.visit('mySite1', 'en', 'content-folders/contents');
         jc.getTable().getRowByLabel('test-event').contextMenu().select('Open in Page Builder');


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22219

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Fixed issue with view mode selector not updated when page builder view does not apply for content being displayed
- Hide subcontents menu for contents in page builder view
- Also cleaned out deprecated references to `isPreview` and `JContentConstants.tableView.viewMode.PREVIEW` in EditFrame that is now obsolete