### PR TITLE
QA-15174 JContent previews now honour the j:view property

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PreviewComponent.container.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PreviewComponent.container.jsx
@@ -1,5 +1,5 @@
 import React, {useEffect} from 'react';
-import {useContentPreview} from '@jahia/data-helper';
+import {useContentPreview, useNodeInfo} from '@jahia/data-helper';
 import {CM_DRAWER_STATES} from '~/JContent/redux/JContent.redux';
 import PreviewComponent from './PreviewComponent';
 import PropTypes from 'prop-types';
@@ -8,13 +8,24 @@ import {useSelector} from 'react-redux';
 import {LoaderOverlay, LoaderSuspense} from '@jahia/jahia-ui-root';
 import {refetchTypes, setRefetcher, unsetRefetcher} from '~/JContent/JContent.refetches';
 
+const getViewProperty = properties => {
+    return properties && properties.length && properties.find(p => p.name === 'j:view')?.value;
+};
+
 export const PreviewComponentContainer = ({previewMode, previewSelection, previewState, notificationContext}) => {
     const {t} = useTranslation('jcontent');
     const language = useSelector(state => state.language);
+    const {loading: nodeInfoLoading, error: nodeInfoError, node} = useNodeInfo({
+        path: previewSelection && previewSelection.path,
+        language
+    }, {
+        getProperties: ['j:view']
+    });
+
     const {data, loading, error, refetch} = useContentPreview({
         path: previewSelection && previewSelection.path,
         templateType: 'html',
-        view: 'cm',
+        view: getViewProperty(node?.properties) ?? 'cm',
         contextConfiguration: 'preview',
         language,
         workspace: previewMode
@@ -29,14 +40,15 @@ export const PreviewComponentContainer = ({previewMode, previewSelection, previe
         refetch();
     }
 
-    if (error) {
-        console.error('Error when fetching data: ', error);
-        const message = t('jcontent:label.contentManager.error.queryingContent', {details: (error.message ? error.message : '')});
+    if (error || nodeInfoError) {
+        const realError = error || nodeInfoError;
+        console.error('Error when fetching data: ', realError);
+        const message = t('jcontent:label.contentManager.error.queryingContent', {details: (realError.message ? realError.message : '')});
         notificationContext.notify(message, ['closeButton', 'noAutomaticClose']);
         return null;
     }
 
-    if (loading || Object.keys(data || {}).length === 0) {
+    if (loading || nodeInfoLoading || Object.keys(data || {}).length === 0) {
         return <LoaderOverlay/>;
     }
 

--- a/tests/cypress/e2e/jcontent/preview.cy.ts
+++ b/tests/cypress/e2e/jcontent/preview.cy.ts
@@ -1,0 +1,32 @@
+import {JContent} from '../../page-object';
+
+describe('JContent preview tests', () => {
+    beforeEach(() => {
+        cy.executeGroovy('jcontent/createSite.groovy', {SITEKEY: 'jcontentSite'});
+        cy.apollo({mutationFile: 'jcontent/createContent.graphql'});
+        cy.loginAndStoreSession(); // Edit in chief
+    });
+
+    it('should honor the j:view property when previewing content', () => {
+        const jcontent = JContent.visit('jcontentSite', 'en', 'pages/home');
+        jcontent.switchToListMode();
+        jcontent.getTable().getRowByLabel('test 6').contextMenu().select('Preview');
+        cy.get('iframe[data-sel-role="edit-preview-frame"]')
+            .its('0.contentDocument.body')
+            .should('be.visible')
+            .should('contain.html',
+                '<a target="" href="/cms/render/default/en/sites/jcontentSite/home/area-main/test-content6-linkview.html">test-content6-linkview</a>');
+
+        cy.get('button[data-cm-role="preview-drawer-close"]').click();
+        jcontent.getTable().getRowByLabel('test 7').contextMenu().select('Preview');
+        cy.get('iframe[data-sel-role="edit-preview-frame"]')
+            .its('0.contentDocument.body.textContent')
+            .should('equal',
+                'test 7');
+    });
+
+    afterEach(() => {
+        cy.logout();
+        cy.executeGroovy('jcontent/deleteSite.groovy', {SITEKEY: 'jcontentSite'});
+    });
+});

--- a/tests/cypress/e2e/jcontent/search.cy.ts
+++ b/tests/cypress/e2e/jcontent/search.cy.ts
@@ -38,8 +38,8 @@ describe('Search tests', () => {
                 .searchTerm('test')
                 .searchInWholeSite()
                 .executeSearch()
-                .verifyResults(['test', 'test', 'test', 'test', 'test'])
-                .verifyTotalCount(5);
+                .verifyResults(['test', 'test', 'test', 'test', 'test', 'test', 'test'])
+                .verifyTotalCount(7);
         });
 
         it('Test search with type', function () {
@@ -62,7 +62,7 @@ describe('Search tests', () => {
                 .editQuery()
                 .searchInWholeSite()
                 .executeSearch()
-                .verifyTotalCount(5);
+                .verifyTotalCount(7);
         });
 
         it('Test search system name', function () {

--- a/tests/cypress/fixtures/jcontent/createContent.graphql
+++ b/tests/cypress/fixtures/jcontent/createContent.graphql
@@ -56,6 +56,17 @@ mutation {
                                     { name: "j:tagList", language: "en", values: ["tagToLookFor"] }
                                 ]
                             }
+                            {
+                                name: "test-content6-linkview"
+                                primaryNodeType: "jnt:bigText"
+                                properties: [{ name: "text", language: "en", value: "test 6" }, {name: "j:view", language: "en", value: "link"}]
+                                mixins: ["jmix:renderable"],
+                            }
+                            {
+                                name: "test-content7-defaultview"
+                                primaryNodeType: "jnt:bigText"
+                                properties: [{ name: "text", language: "en", value: "test 7" }]
+                            }
                         ]
                     }
                     {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-15174

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
This PR makes the JContent preview respect the j:view property on the node.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
