### PR TITLE
BACKLOG-23132: Add isAlwaysActivated fieldset json override property

### DIFF
--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
@@ -179,7 +179,10 @@ public class EditorFormServiceImpl implements EditorFormService {
                         boolean isExtend = !nodeType.getMixinExtends().isEmpty() && !primaryNodeType.isNodeType(nodeType.getName());
                         if (isExtend) {
                             fieldSet.setDynamic(true);
-                            fieldSet.setActivated(existingNode != null && existingNode.isNodeType(fieldSet.getName()) || existingNode == null && fieldSet.isActivatedOnCreate() != null && fieldSet.isActivatedOnCreate());
+                            boolean isActivated = existingNode != null && existingNode.isNodeType(fieldSet.getName());
+                            boolean isAlwaysActivated = fieldSet.isAlwaysActivated() != null && fieldSet.isAlwaysActivated();
+                            boolean isActivatedOnCreate = fieldSet.isActivatedOnCreate() != null && fieldSet.isActivatedOnCreate();
+                            fieldSet.setActivated(isActivated || isAlwaysActivated || existingNode == null && isActivatedOnCreate);
                             fieldSet.setHasEnableSwitch(!nodeType.isNodeType("jmix:templateMixin"));
 
                             // Update readonly if user does not have permission to add/remove mixin

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/model/FieldSet.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/model/FieldSet.java
@@ -32,6 +32,8 @@ public class FieldSet implements DefinitionRegistryItem, Ranked {
     private Boolean hide;
     private Boolean readOnly;
     private Boolean activatedOnCreate = false;
+
+    private Boolean isAlwaysActivated = false;
     // Fieldset will be included in section even if it is invisible
     private Boolean alwaysPresent;
     private Double rank;
@@ -137,6 +139,14 @@ public class FieldSet implements DefinitionRegistryItem, Ranked {
 
     public void setActivatedOnCreate(Boolean activatedOnCreate) {
         this.activatedOnCreate = activatedOnCreate;
+    }
+
+    public Boolean isAlwaysActivated() {
+        return isAlwaysActivated;
+    }
+
+    public void setIsAlwaysActivated(Boolean isAlwaysActivated) {
+        this.isAlwaysActivated = isAlwaysActivated;
     }
 
     public Boolean isAlwaysPresent() {
@@ -275,6 +285,7 @@ public class FieldSet implements DefinitionRegistryItem, Ranked {
         setHide(otherFieldSet.isHide() != null ? otherFieldSet.isHide() : hide);
         setReadOnly(otherFieldSet.isReadOnly() != null ? otherFieldSet.isReadOnly() : readOnly);
         setActivatedOnCreate(otherFieldSet.isActivatedOnCreate() != null ? otherFieldSet.isActivatedOnCreate() : activatedOnCreate);
+        setIsAlwaysActivated(otherFieldSet.isAlwaysActivated() != null ? otherFieldSet.isAlwaysActivated() : isAlwaysActivated);
         setRank(otherFieldSet.getRank() != null ? otherFieldSet.getRank() : rank);
         setAlwaysPresent(otherFieldSet.isAlwaysPresent() != null ? otherFieldSet.isAlwaysPresent() : alwaysPresent);
         mergeFields(otherFieldSet.getFields(), form);

--- a/tests/cypress/e2e/contentEditor/contentEditorForm.cy.ts
+++ b/tests/cypress/e2e/contentEditor/contentEditorForm.cy.ts
@@ -13,8 +13,17 @@ describe('Content editor form', () => {
         cy.apollo({
             mutation: gql`mutation GrantRoles {
                 jcr {
-                    mutateNode(pathOrId: "/sites/contentEditorSite") {
+                    grantRoles: mutateNode(pathOrId: "/sites/contentEditorSite") {
                         grantRoles(roleNames: "editor", principalType: USER, principalName: "mathias")
+                    }
+                    addContent: mutateNode(pathOrId: "/sites/contentEditorSite/contents") {
+                        addChild(
+                            name: "alwaysActivatedOverrideTest", 
+                            primaryNodeType: "jnt:bigText", 
+                            properties: [{ name: "text", language: "en", value: "isAlwaysActivated override test" }]
+                        ) {
+                            uuid
+                        }
                     }
                 }
             }`
@@ -141,14 +150,22 @@ describe('Content editor form', () => {
         field.get().scrollIntoView().contains('Customized description').should('be.visible');
     });
 
-    it('Should enable automatically cemix:testAutoActivatedMixin on jnt:bigText', () => {
+    it('Should enable automatically cemix:testAutoActivatedMixin on jnt:bigText for create', () => {
         const contentEditor = jcontent.createContent('Rich text');
         contentEditor.getField(SmallTextField, 'cemix:testAutoActivatedMixin_j:testAutoActivatedMixinField');
+        contentEditor.getField(SmallTextField, 'cemix:testAutoAlwaysActivatedMixin_j:testAutoAlwaysActivatedMixinField');
     });
 
-    it('Should not enable automatically cemix:testAutoActivatedMixin on jnt:simpleText', () => {
+    it('Should enable automatically cemix:testAutoAlwaysActivatedMixin on jnt:bigText for edit', () => {
+        const contentEditor = jcontent.editComponentByText('isAlwaysActivated override test');
+        cy.get('[data-sel-content-editor-field="cemix:testAutoActivatedMixin_j:testAutoActivatedMixinField"]').should('not.exist');
+        contentEditor.getField(SmallTextField, 'cemix:testAutoAlwaysActivatedMixin_j:testAutoAlwaysActivatedMixinField');
+    });
+
+    it('Should not enable automatically cemix:testAutoActivatedMixin on jnt:simpleText for create', () => {
         jcontent.createContent('Simple text');
         cy.get('[data-sel-content-editor-field="cemix:testAutoActivatedMixin_j:testAutoActivatedMixinField"]').should('not.exist');
+        cy.get('[data-sel-content-editor-field="cemix:testAutoAlwaysActivatedMixin_j:testAutoAlwaysActivatedMixinField"]').should('not.exist');
     });
 
     it('Should not see readonly text field for reviewer', () => {

--- a/tests/cypress/e2e/contentEditor/textFieldInitializerTest.cy.ts
+++ b/tests/cypress/e2e/contentEditor/textFieldInitializerTest.cy.ts
@@ -53,6 +53,9 @@ describe('Test the text field initializer', () => {
                 return;
             }
 
+            // Seems necessary with the flicker on changing language
+            // eslint-disable-next-line cypress/no-unnecessary-waiting
+            cy.wait(5000);
             pageComposer.switchLanguage(data);
             checkValuesDisplayedInPageComposer(pageComposer, valuesToCheck, lang);
         });

--- a/tests/cypress/page-object/pageComposer.ts
+++ b/tests/cypress/page-object/pageComposer.ts
@@ -192,8 +192,12 @@ export class PageComposer extends BasePage {
 
     switchLanguage(language: string) {
         cy.iframe('#page-composer-frame', this.iFrameOptions).within(() => {
-            cy.get('.toolbar-itemsgroup-languageswitcher').click();
-            cy.get('.x-combo-list-item').contains(language).click();
+            // Seems necessary with the flicker on changing language
+            // eslint-disable-next-line cypress/no-unnecessary-waiting
+            cy.wait(5000).then(() => {
+                cy.get('.toolbar-itemsgroup-languageswitcher').should('be.visible').click();
+                cy.get('.x-combo-list-item').contains(language).click();
+            });
         });
     }
 

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -99,6 +99,10 @@
  extends = jnt:content
  - j:testAutoActivatedMixinField (string)
 
+[cemix:testAutoAlwaysActivatedMixin] mixin
+ extends = jnt:content
+ - j:testAutoAlwaysActivatedMixinField (string)
+
 [cent:visibleInTree] > jnt:content, jmix:visibleInPagesTree
 
 [cent:html5PluginTestComponent] > jnt:content, mix:title, jmix:editorialContent, jmix:droppableContent, jmix:siteComponent

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_bigText.json
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_bigText.json
@@ -8,6 +8,10 @@
         {
           "name": "cemix:testAutoActivatedMixin",
           "activatedOnCreate": true
+        },
+        {
+          "name": "cemix:testAutoAlwaysActivatedMixin",
+          "isAlwaysActivated": true
         }
       ]
     }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23132

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Adding new json override property `isAlwaysActivated` for fieldsets in order to be able to remove fieldset toggle. 

Similar to existing `activatedOnCreate` (https://github.com/Jahia/jcontent/pull/1054) but applied for both edit and create scenarios.

Added cypress test.