### PR TITLE
BACKLOG-23304: Hide rename action for media/files root folder

### DIFF
--- a/src/javascript/JContent/actions/renameAction/renameAction.jsx
+++ b/src/javascript/JContent/actions/renameAction/renameAction.jsx
@@ -3,6 +3,7 @@ import {RenameDialog} from './RenameDialog';
 import {useNodeChecks} from '@jahia/data-helper';
 import {ComponentRendererContext} from '@jahia/ui-extender';
 import PropTypes from 'prop-types';
+import {PATH_FILES_ITSELF} from '../actions.constants';
 
 export const RenameActionComponent = ({path, render: Render, loading: Loading, ...others}) => {
     const componentRenderer = useContext(ComponentRendererContext);
@@ -10,7 +11,8 @@ export const RenameActionComponent = ({path, render: Render, loading: Loading, .
         {path},
         {
             requiredPermission: ['jcr:write'],
-            showOnNodeTypes: ['jnt:folder', 'jnt:file']
+            showOnNodeTypes: ['jnt:folder', 'jnt:file'],
+            hideForPaths: [PATH_FILES_ITSELF]
         }
     );
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

https://jira.jahia.org/browse/BACKLOG-23304
