### PR TITLE
BACKLOG-23415: Add query checks for customized preview app

### DIFF
--- a/src/javascript/JContent/actions/customizedPreviewAction/customizedPreviewApp.jsx
+++ b/src/javascript/JContent/actions/customizedPreviewAction/customizedPreviewApp.jsx
@@ -46,13 +46,14 @@ export const CustomizedPreviewApp = () => {
         params: state.jcontent.params
     }));
     const {width, height} = useIframeDimensions(params?.openDialog?.params);
+    const isCustomizedPreview = params?.openDialog?.key === 'customizedPreview';
 
     const res = useQuery(OpenInActionQuery, {
         variables: {path, language, workspace: 'EDIT'},
-        skip: !path
+        skip: !path || !isCustomizedPreview
     });
 
-    if (params?.openDialog?.key !== 'customizedPreview') {
+    if (!isCustomizedPreview) {
         return null;
     }
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23415

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

As the customized preview component is exposed as a jcontent root app, we need to filter out the requests and make sure that the request only applies in the context of customized preview before the query.

Fixed for failing tests in robots module.