### PR TITLE
QA-15243: Fix issue with returning null NodeIcon; fix thumbnails grid css

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.scss
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.scss
@@ -32,7 +32,7 @@
 
 .detailedGrid.detailedGrid {
     grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-    padding: 0 var(--spacing-medium) var(--spacing-medium);
+    padding: var(--spacing-small) var(--spacing-medium);
     overflow-x: hidden;
     overflow-y: auto;
 }

--- a/src/javascript/utils/NodeIcon.jsx
+++ b/src/javascript/utils/NodeIcon.jsx
@@ -92,6 +92,8 @@ function getFileIcon(node, props) {
                     );
             }
         }
+
+        return <File {...props}/>;
     }
 
     // eslint-disable-next-line complexity


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-15243

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Backport is not compatible with older version of react; returning null crashes thumbnail grid

- Return a default file icon instead of null
- Also fixed thumbnail grid styling https://github.com/Jahia/jcontent/pull/983
