### PR TITLE
BACKLOG-23099: Fix value update for MultipleLeftRightSelector component

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/MultipleLeftRightSelector/MultipleLeftRightSelector.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/MultipleLeftRightSelector/MultipleLeftRightSelector.jsx
@@ -9,13 +9,13 @@ const toArray = value => (Array.isArray(value) ? value : [value]);
 export const MultipleLeftRightSelector = ({field, onChange, value, labels}) => {
     const {t} = useTranslation('jcontent');
     const labelBase = 'label.contentEditor.picker.selectors.multipleLeftRightSelector';
-    const availableValues = field.valueConstraints.map(valueConstraint => valueConstraint.value.string);
-    const arrayValue = value ? toArray(value).filter(v => availableValues.includes(v)) : [];
+    const arrayValue = value ? toArray(value) : [];
 
     // Reset selection if previously selected option no longer available
+    const availableValues = field.valueConstraints.map(valueConstraint => valueConstraint.value.string);
+    const actualValues = arrayValue.filter(v => availableValues.includes(v));
     useEffect(() => {
         if (arrayValue && arrayValue.length > 0) {
-            const actualValues = arrayValue.filter(v => availableValues.includes(v));
             if (actualValues.length !== arrayValue.length) {
                 onChange(actualValues);
             }
@@ -43,7 +43,7 @@ export const MultipleLeftRightSelector = ({field, onChange, value, labels}) => {
         }
     }
 
-    return (
+    return (arrayValue.length !== actualValues.length) ? null : (
         <ListSelector
             isReadOnly={field.readOnly || field.valueConstraints.length === 0}
             label={listLabels}

--- a/src/javascript/ContentEditor/SelectorTypes/MultipleLeftRightSelector/MultipleLeftRightSelector.spec.js
+++ b/src/javascript/ContentEditor/SelectorTypes/MultipleLeftRightSelector/MultipleLeftRightSelector.spec.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import MultipleLeftRightSelector from './MultipleLeftRightSelector';
+import {mount} from '@jahia/test-framework';
+
+describe('MultipleLeftRightSelector component', () => {
+    let props;
+    const onChange = jest.fn();
+
+    beforeEach(() => {
+        MultipleLeftRightSelector.propTypes = {};
+        props = {
+            onChange,
+            id: 'MultipleLeftRightSelector',
+            field: {
+                displayName: 'My Colors',
+                name: 'colors',
+                readOnly: false,
+                multiple: true,
+                selectorType: 'MultipleLeftRightSelector',
+                valueConstraints: []
+            },
+            value: ['blue', 'red']
+        };
+    });
+
+    it('should render selector and call onChange when value does not match options ', () => {
+        // Remove red from the options but still present in values
+        props.field.valueConstraints = [
+            {displayValue: 'Blue', value: {string: 'blue'}},
+            {displayValue: 'Green', value: {string: 'green'}}
+        ];
+        const cmp = mount(<MultipleLeftRightSelector {...props}/>);
+
+        // Red should be removed and onChange has been called
+        expect(onChange).toHaveBeenCalledWith(['blue']);
+        expect(cmp.find('MultipleLeftRightSelector').exists()).toBe(true);
+    });
+});


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-23099

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Forward port from PR https://github.com/Jahia/content-editor/pull/1737 and added test

Fix value update when selection is inconsistent with options i.e. onChange should be called with the correct values ( actualValues and arrayValue was always the same and onChange was never called). Also added check to make sure that original values matches verified values (`actualValues`) to prevent error.