### PR TITLE
BACKLOG-23452: Provide a way to override date format in date time picker

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/DateTimePicker/DateTimePicker.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/DateTimePicker/DateTimePicker.jsx
@@ -13,15 +13,30 @@ const variantMapper = {
     DateTimePicker: 'datetime'
 };
 
+function getDateFormat(editorContext) {
+    const userNavigatorLocale = editorContext.browserLang;
+    const allowedOverridesDateFormat = ['MM/DD/YYYY', 'DD/MM/YYYY'];
+
+    // Read date format from config
+    const forceDateFormat = window.contextJsParameters?.config?.jcontent?.forceDateFormat;
+    if (forceDateFormat && !allowedOverridesDateFormat.includes(forceDateFormat)) {
+        console.warn(`forceDateFormat as been set to an invalid value (${forceDateFormat}). Please use one of the following values: ${allowedOverridesDateFormat.join(', ')}`);
+    } else if (forceDateFormat) {
+        return forceDateFormat;
+    }
+
+    // Fallback on browser language date format
+    return userNavigatorLocale in specificDateFormat ? specificDateFormat[userNavigatorLocale] : 'DD/MM/YYYY';
+}
+
 export const DateTimePicker = ({id, field, value, editorContext, onChange, onBlur}) => {
     const variant = variantMapper[field.selectorType];
     const isDateTime = variant === 'datetime';
     const disabledDays = fillDisabledDaysFromJCRConstraints(field, isDateTime);
     const uilang = useSelector(state => state.uilang);
 
-    const userNavigatorLocale = editorContext.browserLang;
+    const dateFormat = getDateFormat(editorContext);
 
-    const dateFormat = userNavigatorLocale in specificDateFormat ? specificDateFormat[userNavigatorLocale] : 'DD/MM/YYYY';
     const displayDateFormat = isDateTime ? (dateFormat + ' HH:mm') : dateFormat;
 
     const maskLocale = String(dateFormat).replace(/[^\W]+?/g, '_');

--- a/src/javascript/ContentEditor/SelectorTypes/DateTimePicker/DateTimePicker.spec.js
+++ b/src/javascript/ContentEditor/SelectorTypes/DateTimePicker/DateTimePicker.spec.js
@@ -120,4 +120,26 @@ describe('DateTimePicker component', () => {
 
         expect(cmp.props().dayPickerProps.disabledDays).toEqual([{before: new Date('2019-06-04T00:00:00.000')}]);
     });
+
+    it('should use the override date format when provided', () => {
+        window.contextJsParameters = {
+            config: {
+                jcontent: {
+                    forceDateFormat: 'MM/DD/YYYY'
+                }
+            }
+        };
+        testDateFormat('de-DE', 'MM/DD/YYYY');
+    });
+
+    it('should NOT use the override date format when an invalid format is provided', () => {
+        window.contextJsParameters = {
+            config: {
+                jcontent: {
+                    forceDateFormat: 'MM/DD/INVALID'
+                }
+            }
+        };
+        testDateFormat('de-DE', 'DD.MM.YYYY');
+    });
 });

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.jcontent.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.jcontent.cfg
@@ -7,3 +7,7 @@ hideLegacyPageComposer=true
 
 # Allow to define the number of "New Content" buttons when an editing zone as content restrictions activated
 createChildrenDirectButtons.limit = 5
+
+# forceDateFormat overrides the browser locale format of date in content editor
+# Possible values are: DD/MM/YYYY, MM/DD/YYYY
+forceDateFormat=DD/MM/YYYY


### PR DESCRIPTION
Provide a way to override date format in date time selector type using a configuration name forceDateFormat (DD/MM/YYYY, MM/DD/YYYY are only valid format)

https://jira.jahia.org/browse/BACKLOG-23452

(Same as https://github.com/Jahia/content-editor/pull/1778 in content editor)