### PR TITLE
BACKLOG-22298: Fix mimetype display for pickers

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/mediaPicker/useMediaPickerInputData.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/mediaPicker/useMediaPickerInputData.js
@@ -1,6 +1,7 @@
 import {useQuery} from '@apollo/client';
 import {MediaPickerFilledQuery} from './MediaPicker.gql-queries';
 import {useContentEditorContext} from '~/ContentEditor/contexts';
+import {getMimeType} from '~/JContent/ContentRoute/ContentLayout/ContentLayout.utils';
 
 export const useMediaPickerInputData = uuids => {
     const {lang} = useContentEditorContext();
@@ -22,12 +23,14 @@ export const useMediaPickerInputData = uuids => {
     const fieldData = data.jcr.result.map(imageData => {
         const sizeInfo = (imageData.height && imageData.width) ? ` - ${parseInt(imageData.width.value, 10)}x${parseInt(imageData.height.value, 10)}px` : '';
         const url = imageData.thumbnailUrl + (imageData.thumbnailUrl.indexOf('?') > 0 ? '&' : '?') + 'lastModified=' + imageData.lastModified?.value;
+        const mimeType = getMimeType(imageData) || '';
+
         return {
             uuid: imageData.uuid,
             url,
             name: imageData.displayName,
             path: imageData.path,
-            info: `${imageData.content && imageData.content?.mimeType?.value}${sizeInfo}`
+            info: `${mimeType}${sizeInfo}`
         };
     });
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.utils.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.utils.js
@@ -3,7 +3,7 @@ import JContentConstants from '~/JContent/JContent.constants';
 import mime from 'mime';
 const imageExtensionSet = new Set(imageExtensions);
 
-export const isBrowserImage = function (node) {
+export const isBrowserImage = node => {
     if (node.isFile) {
         const mimetype = node.content === undefined ? node.resourceChildren.nodes[0].mimeType.value : node.content.mimeType.value;
         if (mimetype === 'application/binary' || mimetype === 'application/octet-stream') {
@@ -29,11 +29,11 @@ export const isBrowserImage = function (node) {
     return false;
 };
 
-export const isImageFile = function (filename) {
+export const isImageFile = filename => {
     return imageExtensionSet.has(filename.split('.').pop().toLowerCase());
 };
 
-export const isPDF = function (node) {
+export const isPDF = node => {
     if (node.isFile) {
         const mimetype = node.content === undefined ? node.resourceChildren.nodes[0].mimeType.value : node.content.mimeType.value;
         if (mimetype === 'application/binary' || mimetype === 'application/octet-stream') {
@@ -50,7 +50,7 @@ export const isPDF = function (node) {
     return false;
 };
 
-export const getFileType = function (node) {
+export const getFileExtension = node => {
     if (node.isFile) {
         const mimetype = node.content === undefined ? node.resourceChildren.nodes[0].mimeType.value : node.content.mimeType.value;
         if (mimetype === 'application/binary' || mimetype === 'application/octet-stream') {
@@ -65,6 +65,16 @@ export const getFileType = function (node) {
     }
 
     return undefined;
+};
+
+export const getMimeType = node => {
+    const mimetype = node.content?.mimeType.value;
+    if (!mimetype || mimetype === 'null') {
+        // Try to get mimetype using file extension
+        return mime.getType(node.path.split('.').pop().toLowerCase());
+    }
+
+    return mimetype;
 };
 
 export const flattenTree = function (rows) {

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PreviewComponent.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PreviewComponent.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {getFileType, isBrowserImage, isPDF} from '../../../ContentLayout.utils';
+import {getFileExtension, isBrowserImage, isPDF} from '../../../ContentLayout.utils';
 import classNames from 'clsx';
 import {Paper} from '@material-ui/core';
 import DocumentViewer from './DocumentViewer';
@@ -97,7 +97,7 @@ const PreviewComponentCmp = ({data, workspace, fullScreen, domLoadedCallback, iF
             );
         }
 
-        const type = getFileType(data.nodeByPath);
+        const type = getFileExtension(data.nodeByPath);
         // Media compatible with react-file-viewer
         const isMedia = (type === 'mp4' || type === 'webm');
         return (

--- a/tests/cypress/e2e/pickers/pickerMultiple.cy.ts
+++ b/tests/cypress/e2e/pickers/pickerMultiple.cy.ts
@@ -44,11 +44,13 @@ describe('Picker tests - multiple', () => {
         picker.select();
 
         cy.log('verify selected is listed in CE modal/page');
+        const mimeType = 'image/png';
         pickerField
             .get()
             .find('[data-sel-content-editor-multiple-generic-field]')
             .then(elems => {
                 expect(elems.length).eq(numRows + 1); // Includes last reorder row
+                cy.wrap(elems).find('[data-sel-field-picker-info]').should('contain', mimeType);
 
                 cy.log('verify removed element is reflected in selection');
                 cy.wrap(elems.eq(0))


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22298

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Add new `getMimeType` util function to process mimetype for file/image nodes in pickers
- Add additional check in cypress for mimetype display in picker selection