### PR TITLE
BACKLOG-22314 Expand contribute types to include jmix:droppableContent

### DIFF
--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_contributeMode.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_contributeMode.json
@@ -19,7 +19,10 @@
             {
               "rank": 1.0,
               "name": "j:contributeTypes",
-              "selectorType": "MultipleLeftRightSelector"
+              "selectorType": "MultipleLeftRightSelector",
+              "selectorOptionsMap": {
+                "componenttypes": "jmix:droppableContent"
+              }
             }
           ]
         }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22314

## Description

Expand contribute types to include jmix:droppableContent

This one is a bit messy, we'll need to discuss it with the team, I think it includes a bit much. 