### PR TITLE
BACKLOG-22873 : prepare publish of jcontent cypress lib

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jahia/jcontent-cypress",
   "private": false,
-  "version": "3.0.0-tests.8",
+  "version": "3.0.0-tests.9",
   "scripts": {
     "instrument": "nyc instrument --compact=false cypress instrumented",
     "e2e:ci": "cypress run --browser chrome",


### PR DESCRIPTION
following changes in jcontent cypress page object, bump the version of the lib to prepare its publication
related to https://jira.jahia.org/browse/BACKLOG-22873