### PR TITLE
QA-15374: Add check if node is renderable in page builder

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentRoute.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentRoute.jsx
@@ -26,7 +26,7 @@ const useRenderCheck = ({path, language, template, node, skip}) => {
         if (node && !renderCheck?.loading && renderCheck?.error) {
             openDialog(node);
         }
-    }, [node, renderCheck]);
+    }, [node, renderCheck, openDialog]);
 
     return {renderCheck, dialogProps};
 };
@@ -51,7 +51,7 @@ export const ContentRoute = () => {
     const isOpenDialog = Boolean(params?.openDialog?.key);
     const canShowEditFrame = Boolean(res?.node) && nodeTypes.some(nt => res.node[nt]) && !isOpenDialog;
     const {renderCheck, dialogProps} = useRenderCheck({
-        path, language, template, node: res?.node, skip: !Boolean(res?.node && isPageBuilderView && canShowEditFrame)
+        path, language, template, node: res?.node, skip: !(res?.node && isPageBuilderView && canShowEditFrame)
     });
 
     useEffect(() => {
@@ -121,12 +121,12 @@ export const ContentRoute = () => {
             <MainLayout header={<ContentHeader/>}>
                 <LoaderSuspense>
                     <ErrorBoundary>
-                        {renderCheck?.error && <></>}
+                        {renderCheck?.error && null}
                         {(!renderCheck?.error && isPageBuilderView && canShowEditFrame) ? <EditFrame/> : <ContentLayout/>}
                     </ErrorBoundary>
                 </LoaderSuspense>
             </MainLayout>
-            <NonDisplayableNodeDialog {...dialogProps}/>;
+            <NonDisplayableNodeDialog hasCancel={false} {...dialogProps}/>;
         </>
     );
 };

--- a/src/javascript/JContent/ContentRoute/renderedContent.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/renderedContent.gql-queries.js
@@ -2,11 +2,13 @@ import gql from 'graphql-tag';
 import {PredefinedFragments} from '@jahia/data-helper';
 
 export const RenderCheckQuery = gql`
-    query renderCheck($path: String!) {
+    query renderCheck($path: String!, $language: String!, $view: String = "default") {
         jcr {
             nodeByPath(path: $path) {
                 ...NodeCacheRequiredFields
-                isDisplayableNode
+                renderedContent(view: $view, templateType: "html", contextConfiguration: "page", language: $language) {
+                    output
+                }
             }
         }
     }

--- a/src/javascript/JContent/ContentRoute/renderedContent.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/renderedContent.gql-queries.js
@@ -2,13 +2,11 @@ import gql from 'graphql-tag';
 import {PredefinedFragments} from '@jahia/data-helper';
 
 export const RenderCheckQuery = gql`
-    query renderCheck($path: String!, $language: String!, $view: String = "default") {
+    query renderCheck($path: String!) {
         jcr {
             nodeByPath(path: $path) {
                 ...NodeCacheRequiredFields
-                renderedContent(view: $view, templateType: "html", contextConfiguration: "page", language: $language) {
-                    output
-                }
+                isDisplayableNode
             }
         }
     }

--- a/src/javascript/JContent/ContentRoute/renderedContent.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/renderedContent.gql-queries.js
@@ -1,0 +1,16 @@
+import gql from 'graphql-tag';
+import {PredefinedFragments} from '@jahia/data-helper';
+
+export const RenderCheckQuery = gql`
+    query renderCheck($path: String!, $language: String!, $view: String = "default") {
+        jcr {
+            nodeByPath(path: $path) {
+                ...NodeCacheRequiredFields
+                renderedContent(view: $view, templateType: "html", contextConfiguration: "page", language: $language) {
+                    output
+                }
+            }
+        }
+    }
+    ${PredefinedFragments.nodeCacheRequiredFields.gql}
+`;

--- a/src/javascript/JContent/NavigationDialogs/NonDisplayableNodeDialog.jsx
+++ b/src/javascript/JContent/NavigationDialogs/NonDisplayableNodeDialog.jsx
@@ -20,12 +20,18 @@ export const NonDisplayableNodeDialog = ({node, isOpen, onClose, setPathAction, 
     const dispatch = useDispatch();
 
     const handleParentNavigation = () => {
-        dispatch(setPathAction(parentPage.path));
+        if (setPathAction) {
+            dispatch(setPathAction(parentPage.path));
+        }
         onClose();
     };
 
     const handleListNavigation = () => {
-        dispatch(batchActions([setTableViewMode(JContentConstants.tableView.viewMode.FLAT), setPathAction(node.path, {sub: false})]));
+        const actions = [setTableViewMode(JContentConstants.tableView.viewMode.FLAT)];
+        if (setPathAction) {
+            actions.push(setPathAction(node.path, {sub: false}))
+        }
+        dispatch(batchActions(actions));
         onClose();
     };
 

--- a/src/javascript/JContent/NavigationDialogs/NonDisplayableNodeDialog.jsx
+++ b/src/javascript/JContent/NavigationDialogs/NonDisplayableNodeDialog.jsx
@@ -15,7 +15,7 @@ const messageRegistry = {
     default: 'jcontent:label.contentManager.contentPath.dialog'
 };
 
-export const NonDisplayableNodeDialog = ({node, isOpen, onClose, setPathAction, parentPage}) => {
+export const NonDisplayableNodeDialog = ({node, isOpen, onClose, setPathAction, parentPage, hasCancel = true}) => {
     const {t} = useTranslation('jcontent');
     const dispatch = useDispatch();
 
@@ -23,14 +23,16 @@ export const NonDisplayableNodeDialog = ({node, isOpen, onClose, setPathAction, 
         if (setPathAction) {
             dispatch(setPathAction(parentPage.path));
         }
+
         onClose();
     };
 
     const handleListNavigation = () => {
         const actions = [setTableViewMode(JContentConstants.tableView.viewMode.FLAT)];
         if (setPathAction) {
-            actions.push(setPathAction(node.path, {sub: false}))
+            actions.push(setPathAction(node.path, {sub: false}));
         }
+
         dispatch(batchActions(actions));
         onClose();
     };
@@ -54,7 +56,7 @@ export const NonDisplayableNodeDialog = ({node, isOpen, onClose, setPathAction, 
                 </DialogContentText>
             </DialogContent>
             <DialogActions className={styles.dialogActions}>
-                <Button label={t('jcontent:label.cancel')} size="big" data-sel-role="cancel-button" onClick={onClose}/>
+                {hasCancel && <Button label={t('jcontent:label.cancel')} size="big" data-sel-role="cancel-button" onClick={onClose}/>}
                 <Button label={t('jcontent:label.contentManager.contentPath.dialog.listView')} size="big" color={parentPage ? 'default' : 'accent'} data-sel-role="view-list" onClick={handleListNavigation}/>
                 {parentPage && <Button label={t('jcontent:label.contentManager.contentPath.dialog.parentPage')} size="big" color="accent" data-sel-role="view-parent" onClick={handleParentNavigation}/>}
             </DialogActions>
@@ -67,6 +69,7 @@ NonDisplayableNodeDialog.propTypes = {
     parentPage: PropTypes.object,
     onClose: PropTypes.func.isRequired,
     isOpen: PropTypes.bool.isRequired,
-    setPathAction: PropTypes.func
+    setPathAction: PropTypes.func,
+    hasCancel: PropTypes.bool
 };
 

--- a/tests/cypress/e2e/menuActions/areaActions.cy.ts
+++ b/tests/cypress/e2e/menuActions/areaActions.cy.ts
@@ -37,14 +37,20 @@ describe('Area actions', () => {
 
     it('Checks that content can be pasted into the area', () => {
         const jcontentPageBuilder = jcontent.switchToPageBuilder();
-        jcontentPageBuilder.getModule('/sites/jcontentSite/home/area-main/test-content1').contextMenu(true).select('Copy');
-        jcontentPageBuilder.getModule('/sites/jcontentSite/home/landing')
-            .contextMenu(true, false)
+        jcontentPageBuilder.getModule('/sites/jcontentSite/home/landing/test-content-path2').contextMenu(true).select('Copy');
+
+        // Clicking on area header is very tricky due to overlapping contents. Select area header using footer instead.
+        const moduleItem = jcontentPageBuilder.getModule('/sites/jcontentSite/home/area-main/test-content1');
+        moduleItem.click();
+        moduleItem.getFooter().getBreadcrumbs().select('area-main');
+
+        jcontentPageBuilder.getModule('/sites/jcontentSite/home/area-main')
+            .contextMenu(false)
             .select('Paste');
         jcontentPageBuilder.refresh();
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(3000);
-        jcontentPageBuilder.getModule('/sites/jcontentSite/home/landing/test-content1').should('exist');
+        jcontentPageBuilder.getModule('/sites/jcontentSite/home/area-main/test-content-path2').should('exist');
     });
 
     it('Checks that delete, copy and cut menu items are not present on areas in structured view', () => {

--- a/tests/cypress/fixtures/jcontent/menuActions/createLockContent.graphql
+++ b/tests/cypress/fixtures/jcontent/menuActions/createLockContent.graphql
@@ -46,7 +46,7 @@ mutation createLockContent {
                     primaryNodeType: "jnt:page",
                     properties: [
                         { name: "jcr:title", language: "en", value: "Page test 1" },
-                        { name: "j:templateName", value: "default" }
+                        { name: "j:templateName", value: "home" }
                     ]
                 }
             ]) {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

https://jira.jahia.org/browse/QA-15374

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Added a graphql query to check renderable content for any errors before actually displaying page builder. If an error is encountered, we display a dialog that lets users switch to list view if not.

Not sure if there could be some performance impact due to trying to re-render first then perform actual render (maybe negligible). Other option would be to do the check during dom parsing for areas as well.

Also refactored the test menuActions/areaActions a bit as it's a bit flaky with this test.