### PR TITLE
BACKLOG-23347: Hide SEO fields by default

### DIFF
--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/nt_base.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/nt_base.json
@@ -57,6 +57,7 @@
     },
     {
       "name": "seo",
+      "hide": true,
       "labelKey": "label.engineTab.seo",
       "rank": 6.0,
       "requiredPermission": "viewSeoTab",

--- a/tests/cypress/e2e/contentEditor/contentEditorForm.cy.ts
+++ b/tests/cypress/e2e/contentEditor/contentEditorForm.cy.ts
@@ -196,7 +196,7 @@ describe('Content editor form', () => {
         cy.log('verify there is only one title field');
         const contentEditor = jcontent.createContent(contentTypeName);
         // Get all the fields and ensure there is only one title field
-        cy.get('[data-sel-content-editor-field]').should('have.length.greaterThan', 8).filter('[data-sel-content-editor-field$="_jcr:title"]').should('have.length', 1);
+        cy.get('[data-sel-content-editor-field]').should('have.length.greaterThan', 7).filter('[data-sel-content-editor-field$="_jcr:title"]').should('have.length', 1);
         contentEditor.cancel();
     });
 

--- a/tests/cypress/page-object/fields/choiceTreeField.ts
+++ b/tests/cypress/page-object/fields/choiceTreeField.ts
@@ -15,7 +15,7 @@ export class ChoiceTreeField extends Field {
     }
 
     closeTree(): ChoiceTreeField {
-        cy.get('body').click();
+        cy.get('body').click('topLeft');
         return this;
     }
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Hide SEO by default. SEO Section will be enabled specifically for jnt:page and jmix:mainResource in site-settings-seo module

Related PR: https://github.com/Jahia/site-settings-seo/pull/256