### PR TITLE
QA-15348: Add logic for checking mixin nodetypes on edit/create

### DIFF
--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/StaticDefinitionsRegistry.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/StaticDefinitionsRegistry.java
@@ -97,12 +97,12 @@ public class StaticDefinitionsRegistry implements SynchronousBundleListener {
      * @param site
      * @return form definitions that match the type
      */
-    public Collection<Form> getFormsForType(JCRNodeWrapper node, ExtendedNodeType type, JCRSiteNode site) {
+    public Collection<Form> getFormsForType(ExtendedNodeType type, JCRSiteNode site, Collection<ExtendedNodeType> nodeTypes) {
         return forms.stream()
             .filter(definition -> definition.getConditionNodeTypeName() != null)
             .filter(definition -> type.isNodeType(definition.getConditionNodeTypeName()) &&
                 (definition.getCondition() == null || matchCondition(definition.getCondition(), type, site)))
-            .filter(definition -> checkMixinCondition(definition.getCondition(), node))
+            .filter(definition -> checkMixinCondition(definition.getCondition(), nodeTypes))
             .collect(Collectors.toCollection(ArrayList::new));
     }
 
@@ -112,16 +112,16 @@ public class StaticDefinitionsRegistry implements SynchronousBundleListener {
      * @param type to look at
      * @return form definitions that match the type
      */
-    public Collection<FieldSet> getFieldSetsForType(JCRNodeWrapper node, ExtendedNodeType type, JCRSiteNode site) {
+    public Collection<FieldSet> getFieldSetsForType(ExtendedNodeType type, JCRSiteNode site, Collection<ExtendedNodeType> nodeTypes) {
         return fieldSets.stream()
             .filter(definition -> definition.getConditionNodeTypeName() != null)
             .filter(definition -> type.isNodeType(definition.getConditionNodeTypeName()) &&
                 (definition.getCondition() == null || matchCondition(definition.getCondition(), type, site)))
-            .filter(definition -> checkMixinCondition(definition.getCondition(), node))
+            .filter(definition -> checkMixinCondition(definition.getCondition(), nodeTypes))
             .collect(Collectors.toCollection(ArrayList::new));
     }
 
-    public boolean checkMixinCondition(Condition condition, JCRNodeWrapper node) {
+    public boolean checkMixinCondition(Condition condition, Collection<ExtendedNodeType> nodeTypes) {
         // step 1 - check if we have condition
         if (condition == null) return true;
 
@@ -139,12 +139,8 @@ public class StaticDefinitionsRegistry implements SynchronousBundleListener {
         // step 3 - check if the condition node is a mixin
         if (!conditionTypeDefinition.isMixin()) return true;
 
-        // step 4 - check if node has the mixin
-        try {
-            return Arrays.stream(node.getMixinNodeTypes()).anyMatch(m -> m.getName().equals(conditionType));
-        } catch (RepositoryException e) {
-            return true;
-        }
+        // step 4 - check if nodetypes has the mixin
+        return nodeTypes.stream().anyMatch(m -> m.getName().equals(conditionType));
     }
 
     public boolean matchCondition(Condition condition, ExtendedNodeType type, JCRSiteNode site) {

--- a/tests/cypress/e2e/contentEditor/jsonOverrides/extendMixins.cy.ts
+++ b/tests/cypress/e2e/contentEditor/jsonOverrides/extendMixins.cy.ts
@@ -1,10 +1,12 @@
-import {JContent} from '../../../page-object';
+import {JContent, ContentEditor} from '../../../page-object';
 import {SmallTextField} from '../../../page-object/fields';
 import {createSite, deleteSite, enableModule} from '@jahia/cypress';
+import {ChoicelistField} from '../../../page-object/fields/choicelistField';
 
 // This test makes use of jmix_freezeSystemName.json form override from jcontent-test-module
 describe('Extend Mixins tests with CE', () => {
     const siteKey = 'extendMixinsSite';
+    const systemNameFieldSel = 'nt:base_ce:systemName';
 
     before(() => {
         createSite(siteKey);
@@ -12,8 +14,8 @@ describe('Extend Mixins tests with CE', () => {
     });
 
     after(() => {
-        cy.logout();
         deleteSite(siteKey);
+        cy.logout();
     });
 
     beforeEach(() => {
@@ -23,7 +25,6 @@ describe('Extend Mixins tests with CE', () => {
     it('Applies extend mixin only if it is enabled on the node', () => {
         const jcontent = JContent.visit(siteKey, 'en', 'pages');
         let contentEditor = jcontent.editPage();
-        const systemNameFieldSel = 'nt:base_ce:systemName';
 
         cy.log('Verify conditional override is not applied');
         let systemNameField = contentEditor.getField(SmallTextField, systemNameFieldSel);
@@ -35,6 +36,30 @@ describe('Extend Mixins tests with CE', () => {
 
         cy.log('Verify conditional override is applied after applying mixin');
         contentEditor = jcontent.editPage();
+        systemNameField = contentEditor.getField(SmallTextField, systemNameFieldSel);
+        systemNameField.isReadOnly();
+
+        contentEditor.cancel();
+    });
+
+    it('Does not apply extend mixin on create', () => {
+        const jcontent = JContent.visit(siteKey, 'en', 'pages');
+        jcontent.getAccordionItem('pages').getTreeItem('home').contextMenu().select('New Page');
+        let contentEditor = new ContentEditor();
+
+        cy.log('Verify conditional override is not applied on create');
+        let systemNameField = contentEditor.getField(SmallTextField, systemNameFieldSel);
+        systemNameField.isNotReadOnly();
+
+        cy.log('Enable the mixin');
+        contentEditor.toggleOption('jmix:freezeSystemName');
+        contentEditor.getField(SmallTextField, 'jnt:page_jcr:title').addNewValue('Test page');
+        contentEditor.getField(ChoicelistField, 'jmix:hasTemplateNode_j:templateName').addNewValue('2-column');
+        contentEditor.create();
+
+        cy.log('Verify conditional override is applied to created page after applying mixin');
+        jcontent.getAccordionItem('pages').getTreeItem('test-page').contextMenu().select('Edit');
+        contentEditor = new ContentEditor();
         systemNameField = contentEditor.getField(SmallTextField, systemNameFieldSel);
         systemNameField.isReadOnly();
 

--- a/tests/cypress/page-object/fields/choicelistField.ts
+++ b/tests/cypress/page-object/fields/choicelistField.ts
@@ -1,0 +1,13 @@
+import {getComponentBySelector, Menu} from '@jahia/cypress';
+import {Field} from './field';
+
+export class ChoicelistField extends Field {
+    addNewValue(value: string): void {
+        this.get().click();
+        const choicelistMenu = getComponentBySelector(Menu, '[role="listbox"]');
+
+        const itemSel = `.moonstone-menuItem[data-value="${value}"]`;
+        choicelistMenu.get().find(itemSel).scrollIntoView().should('be.visible');
+        choicelistMenu.get().find(itemSel).click();
+    }
+}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-15348

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Fix issue where we are using the wrong node when determining when to apply conditional nodeType override.

`currentNode` shouldn't be used during create as this points to the parent node, which is not necessarily the nodetype we are creating.

Refactor and pass the nodeTypes to check instead when determining when to apply conditional nodeType override.