### PR TITLE
BACKLOG-23452: Trim the date format when configured

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/DateTimePicker/DateTimePicker.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/DateTimePicker/DateTimePicker.jsx
@@ -18,7 +18,7 @@ function getDateFormat(editorContext) {
     const allowedOverridesDateFormat = ['MM/DD/YYYY', 'DD/MM/YYYY'];
 
     // Read date format from config
-    const forceDateFormat = window.contextJsParameters?.config?.jcontent?.forceDateFormat;
+    const forceDateFormat = window.contextJsParameters?.config?.jcontent?.forceDateFormat?.trim().toUpperCase();
     if (forceDateFormat && !allowedOverridesDateFormat.includes(forceDateFormat)) {
         console.warn(`forceDateFormat as been set to an invalid value (${forceDateFormat}). Please use one of the following values: ${allowedOverridesDateFormat.join(', ')}`);
     } else if (forceDateFormat) {

--- a/src/javascript/ContentEditor/SelectorTypes/DateTimePicker/DateTimePicker.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/DateTimePicker/DateTimePicker.jsx
@@ -18,7 +18,7 @@ function getDateFormat(editorContext) {
     const allowedOverridesDateFormat = ['MM/DD/YYYY', 'DD/MM/YYYY'];
 
     // Read date format from config
-    const forceDateFormat = window.contextJsParameters?.config?.jcontent?.forceDateFormat?.trim().toUpperCase();
+    const forceDateFormat = window.contextJsParameters?.config?.jcontent?.forceDateFormat?.trim();
     if (forceDateFormat && !allowedOverridesDateFormat.includes(forceDateFormat)) {
         console.warn(`forceDateFormat as been set to an invalid value (${forceDateFormat}). Please use one of the following values: ${allowedOverridesDateFormat.join(', ')}`);
     } else if (forceDateFormat) {

--- a/src/javascript/ContentEditor/SelectorTypes/DateTimePicker/DateTimePicker.spec.js
+++ b/src/javascript/ContentEditor/SelectorTypes/DateTimePicker/DateTimePicker.spec.js
@@ -143,17 +143,6 @@ describe('DateTimePicker component', () => {
         testDateFormat('de-DE', 'MM/DD/YYYY');
     });
 
-    it('should use the override date format when provided in lowercase', () => {
-        window.contextJsParameters = {
-            config: {
-                jcontent: {
-                    forceDateFormat: 'mm/dd/yyyy'
-                }
-            }
-        };
-        testDateFormat('de-DE', 'MM/DD/YYYY');
-    });
-
     it('should NOT use the override date format when an invalid format is provided', () => {
         window.contextJsParameters = {
             config: {

--- a/src/javascript/ContentEditor/SelectorTypes/DateTimePicker/DateTimePicker.spec.js
+++ b/src/javascript/ContentEditor/SelectorTypes/DateTimePicker/DateTimePicker.spec.js
@@ -132,6 +132,28 @@ describe('DateTimePicker component', () => {
         testDateFormat('de-DE', 'MM/DD/YYYY');
     });
 
+    it('should use the override date format when provided with leading/trailing spaces', () => {
+        window.contextJsParameters = {
+            config: {
+                jcontent: {
+                    forceDateFormat: '  MM/DD/YYYY   '
+                }
+            }
+        };
+        testDateFormat('de-DE', 'MM/DD/YYYY');
+    });
+
+    it('should use the override date format when provided in lowercase', () => {
+        window.contextJsParameters = {
+            config: {
+                jcontent: {
+                    forceDateFormat: 'mm/dd/yyyy'
+                }
+            }
+        };
+        testDateFormat('de-DE', 'MM/DD/YYYY');
+    });
+
     it('should NOT use the override date format when an invalid format is provided', () => {
         window.contextJsParameters = {
             config: {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

https://jira.jahia.org/browse/BACKLOG-23452

## Description

When a date format is configured in _Jcontent_ (`jcontent.forceDateFormat` property), trim its value ~~and convert it to uppercase,~~ to loose restrictions on this property (as the value **must** be `'MM/DD/YYYY'` or  `'DD/MM/YYYY'`).
<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->


## Tests

The following are included in this PR
- [x] Unit Tests (Most changes _should_ have unit tests)
