### PR TITLE
BACKLOG-23067: Show delete action for selected categories

### DIFF
--- a/src/javascript/JContent/actions/deleteActions/deletePermanentlyAction.jsx
+++ b/src/javascript/JContent/actions/deleteActions/deletePermanentlyAction.jsx
@@ -29,6 +29,7 @@ export const DeletePermanentlyActionComponent = ({path, paths, buttonProps, onDe
         {path, paths, language},
         {
             getDisplayName: true,
+            getPrimaryNodeType: true,
             getProperties: ['jcr:mixinTypes'],
             getAggregatedPublicationInfo: true,
             getOperationSupport: true,

--- a/tests/cypress/e2e/jcontent/categoryManager.cy.ts
+++ b/tests/cypress/e2e/jcontent/categoryManager.cy.ts
@@ -88,9 +88,18 @@ describe('Category Manager', {defaultCommandTimeout: 10000}, () => {
         const primaryActions = ['New category', 'Edit', 'Import content', 'Refresh'];
         cy.get('.moonstone-header').children('.moonstone-header_toolbar').children('.moonstone-header_actions')
             .find('.moonstone-button')
-            .should('have.length', primaryActions.length + 1)
+            .should('have.length', primaryActions.length + 1) // +1 for 3-menu button
             .and(elems => {
                 primaryActions.forEach(action => expect(elems).to.contain(action));
+            });
+
+        categoryManager.getTable().selectRowByLabel('test-category1');
+        const selectedPrimaryActions = ['Clear selection', 'Export', 'Copy', 'Cut', 'Delete (permanently)'];
+        cy.get('.moonstone-header').children('.moonstone-header_toolbar').children('.moonstone-header_actions')
+            .find('.moonstone-button')
+            .should('have.length', selectedPrimaryActions.length)
+            .and(elems => {
+                selectedPrimaryActions.forEach(action => expect(elems).to.contain(action));
             });
     });
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23067

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Add primaryNodeType to node to be able to validate visibility for categories
- Added cypress test