### PR TITLE
QABACKLOG-1659: remove duplicate test

### DIFF
--- a/tests/cypress/e2e/jcontent/selection.cy.ts
+++ b/tests/cypress/e2e/jcontent/selection.cy.ts
@@ -158,14 +158,6 @@ describe('Multi-selection tests', {testIsolation: false}, () => {
             checkSelectionCount(2);
         });
 
-        it('should have dedicated context menu', () => {
-            jcontent.getGrid().getCardByLabel('fans-stadium').get().click();
-            jcontent.getGrid().getCardByLabel('forest-woman').contextMenu().select('Add to selection');
-            jcontent.getGrid().getCardByLabel('fans-stadium').shouldBeSelected();
-            jcontent.getGrid().getCardByLabel('forest-woman').shouldBeSelected();
-            checkSelectionCount(2);
-        });
-
         it('should not select anything if preview is opened', () => {
             jcontent.getGrid().getCardByLabel('fans-stadium').contextMenu().select('Preview');
             jcontent.getGrid().getCardByLabel('forest-woman').get().click({cmdKey: true});


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description
QABACKLOG-1659: remove duplicate test

The same test was added twice - so one can be removed.
<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
...

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
