### PR TITLE
QA-15113 Changed default view to structured on editorial picker

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/Picker/Picker.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/Picker.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {useTranslation} from 'react-i18next';
 import {FieldPropTypes} from '~/ContentEditor/ContentEditor.proptypes';
@@ -15,6 +15,8 @@ import {useFormikContext} from 'formik';
 import {OrderableValue} from '~/ContentEditor/DesignSystem/OrderableValue/OrderableValue';
 import {useContentEditorConfigContext} from '~/ContentEditor/contexts';
 import {useExternalPickersInfo} from '~/ContentEditor/SelectorTypes/Picker/useExternalPickersInfo';
+import {cePickerSetTableViewMode} from '~/ContentEditor/SelectorTypes/Picker/Picker.redux';
+import {useDispatch} from 'react-redux';
 
 const ButtonRenderer = getButtonRenderer({labelStyle: 'none', defaultButtonProps: {variant: 'ghost'}});
 
@@ -122,6 +124,14 @@ export const Picker = ({
     const {
         fieldData, error, loading, notFound
     } = usePickerInputData(value && toArray(value));
+
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        if (pickerConfig.defaultViewMode) {
+            dispatch(cePickerSetTableViewMode(pickerConfig.defaultViewMode));
+        }
+    }, [dispatch, pickerConfig.defaultViewMode]);
 
     if (error) {
         const message = t(

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/editorialPicker/editorialPicker.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/editorialPicker/editorialPicker.js
@@ -32,12 +32,14 @@ const PickerContentsFolderQueryHandler = transformQueryHandler({
 export const registerEditorialPicker = registry => {
     registry.add(Constants.pickerConfig, 'editorial', {
         searchContentType: 'jmix:searchable',
-        selectableTypesTable: ['jnt:page', 'jnt:contentList', 'jnt:contentFolder', 'jmix:siteContent', 'jmix:editorialContent']
+        selectableTypesTable: ['jnt:page', 'jnt:contentList', 'jnt:contentFolder', 'jmix:siteContent', 'jmix:editorialContent'],
+        defaultViewMode: JContentConstants.tableView.viewMode.STRUCTURED
     });
 
     registry.add(Constants.pickerConfig, 'droppableContent', {
         searchContentType: 'jmix:searchable',
-        selectableTypesTable: ['jmix:droppableContent']
+        selectableTypesTable: ['jmix:droppableContent'],
+        defaultViewMode: JContentConstants.tableView.viewMode.STRUCTURED
     });
 
     // These are jcontent accordion items, additional targets are added to enhance selection

--- a/tests/cypress/e2e/pickers/editorialpicker.cy.ts
+++ b/tests/cypress/e2e/pickers/editorialpicker.cy.ts
@@ -1,0 +1,29 @@
+import {contentTypes} from '../../fixtures/contentEditor/pickers/contentTypes';
+import {JContent} from '../../page-object';
+
+describe('Editorial picker tests', () => {
+    const siteKey = 'digitall';
+    let jcontent: JContent;
+
+    beforeEach(() => {
+        cy.login(); // Edit in chief
+
+        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+    });
+
+    afterEach(() => {
+        cy.logout();
+    });
+
+    it('should open editorial picker with structured view as default', () => {
+        const contentType = contentTypes.editorialpicker;
+        jcontent
+            .createContent(contentType.typeName)
+            .getPickerField(contentType.fieldNodeType, contentType.multiple)
+            .open();
+
+        cy.get('div[data-sel-type="editorial"] div[data-sel-role="sel-view-mode-dropdown"] > div[role="dropdown"] > span')
+            .should('have.text', 'Structured')
+            .should('not.have.text', 'List');
+    });
+});


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-15113

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
This PR changes the default view for the editorial picker to structured. It also adds a `defaultViewMode` option for the picker config.
## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
