### PR TITLE
BACKLOG-23136: Add new tagField cypress object

### DIFF
--- a/tests/.eslintignore
+++ b/tests/.eslintignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/tests/cypress/e2e/performance/8.1.7-performance.cy.ts
+++ b/tests/cypress/e2e/performance/8.1.7-performance.cy.ts
@@ -1,4 +1,4 @@
-import {ContentEditor, JContent} from '../../page-object';
+import {JContent} from '../../page-object';
 import {preparePerformanceTool, generateReportFile, gatherPerformanceStats} from '../../support/performanceTool';
 import {Button, getComponentByRole} from '@jahia/cypress';
 

--- a/tests/cypress/e2e/pickers/externalpicker.cy.ts
+++ b/tests/cypress/e2e/pickers/externalpicker.cy.ts
@@ -1,6 +1,3 @@
-import {contentTypes} from '../../fixtures/contentEditor/pickers/contentTypes';
-import {assertUtils} from '../../utils/assertUtils';
-import {AccordionItem} from '../../page-object/accordionItem';
 import {JContent} from '../../page-object/jcontent';
 import {createSite, deleteSite, Dropdown, enableModule, getComponentByRole} from '@jahia/cypress';
 
@@ -29,7 +26,7 @@ describe('Picker tests', () => {
         const pickerField = jcontent
             .createContent('Pickers')
             .getPickerField('qant:pickers_filepicker');
-        const picker = pickerField.open();
+        pickerField.open();
         getComponentByRole(Dropdown, 'picker-selector').select('Custom picker');
         cy.contains('Test picker');
         cy.get('button[data-sel-role="custom-selector"]').click();

--- a/tests/cypress/page-object/fields/field.ts
+++ b/tests/cypress/page-object/fields/field.ts
@@ -5,12 +5,12 @@ export class Field extends BaseComponent {
     multiple: boolean;
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    checkValue(string: string): void {
+    checkValue(text: string): void {
         // Empty method
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    addNewValue(string: string): void {
+    addNewValue(text: string): void {
         // Empty method
     }
 }

--- a/tests/cypress/page-object/fields/richTextField.ts
+++ b/tests/cypress/page-object/fields/richTextField.ts
@@ -17,7 +17,7 @@ export class RichTextField extends Field {
         return cy.window().its('CKEDITOR').its('instances').then(instances => instances[Object.keys(instances)[0]].getData());
     }
 
-    getElement(elementName: string): Cypress.Chainable<JQuery> {
+    getElement(): Cypress.Chainable<JQuery> {
         return cy.window().its('CKEDITOR').its('instances').then(instances => {
             const instanceOfCK = instances[Object.keys(instances)[0]];
             instanceOfCK.focus();

--- a/tests/cypress/page-object/fields/tagField.ts
+++ b/tests/cypress/page-object/fields/tagField.ts
@@ -1,7 +1,6 @@
 import {Field} from './field';
 
 export class TagField extends Field {
-
     addNewValue(text: string): void {
         this.get().find(`#${this.fieldName}`).type(`${text}{enter}`, {delay: 500});
         this.get().find(`#${this.fieldName} [role="button"]`).contains(text).should('be.visible');

--- a/tests/cypress/page-object/fields/tagField.ts
+++ b/tests/cypress/page-object/fields/tagField.ts
@@ -1,0 +1,9 @@
+import {Field} from './field';
+
+export class TagField extends Field {
+
+    addNewValue(text: string): void {
+        this.get().find(`#${this.fieldName}`).type(`${text}{enter}`, {delay: 500});
+        this.get().find(`#${this.fieldName} [role="button"]`).contains(text).should('be.visible');
+    }
+}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23136

- Implement `addNewValue` for tag fields in CE cypress tests. Related to PR https://github.com/Jahia/site-settings-seo/pull/245
- Clean up yarn lint warnings

