### PR TITLE
BACKLOG-22766: Disable Empty drop zone for unauthorized user

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/Picker/JahiaPicker/RightPanel/PickerContentLayout/PickerContentTable/PickerContentTable.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/JahiaPicker/RightPanel/PickerContentLayout/PickerContentTable/PickerContentTable.jsx
@@ -140,7 +140,7 @@ export const PickerContentTable = ({rows, isContentNotFound, totalCount, isLoadi
         dispatch(batchActions(actions));
     };
 
-    const [{isCanDrop}, drop] = useFileDrop({
+    const [{isCanDrop, allowDrop}, drop] = useFileDrop({
         uploadType: tableConfig?.uploadType,
         uploadPath: path,
         uploadFilter: file => !tableConfig?.uploadFilter || tableConfig.uploadFilter(file, mode, pickerConfig)
@@ -160,7 +160,7 @@ export const PickerContentTable = ({rows, isContentNotFound, totalCount, isLoadi
         return (
             <>
                 {tableHeader}
-                <ContentEmptyDropZone reference={drop} uploadType={tableConfig?.uploadType} isCanDrop={isCanDrop}/>
+                <ContentEmptyDropZone reference={drop} uploadType={tableConfig?.uploadType} isCanDrop={isCanDrop} allowDrop={allowDrop}/>
             </>
         );
     }

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/JahiaPicker/RightPanel/PickerContentLayout/PickerFilesGrid/PickerFilesGrid.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/JahiaPicker/RightPanel/PickerContentLayout/PickerFilesGrid/PickerFilesGrid.jsx
@@ -92,7 +92,7 @@ export const PickerFilesGrid = ({totalCount, rows, isLoading, pickerConfig, isMu
         }
     }, [pagination.currentPage]);
 
-    const [{isCanDrop}, dropFile] = useFileDrop({
+    const [{isCanDrop, allowDrop}, dropFile] = useFileDrop({
         uploadType: 'upload',
         uploadPath: path,
         uploadFilter: file => !tableConfig?.uploadFilter || tableConfig.uploadFilter(file, mode, pickerConfig)
@@ -102,7 +102,7 @@ export const PickerFilesGrid = ({totalCount, rows, isLoading, pickerConfig, isMu
 
     if ((!rows || rows.length === 0) && !isLoading) {
         return (
-            <FilesGridEmptyDropZone uploadType="upload" reference={mainPanelRef} isCanDrop={isCanDrop}/>
+            <FilesGridEmptyDropZone uploadType="upload" reference={mainPanelRef} isCanDrop={isCanDrop} allowDrop={allowDrop}/>
         );
     }
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentEmptyDropZone.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentEmptyDropZone.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import EmptyDropZone from '../EmptyDropZone';
 
-export const ContentEmptyDropZone = ({uploadType, reference, isCanDrop, selector}) => (
+export const ContentEmptyDropZone = ({uploadType, reference, isCanDrop, allowDrop, selector}) => (
     <div ref={reference} className="flexFluid flexRow" style={{padding: '16px'}}>
-        <EmptyDropZone component="div" uploadType={uploadType} isCanDrop={isCanDrop} selector={selector}/>
+        <EmptyDropZone component="div" uploadType={uploadType} isCanDrop={isCanDrop} allowDrop={allowDrop} selector={selector}/>
     </div>
 );
 
@@ -12,5 +12,6 @@ ContentEmptyDropZone.propTypes = {
     uploadType: PropTypes.string,
     reference: PropTypes.object,
     isCanDrop: PropTypes.bool,
+    allowDrop: PropTypes.bool,
     selector: PropTypes.func
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
@@ -109,7 +109,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
 
     const tableConfig = registry.get('accordionItem', mode)?.tableConfig;
 
-    const [{isCanDrop}, drop] = useFileDrop({uploadType: tableConfig?.uploadType, uploadPath: path});
+    const [{isCanDrop, allowDrop}, drop] = useFileDrop({uploadType: tableConfig?.uploadType, uploadPath: path});
 
     if (isContentNotFound) {
         return <ContentNotFound columnSpan={columnData.length} t={t}/>;
@@ -125,7 +125,7 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
         return (
             <>
                 {tableHeader}
-                <ContentEmptyDropZone reference={drop} uploadType={tableConfig?.uploadType} isCanDrop={isCanDrop} selector={selector}/>
+                <ContentEmptyDropZone reference={drop} uploadType={tableConfig?.uploadType} isCanDrop={isCanDrop} allowDrop={allowDrop} selector={selector}/>
             </>
         );
     }

--- a/src/javascript/JContent/ContentRoute/ContentLayout/EmptyDropZone/EmptyDropZone.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/EmptyDropZone/EmptyDropZone.jsx
@@ -13,7 +13,7 @@ import {getButtonRenderer} from '~/utils/getButtonRenderer';
 
 const ButtonRenderer = getButtonRenderer({labelStyle: 'short', defaultButtonProps: {className: styles.button, size: 'big'}});
 
-const EmptyDropZone = ({component: Component, isCanDrop, uploadType, selector}) => {
+const EmptyDropZone = ({component: Component, isCanDrop, allowDrop, uploadType, selector}) => {
     const currentState = useSelector(selector, shallowEqual);
     const {t} = useTranslation('jcontent');
 
@@ -63,7 +63,7 @@ const EmptyDropZone = ({component: Component, isCanDrop, uploadType, selector}) 
         );
     }
 
-    if (uploadType === JContentConstants.mode.UPLOAD && permissions.node.site.uploadFilesAction) {
+    if (uploadType === JContentConstants.mode.UPLOAD && permissions.node.site.uploadFilesAction && allowDrop) {
         return (
             <Component data-type="upload" className={clsx(styles.dropZone, isCanDrop && styles.dropZoneEnabled)}>
                 {!isCanDrop && <Typography variant="heading">{t('jcontent:label.contentManager.fileUpload.dropMessage')}</Typography>}
@@ -73,7 +73,7 @@ const EmptyDropZone = ({component: Component, isCanDrop, uploadType, selector}) 
         );
     }
 
-    if (uploadType === JContentConstants.mode.IMPORT && permissions.node.site.importAction) {
+    if (uploadType === JContentConstants.mode.IMPORT && permissions.node.site.importAction && allowDrop) {
         return (
             <Component data-type="import" className={clsx(styles.dropZone, isCanDrop && styles.dropZoneEnabled)}>
                 {!isCanDrop && <Typography variant="heading">{t('jcontent:label.contentManager.import.dropMessage')}</Typography>}
@@ -95,6 +95,7 @@ EmptyDropZone.propTypes = {
     component: PropTypes.string.isRequired,
     uploadType: PropTypes.string,
     isCanDrop: PropTypes.bool,
+    allowDrop: PropTypes.bool,
     selector: PropTypes.func
 };
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.jsx
@@ -98,7 +98,7 @@ export const FilesGrid = ({isContentNotFound, totalCount, rows, isLoading}) => {
 
     const tableConfig = registry.get('accordionItem', mode)?.tableConfig;
 
-    const [{isCanDrop}, drop] = useFileDrop({uploadType: JContentConstants.mode.UPLOAD, uploadPath: path});
+    const [{isCanDrop, allowDrop}, drop] = useFileDrop({uploadType: JContentConstants.mode.UPLOAD, uploadPath: path});
 
     if ((!rows || rows.length === 0) && isLoading) {
         return null;
@@ -116,12 +116,15 @@ export const FilesGrid = ({isContentNotFound, totalCount, rows, isLoading}) => {
 
     if ((!rows || rows.length === 0) && !isLoading) {
         return (
-            <FilesGridEmptyDropZone uploadType={JContentConstants.mode.UPLOAD}
-                                    reference={el => {
-                                        mainPanelRef.current = el;
-                                        drop(mainPanelRef);
-                                    }}
-                                    isCanDrop={isCanDrop}/>
+            <FilesGridEmptyDropZone
+                uploadType={JContentConstants.mode.UPLOAD}
+                reference={el => {
+                    mainPanelRef.current = el;
+                    drop(mainPanelRef);
+                }}
+                isCanDrop={isCanDrop}
+                allowDrop={allowDrop}
+            />
         );
     }
 

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGridEmptyDropZone.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGridEmptyDropZone.jsx
@@ -4,12 +4,12 @@ import {Grid, RootRef} from '@material-ui/core';
 import EmptyDropZone from '../EmptyDropZone';
 import styles from './FilesGridEmptyDropZone.scss';
 
-export const FilesGridEmptyDropZone = ({uploadType, reference, isCanDrop}) => {
+export const FilesGridEmptyDropZone = ({uploadType, reference, isCanDrop, allowDrop}) => {
     return (
         <RootRef rootRef={reference}>
             <Grid container className={styles.gridEmpty} data-cm-role="grid-content-list">
                 <div className={styles.dragZoneRoot}>
-                    <EmptyDropZone component="div" uploadType={uploadType} isCanDrop={isCanDrop}/>
+                    <EmptyDropZone component="div" uploadType={uploadType} isCanDrop={isCanDrop} allowDrop={allowDrop}/>
                 </div>
             </Grid>
         </RootRef>
@@ -19,7 +19,8 @@ export const FilesGridEmptyDropZone = ({uploadType, reference, isCanDrop}) => {
 FilesGridEmptyDropZone.propTypes = {
     uploadType: PropTypes.string,
     reference: PropTypes.object,
-    isCanDrop: PropTypes.bool
+    isCanDrop: PropTypes.bool,
+    allowDrop: PropTypes.bool
 };
 
 export default FilesGridEmptyDropZone;

--- a/src/javascript/JContent/dnd/useFileDrop.jsx
+++ b/src/javascript/JContent/dnd/useFileDrop.jsx
@@ -143,7 +143,8 @@ export function useFileDrop({uploadPath, uploadType, uploadMaxSize = Infinity, u
         canDrop: (item, monitor) => allowDrop && monitor.isOver({shallow: true}),
         collect: monitor => ({
             isOver: monitor.isOver({shallow: true}),
-            isCanDrop: monitor.canDrop()
+            isCanDrop: monitor.canDrop(),
+            allowDrop
         })
     }), [client, dispatch, uploadFilter, uploadPath, uploadType, uploadMaxSize, uploadMinSize, allowDrop]);
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22766

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Propagate the permission check done in useFileDrop down to EmptyDropZone to be able to display the correct Empty zone component.

Added cypress test
