### PR TITLE
BACKLOG-23258: Remove 'View sub-contents' menu item in left navigation

### DIFF
--- a/src/javascript/ContentEditor/actions/registerCreateActions.js
+++ b/src/javascript/ContentEditor/actions/registerCreateActions.js
@@ -12,7 +12,7 @@ export const registerCreateActions = registry => {
         defaultIcon: <AddCircle/>,
         buttonLabel:
             'jcontent:label.contentEditor.CMMActions.createNewContent.menu',
-        targets: ['createMenuActions:3', 'contentActions:3', 'headerPrimaryActions:1', 'narrowHeaderMenu:1'],
+        targets: ['createMenuActions:3', 'contentActions:3', 'accordionContentActions:3', 'headerPrimaryActions:1', 'narrowHeaderMenu:1'],
         showOnNodeTypes: ['jnt:contentFolder', 'jnt:content', 'jnt:category'],
         hideOnNodeTypes: ['jnt:navMenuText', 'jnt:page'],
         requiredPermission: ['jcr:addChildNodes'],
@@ -22,7 +22,7 @@ export const registerCreateActions = registry => {
     if (booleanValue(contextJsParameters.config.jcontent?.showPageBuilder)) {
         registry.addOrReplace('action', 'createPage', createContentAction, {
             buttonIcon: <AddCircle/>,
-            targets: ['createMenuActions:-2', 'contentActions:-2', 'rootContentActions:-2', 'headerPrimaryActions:1', 'narrowHeaderMenu:1'],
+            targets: ['createMenuActions:-2', 'contentActions:-2', 'accordionContentActions:-2', 'rootContentActions:-2', 'headerPrimaryActions:1', 'narrowHeaderMenu:1'],
             showOnNodeTypes: ['jnt:page', 'jnt:navMenuText', 'jnt:virtualsite'],
             requiredPermission: ['jcr:addChildNodes'],
             nodeTypes: ['jnt:page'],
@@ -38,7 +38,7 @@ export const registerCreateActions = registry => {
         registry.add('action', 'createNavMenuItemMenu', registry.get('action', 'menuAction'), {
             buttonIcon: <AddCircle/>,
             buttonLabel: 'jcontent:label.contentEditor.CMMActions.createNewContent.newMenu',
-            targets: ['createMenuActions:-1', 'contentActions:-1', 'rootContentActions:-1'],
+            targets: ['createMenuActions:-1', 'contentActions:-1', 'accordionContentActions:-1', 'rootContentActions:-1'],
             menuTarget: 'createNavMenuItemMenu',
             isMenuPreload: true
         });

--- a/src/javascript/ContentEditor/actions/registerEditActions.js
+++ b/src/javascript/ContentEditor/actions/registerEditActions.js
@@ -16,7 +16,9 @@ export const registerEditActions = actionsRegistry => {
     actionsRegistry.add('action', 'edit', editContentAction, {
         buttonIcon: <Edit/>,
         buttonLabel: 'jcontent:label.contentEditor.edit.contentEdit',
-        targets: showPageBuilder ? ['contentActions:2', 'headerPrimaryActions:1.5', 'narrowHeaderMenu:1.5'] : ['contentActions:2', 'narrowHeaderMenu:1.5'],
+        targets: showPageBuilder ? 
+            ['contentActions:2', 'accordionContentActions:2', 'headerPrimaryActions:1.5', 'narrowHeaderMenu:1.5'] : 
+            ['contentActions:2', 'accordionContentActions:2', 'narrowHeaderMenu:1.5'],
         hideOnNodeTypes: ['jnt:virtualsite', 'jnt:page'], // For edit content
         requiredSitePermission: ['editAction'],
         getDisplayName: true
@@ -26,7 +28,7 @@ export const registerEditActions = actionsRegistry => {
     actionsRegistry.add('action', 'editSource', editContentSourceAction, {
         buttonIcon: <Edit/>,
         buttonLabel: 'jcontent:label.contentEditor.edit.contentEditSource',
-        targets: ['contentActions:2.1', 'narrowHeaderMenu:1.1'],
+        targets: ['contentActions:2.1', 'accordionContentActions:2.1', 'narrowHeaderMenu:1.1'],
         showOnNodeTypes: ['jnt:content'], // For edit content
         requiredSitePermission: ['editAction'],
         getDisplayName: true
@@ -36,7 +38,9 @@ export const registerEditActions = actionsRegistry => {
     actionsRegistry.add('action', 'editPage', editContentAction, {
         buttonIcon: <Edit/>,
         buttonLabel: 'jcontent:label.contentEditor.edit.contentEdit',
-        targets: showPageBuilder ? ['contentActions:2', 'headerPrimaryActions:1.5', 'narrowHeaderMenu:1.5'] : ['contentActions:2', 'narrowHeaderMenu:1.5'],
+        targets: showPageBuilder ? 
+            ['contentActions:2', 'accordionContentActions:2', 'headerPrimaryActions:1.5', 'narrowHeaderMenu:1.5'] : 
+            ['contentActions:2', 'accordionContentActions:2', 'narrowHeaderMenu:1.5'],
         showOnNodeTypes: ['jnt:page'], // For edit pages
         requiredSitePermission: ['editPageAction'],
         getDisplayName: true

--- a/src/javascript/ContentEditor/actions/registerEditActions.js
+++ b/src/javascript/ContentEditor/actions/registerEditActions.js
@@ -16,8 +16,8 @@ export const registerEditActions = actionsRegistry => {
     actionsRegistry.add('action', 'edit', editContentAction, {
         buttonIcon: <Edit/>,
         buttonLabel: 'jcontent:label.contentEditor.edit.contentEdit',
-        targets: showPageBuilder ? 
-            ['contentActions:2', 'accordionContentActions:2', 'headerPrimaryActions:1.5', 'narrowHeaderMenu:1.5'] : 
+        targets: showPageBuilder ?
+            ['contentActions:2', 'accordionContentActions:2', 'headerPrimaryActions:1.5', 'narrowHeaderMenu:1.5'] :
             ['contentActions:2', 'accordionContentActions:2', 'narrowHeaderMenu:1.5'],
         hideOnNodeTypes: ['jnt:virtualsite', 'jnt:page'], // For edit content
         requiredSitePermission: ['editAction'],
@@ -38,8 +38,8 @@ export const registerEditActions = actionsRegistry => {
     actionsRegistry.add('action', 'editPage', editContentAction, {
         buttonIcon: <Edit/>,
         buttonLabel: 'jcontent:label.contentEditor.edit.contentEdit',
-        targets: showPageBuilder ? 
-            ['contentActions:2', 'accordionContentActions:2', 'headerPrimaryActions:1.5', 'narrowHeaderMenu:1.5'] : 
+        targets: showPageBuilder ?
+            ['contentActions:2', 'accordionContentActions:2', 'headerPrimaryActions:1.5', 'narrowHeaderMenu:1.5'] :
             ['contentActions:2', 'accordionContentActions:2', 'narrowHeaderMenu:1.5'],
         showOnNodeTypes: ['jnt:page'], // For edit pages
         requiredSitePermission: ['editPageAction'],

--- a/src/javascript/JContent/JContent.accordion-items.jsx
+++ b/src/javascript/JContent/JContent.accordion-items.jsx
@@ -35,7 +35,7 @@ export const jContentAccordionItems = registry => {
     const renderDefaultContentTrees = registry.add('accordionItem', 'renderDefaultContentTrees', {
         render: (v, item) => (
             <AccordionItem key={v.id} {...v}>
-                <ContentTree item={item} contextualMenuAction="contentMenu"/>
+                <ContentTree item={item} contextualMenuAction="accordionContentMenu"/>
             </AccordionItem>
         ),
         routeComponent: ContentRoute,

--- a/src/javascript/JContent/JContent.actions.jsx
+++ b/src/javascript/JContent/JContent.actions.jsx
@@ -335,7 +335,7 @@ export const jContentActions = registry => {
     registry.add('action', 'subContents', {
         buttonIcon: <Subdirectory/>,
         buttonLabel: 'jcontent:label.contentManager.subContentsAction',
-        targets: ['contentActions:15', 'accordionContentActions:15'],
+        targets: ['contentActions:15'],
         component: SubContentsActionComponent
     });
     registry.add('action', 'exportPage', {

--- a/src/javascript/JContent/JContent.actions.jsx
+++ b/src/javascript/JContent/JContent.actions.jsx
@@ -83,26 +83,26 @@ export const jContentActions = registry => {
     registry.add('action', 'preview', {
         buttonIcon: <Visibility/>,
         buttonLabel: 'jcontent:label.contentManager.contentPreview.preview',
-        targets: ['contentActions:1'],
+        targets: ['contentActions:1', 'accordionContentActions:1'],
         component: PreviewActionComponent
     });
     registry.add('action', 'createContentFolder', {
         buttonIcon: <AddFolder/>,
         buttonLabel: 'jcontent:label.contentManager.create.contentFolder',
-        targets: ['createMenuActions:3', 'contentActions:2', 'headerPrimaryActions:2', 'narrowHeaderMenu:2'],
+        targets: ['createMenuActions:3', 'contentActions:2', 'accordionContentActions:2', 'headerPrimaryActions:2', 'narrowHeaderMenu:2'],
         createFolderType: 'contentFolder',
         component: CreateFolderActionComponent
     });
     registry.add('action', 'rename', {
         buttonIcon: <Edit/>,
         buttonLabel: 'jcontent:label.contentManager.rename',
-        targets: ['contentActions:2', 'narrowHeaderMenu:12'],
+        targets: ['contentActions:2', 'accordionContentActions:2', 'narrowHeaderMenu:12'],
         component: RenameActionComponent
     });
     registry.add('action', 'createFolder', {
         buttonIcon: <AddFolder/>,
         buttonLabel: 'jcontent:label.contentManager.create.folder',
-        targets: ['createMenuActions:3', 'contentActions:3', 'headerPrimaryActions:2.5', 'narrowHeaderMenu:2.5'],
+        targets: ['createMenuActions:3', 'contentActions:3', 'accordionContentActions:3', 'headerPrimaryActions:2.5', 'narrowHeaderMenu:2.5'],
         createFolderType: 'folder',
         component: CreateFolderActionComponent
     });
@@ -121,14 +121,14 @@ export const jContentActions = registry => {
     registry.add('action', 'fileUpload', {
         buttonIcon: <Publish/>,
         buttonLabel: 'jcontent:label.contentManager.fileUpload.uploadButtonLabel',
-        targets: ['createMenuActions:4', 'contentActions:4', 'headerPrimaryActions:3', 'narrowHeaderMenu:2.3'],
+        targets: ['createMenuActions:4', 'contentActions:4', 'accordionContentActions:4', 'headerPrimaryActions:3', 'narrowHeaderMenu:2.3'],
         uploadType: 'fileUpload',
         component: FileUploadActionComponent
     });
     registry.add('action', 'publishMenu', menuActionWithRenderer, {
         buttonIcon: <Cloud/>,
         buttonLabel: 'jcontent:label.contentManager.contentPreview.publishMenu',
-        targets: ['contentActions:6', 'selectedContentActions:1'],
+        targets: ['contentActions:6', 'accordionContentActions:6', 'selectedContentActions:1'],
         menuTarget: 'publishMenu',
         hideOnNodeTypes: ['jnt:category'],
         isMenuPreload: true
@@ -170,7 +170,7 @@ export const jContentActions = registry => {
     registry.add('action', 'publishDeletion', {
         buttonIcon: <Delete/>,
         buttonLabel: 'jcontent:label.contentManager.contentPreview.publishDeletion',
-        targets: ['contentActions:4', 'selectedContentActions:4', 'narrowHeaderSelectionMenu:14', 'narrowHeaderMenu:14'],
+        targets: ['contentActions:4', 'accordionContentActions:4', 'selectedContentActions:4', 'narrowHeaderSelectionMenu:14', 'narrowHeaderMenu:14'],
         component: PublishDeletionActionComponent
     });
     registry.add('action', 'unpublish', {
@@ -197,7 +197,14 @@ export const jContentActions = registry => {
             isShowIcons: true
         }
     });
-
+    registry.add('action', 'accordionContentMenu', menuActionWithRenderer, {
+        buttonIcon: <MoreVert/>,
+        buttonLabel: 'jcontent:label.contentManager.contentPreview.moreOptions',
+        menuTarget: 'accordionContentActions',
+        menuItemProps: {
+            isShowIcons: true
+        }
+    });
     registry.add('action', 'rootContentMenu', menuActionWithRenderer, {
         buttonIcon: <MoreVert/>,
         buttonLabel: 'jcontent:label.contentManager.contentPreview.moreOptions',
@@ -228,7 +235,7 @@ export const jContentActions = registry => {
     registry.add('action', 'copy', {
         buttonIcon: <Copy/>,
         buttonLabel: 'jcontent:label.contentManager.copyPaste.copy',
-        targets: ['contentActions:3.8', 'selectedContentActions:3.8', 'narrowHeaderSelectionMenu:3.8'],
+        targets: ['contentActions:3.8', 'accordionContentActions:3.8', 'selectedContentActions:3.8', 'narrowHeaderSelectionMenu:3.8'],
         copyCutType: 'copy',
         hideOnNodeTypes: ['jnt:virtualsite', 'jnt:page', 'jmix:isAreaList'],
         hideForPaths: [PATH_FILES_ITSELF, PATH_CONTENTS_ITSELF],
@@ -238,7 +245,7 @@ export const jContentActions = registry => {
         buttonIcon: <Copy/>,
         buttonLabel: 'jcontent:label.contentManager.copyPaste.copy',
         menuTarget: 'copyPageMenu',
-        targets: ['contentActions:3.8', 'selectedContentActions:3.8', 'narrowHeaderSelectionMenu:3.8'],
+        targets: ['contentActions:3.8', 'accordionContentActions:3.8', 'selectedContentActions:3.8', 'narrowHeaderSelectionMenu:3.8'],
         showOnNodeTypes: ['jnt:page'],
         component: CopyMenuComponent
     });
@@ -262,7 +269,7 @@ export const jContentActions = registry => {
     registry.add('action', 'cut', {
         buttonIcon: <Cut/>,
         buttonLabel: 'jcontent:label.contentManager.copyPaste.cut',
-        targets: ['contentActions:3.9', 'selectedContentActions:3.9', 'narrowHeaderSelectionMenu:3.9'],
+        targets: ['contentActions:3.9', 'accordionContentActions:3.9', 'selectedContentActions:3.9', 'narrowHeaderSelectionMenu:3.9'],
         copyCutType: 'cut',
         hideOnNodeTypes: ['jnt:virtualsite', 'jmix:hideDeleteAction', 'jmix:isAreaList'],
         hideForPaths: [PATH_FILES_ITSELF, PATH_CONTENTS_ITSELF],
@@ -271,7 +278,7 @@ export const jContentActions = registry => {
     registry.add('action', 'paste', {
         buttonIcon: <Paste/>,
         buttonLabel: 'jcontent:label.contentManager.copyPaste.paste',
-        targets: ['headerPrimaryActions:10', 'contentActions:3.91', 'rootContentActions:3.91', 'narrowHeaderMenu:4'],
+        targets: ['headerPrimaryActions:10', 'contentActions:3.91', 'accordionContentActions:3.91', 'rootContentActions:3.91', 'narrowHeaderMenu:4'],
         component: PasteActionComponent
     });
     registry.add('action', 'pasteReference', {
@@ -279,62 +286,62 @@ export const jContentActions = registry => {
         buttonLabel: 'jcontent:label.contentManager.copyPaste.pasteReference',
         hideOnNodeTypes: ['jnt:page', 'jnt:navMenuText', 'jnt:category'],
         referenceTypes: ['jnt:contentReference'],
-        targets: ['headerPrimaryActions:10.1', 'contentActions:3.92'],
+        targets: ['headerPrimaryActions:10.1', 'contentActions:3.92', 'accordionContentActions:3.92'],
         component: PasteActionComponent
     });
     registry.add('action', 'delete', {
         buttonIcon: <Delete/>,
         buttonLabel: 'jcontent:label.contentManager.contentPreview.delete',
-        targets: ['contentActions:4', 'selectedContentActions:4', 'narrowHeaderMenu:12', 'narrowHeaderSelectionMenu:4'],
+        targets: ['contentActions:4', 'accordionContentActions:4', 'selectedContentActions:4', 'narrowHeaderMenu:12', 'narrowHeaderSelectionMenu:4'],
         hideOnNodeTypes: ['jnt:virtualsite', 'jmix:hideDeleteAction', 'jmix:isAreaList'],
         component: DeleteActionComponent
     });
     registry.add('action', 'deletePermanently', {
         buttonIcon: <Delete/>,
         buttonLabel: 'jcontent:label.contentManager.contentPreview.deletePermanently',
-        targets: ['contentActions:4', 'selectedContentActions:4', 'narrowHeaderMenu:12', 'narrowHeaderSelectionMenu:4'],
+        targets: ['contentActions:4', 'accordionContentActions:4', 'selectedContentActions:4', 'narrowHeaderMenu:12', 'narrowHeaderSelectionMenu:4'],
         component: DeletePermanentlyActionComponent
     });
     registry.add('action', 'undelete', {
         buttonIcon: <Undelete/>,
         buttonLabel: 'jcontent:label.contentManager.contentPreview.undelete',
-        targets: ['contentActions:4.1', 'selectedContentActions:4.1', 'narrowHeaderMenu:12', 'narrowHeaderSelectionMenu:4'],
+        targets: ['contentActions:4.1', 'accordionContentActions:4.1', 'selectedContentActions:4.1', 'narrowHeaderMenu:12', 'narrowHeaderSelectionMenu:4'],
         component: UndeleteActionComponent
     });
     registry.add('action', 'lock', {
         buttonLabel: 'jcontent:label.contentManager.contextMenu.lockActions.lock',
-        targets: ['contentActions:5', 'narrowHeaderMenu:14'],
+        targets: ['contentActions:5', 'accordionContentActions:5', 'narrowHeaderMenu:14'],
         buttonIcon: <Lock/>,
         component: LockActionComponent
     });
     registry.add('action', 'unlock', {
         buttonLabel: 'jcontent:label.contentManager.contextMenu.lockActions.unlock',
-        targets: ['contentActions:5', 'narrowHeaderMenu:14'],
+        targets: ['contentActions:5', 'accordionContentActions:5', 'narrowHeaderMenu:14'],
         buttonIcon: <Unlock/>,
         component: UnlockActionComponent
     });
     registry.add('action', 'clearAllLocks', {
         buttonIcon: <Lock/>,
         buttonLabel: 'jcontent:label.contentManager.contextMenu.lockActions.clearAllLocks',
-        targets: ['contentActions:5.5', 'narrowHeaderMenu:14'],
+        targets: ['contentActions:5.5', 'accordionContentActions:5.5', 'narrowHeaderMenu:14'],
         component: ClearAllLocksActionComponent
     });
     registry.add('action', 'locate', {
         buttonLabel: 'jcontent:label.contentManager.actions.locate',
         buttonIcon: <Search/>,
-        targets: ['contentActions:0.5', 'narrowHeaderMenu:10.5'],
+        targets: ['contentActions:0.5', 'accordionContentActions:0.5', 'narrowHeaderMenu:10.5'],
         component: LocateActionComponent
     });
     registry.add('action', 'subContents', {
         buttonIcon: <Subdirectory/>,
         buttonLabel: 'jcontent:label.contentManager.subContentsAction',
-        targets: ['contentActions:15'],
+        targets: ['contentActions:15', 'accordionContentActions:15'],
         component: SubContentsActionComponent
     });
     registry.add('action', 'exportPage', {
         buttonIcon: <Upload/>,
         buttonLabel: 'jcontent:label.contentManager.export.actionLabel',
-        targets: ['contentActions:4.2', 'narrowHeaderMenu:13'],
+        targets: ['contentActions:4.2', 'accordionContentActions:4.2', 'narrowHeaderMenu:13'],
         showOnNodeTypes: ['jnt:page'],
         requiredSitePermission: [ACTION_PERMISSIONS.exportPageAction],
         component: ExportActionComponent
@@ -342,7 +349,7 @@ export const jContentActions = registry => {
     registry.add('action', 'export', {
         buttonIcon: <Upload/>,
         buttonLabel: 'jcontent:label.contentManager.export.actionLabel',
-        targets: ['contentActions:4.2', 'narrowHeaderMenu:13', 'selectedContentActions:2'],
+        targets: ['contentActions:4.2', 'accordionContentActions:4.2', 'narrowHeaderMenu:13', 'selectedContentActions:2'],
         showOnNodeTypes: ['jnt:contentFolder', 'jnt:content', 'jnt:category'],
         requiredSitePermission: [ACTION_PERMISSIONS.exportAction],
         component: ExportActionComponent
@@ -351,46 +358,46 @@ export const jContentActions = registry => {
         buttonIcon: <Archive/>,
         buttonLabel: 'jcontent:label.contentManager.downloadAsZip',
         buttonLabelShort: 'jcontent:label.contentManager.downloadFile.download',
-        targets: ['contentActions:4.21', 'selectedContentActions', 'narrowHeaderMenu:14', 'narrowHeaderSelectionMenu:1'],
+        targets: ['contentActions:4.21', 'accordionContentActions:4.21', 'selectedContentActions', 'narrowHeaderMenu:14', 'narrowHeaderSelectionMenu:1'],
         showOnNodeTypes: ['jnt:file', 'jnt:folder'],
         component: DownloadAsZipActionComponent
     });
     registry.add('action', 'import', {
         buttonIcon: <Download/>,
         buttonLabel: 'jcontent:label.contentManager.import.action',
-        targets: ['contentActions:4.3', 'createMenuActions:3.5', 'narrowHeaderMenu:4', 'narrowHeaderSelectionMenu:4', 'headerPrimaryActions:4'],
+        targets: ['contentActions:4.3', 'accordionContentActions:4.3', 'createMenuActions:3.5', 'narrowHeaderMenu:4', 'narrowHeaderSelectionMenu:4', 'headerPrimaryActions:4'],
         uploadType: 'import',
         component: FileUploadActionComponent
     });
     registry.add('action', 'editImage', {
         buttonIcon: <Edit/>,
         buttonLabel: 'jcontent:label.contentManager.editImage.action',
-        targets: ['contentActions:2.5', 'narrowHeaderMenu:12.5'],
+        targets: ['contentActions:2.5', 'accordionContentActions:2.5', 'narrowHeaderMenu:12.5'],
         component: EditImageActionComponent
     });
     registry.add('action', 'downloadFile', {
         buttonIcon: <CloudDownload/>,
         buttonLabel: 'jcontent:label.contentManager.contentPreview.download',
-        targets: ['contentActions:3.7', 'narrowHeaderMenu:13.7'],
+        targets: ['contentActions:3.7', 'accordionContentActions:3.7', 'narrowHeaderMenu:13.7'],
         component: DownloadFileActionComponent
     });
     registry.add('action', 'replaceFile', {
         buttonIcon: <Reload/>,
         buttonLabel: 'jcontent:label.contentManager.fileUpload.replaceWith',
-        targets: ['contentActions:0.2', 'narrowHeaderMenu:10.2'],
+        targets: ['contentActions:0.2', 'accordionContentActions:0.2', 'narrowHeaderMenu:10.2'],
         uploadType: 'replaceWith',
         component: FileUploadActionComponent
     });
     registry.add('action', 'zip', {
         buttonIcon: <FileZip/>,
         buttonLabel: 'jcontent:label.contentManager.zipUnzip.zip',
-        targets: ['contentActions:2.1', 'selectedContentActions', 'narrowHeaderSelectionMenu:0.5', 'narrowHeaderMenu:12'],
+        targets: ['contentActions:2.1', 'accordionContentActions:2.1', 'selectedContentActions', 'narrowHeaderSelectionMenu:0.5', 'narrowHeaderMenu:12'],
         component: ZipActionComponent
     });
     registry.add('action', 'unzip', {
         buttonIcon: <FileZip/>,
         buttonLabel: 'jcontent:label.contentManager.zipUnzip.unzip',
-        targets: ['contentActions:2.2', 'narrowHeaderMenu:12.2'],
+        targets: ['contentActions:2.2', 'accordionContentActions:2.2', 'narrowHeaderMenu:12.2'],
         component: UnzipActionComponent
     });
     registry.add('action', 'search', {
@@ -408,7 +415,7 @@ export const jContentActions = registry => {
     registry.add('action', 'openInPageBuilder', {
         buttonIcon: <OpenInBrowser/>,
         buttonLabel: 'jcontent:label.contentManager.actions.openInPageBuilder',
-        targets: ['contentActions:2.2', 'narrowHeaderMenu:12.2'],
+        targets: ['contentActions:2.2', 'accordionContentActions:2.2', 'narrowHeaderMenu:12.2'],
         component: OpenInPageBuilderActionComponent
     });
 
@@ -453,17 +460,17 @@ export const jContentActions = registry => {
     registry.add('action', 'openInRepositoryExplorer', {
         buttonIcon: <OpenInBrowser/>,
         buttonLabel: 'jcontent:label.contentManager.actions.openInRepositoryExplorer',
-        targets: ['contentActions:2.3'],
+        targets: ['contentActions:2.3', 'accordionContentActions:2.3'],
         component: OpenInRepositoryExplorerActionComponent
     });
 
     registry.add('action', 'contentActionsSeparator1', {
-        targets: ['contentActions:0', 'rootContentActions:0'],
+        targets: ['contentActions:0', 'accordionContentActions:0', 'rootContentActions:0'],
         isSeparator: true
     });
 
     registry.add('action', 'contentActionsSeparator2', {
-        targets: ['contentActions:10', 'narrowHeaderMenu:10'],
+        targets: ['contentActions:10', 'accordionContentActions:10', 'narrowHeaderMenu:10'],
         isSeparator: true
     });
 
@@ -527,7 +534,7 @@ export const jContentActions = registry => {
         component: FlushCacheActionComponent,
         showOnNodeTypes: ['jnt:page'],
         buttonLabel: 'jcontent:label.cache.flushPageCache',
-        targets: ['contentActions:6'],
+        targets: ['contentActions:6', 'accordionContentActions:6'],
         buttonIcon: <Replay/>
     });
 
@@ -535,7 +542,7 @@ export const jContentActions = registry => {
         component: FlushCacheActionComponent,
         showOnNodeTypes: ['jnt:page', 'jnt:virtualsite'],
         buttonLabel: 'jcontent:label.cache.flushSiteCache',
-        targets: ['contentActions:6'],
+        targets: ['contentActions:6', 'accordionContentActions:6'],
         buttonIcon: <Replay/>
     });
 };

--- a/tests/cypress/e2e/jcontent/registryLabels.cy.ts
+++ b/tests/cypress/e2e/jcontent/registryLabels.cy.ts
@@ -30,11 +30,11 @@ describe('Registry labels test', () => {
         cy.get('li[data-registry-key="action:createPage"]')
             .should('exist')
             .invoke('attr', 'data-registry-target')
-            .should('eq', 'contentActions:-2');
+            .should('eq', 'accordionContentActions:-2');
 
         cy.get('li[data-registry-key="action:editPage"]')
             .should('exist')
             .invoke('attr', 'data-registry-target')
-            .should('eq', 'contentActions:2');
+            .should('eq', 'accordionContentActions:2');
     });
 });


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23258

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Create new `accordionContentActions` menu action and use it as default context menu for accordions/navigation items.

We then remove 'View sub-contents` action only for navigation. 