### PR TITLE
BACKLOG-23210: close notification after 5sec

### DIFF
--- a/src/javascript/JContent/actions/flushCacheAction/FlushCacheAction.jsx
+++ b/src/javascript/JContent/actions/flushCacheAction/FlushCacheAction.jsx
@@ -38,7 +38,7 @@ export const FlushCacheActionComponent = ({path, render: Render, loading: Loadin
                 }).then(res => {
                     if (res?.data?.jcontent?.flush) {
                         const typeOfCache = isSiteFlush ? 'flushedSiteCache' : 'flushedPageCache';
-                        notificationContext.notify(t(`jcontent:label.cache.${typeOfCache}`), ['closeButton']);
+                        notificationContext.notify(t(`jcontent:label.cache.${typeOfCache}`), ['closeButton', 'closeAfter5s']);
                     }
                 });
             }}


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-23210

## Description

I added a step to close the flush cache notification popup after 5 seconds ; otherwise the popup stays open until I click somewhere else.