### PR TITLE
DMF-6381: set fetch-policy to network-only on boxes query

### DIFF
--- a/src/javascript/JContent/EditFrame/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes.jsx
@@ -309,7 +309,7 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
         ...placeholders.map(m => m.ownerDocument.getElementById(m.dataset.jahiaParent).dataset.jahiaPath)
     ])];
 
-    const {data, refetch} = useQuery(BoxesQuery, {variables: {paths, language, displayLanguage}, errorPolicy: 'all'});
+    const {data, refetch} = useQuery(BoxesQuery, {variables: {paths, language, displayLanguage}, fetchPolicy: 'network-only', errorPolicy: 'all'});
 
     useEffect(() => {
         setRefetcher(refetchTypes.PAGE_BUILDER_BOXES, {refetch: refetch});


### PR DESCRIPTION
https://jira.jahia.org/browse/DMF-6381

jExperience has a feature to promote a page variant to the default one in page builder. The promote variant consist in moving the contents of the variant node to the page node and the contents of the page node to the variant node.

When a variant becomes the default one, page builder is refreshed and the default variant is displayed.

At this moment, the boxes in jContent are redrawn but sometimes it's failing because the BoxesQuery returns some old paths. These paths does not match the paths of the the displayed content so the boxes are not displayed correctly.

As it seems to be a cache issue, I changed the fetchPolicy to network-only and it's fixing the issue