### PR TITLE
BACKLOG-22586 Hiding publication status badge on loading

### DIFF
--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderBadges/PublicationInfoBadge.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderBadges/PublicationInfoBadge.jsx
@@ -45,7 +45,6 @@ export const PublicationInfoBadge = () => {
                 {!statuses.warning && renderStatus(statuses.published ? 'published' : 'notPublished')}
                 {statuses.warning && renderStatus('warning')}
             </>}
-            {publicationInfoContext.publicationInfoPolling && renderStatus('publishing')}
         </>
     );
 };

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderBadges/PublicationInfoBadge.spec.js
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderBadges/PublicationInfoBadge.spec.js
@@ -63,11 +63,10 @@ jest.mock('~/ContentEditor/contexts/PublicationInfo', () => {
 });
 
 describe('PublicationInfoBadge', () => {
-    it('Should display "publishing" badge when publication info is polling', () => {
+    it('Should not display any badge when publication info is polling', () => {
         let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
 
-        expect(wrapper.containsMatchingElement(<PublicationStatus type="publishing"/>)).toBeTruthy();
-        expect(wrapper.find('PublicationStatus')).toHaveLength(1);
+        expect(wrapper.find('PublicationStatus')).toHaveLength(0);
     });
 
     it('Should not display "publishing" badge when publication info is not polling', () => {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22586

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

This PR hides the publication status badge in CE while it is loading.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
