### PR TITLE
BACKLOG-23356: Fix issue with GWT refresh when creating another content

### DIFF
--- a/src/javascript/ContentEditor/ContentEditorApi/ContentEditorModal.jsx
+++ b/src/javascript/ContentEditor/ContentEditorApi/ContentEditorModal.jsx
@@ -141,6 +141,8 @@ export const ContentEditorModal = ({editorConfig, updateEditorConfig, onExited})
     mergedConfig.onClosedCallback = () => {
         if (onClosedCallback) {
             onClosedCallback(mergedConfig, needRefresh.current);
+            // Mark as refreshed after callback to avoid multiple refreshes
+            needRefresh.current = false;
         }
     };
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23356

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Potential concurrency issue with multiple calls to onClosedCallback with state changes while create dialog is open (due to create another checkbox enabled).

This could cause for a refresh to be called while in the middle of the refresh and document not fully loaded which could potentially throw errors.

Workaround fix is to update `needRefresh` status after calling callback to make sure that refresh only happens once after an update.
