### PR TITLE
BACKLOG-23413 Using small breadcrumbs dropdown in edit boxes in PC

### DIFF
--- a/src/javascript/JContent/EditFrame/Box.jsx
+++ b/src/javascript/JContent/EditFrame/Box.jsx
@@ -274,7 +274,7 @@ export const Box = React.memo(({
                             jahiatype="footer" // eslint-disable-line react/no-unknown-property
                             onClick={onClick}
                     >
-                        <Breadcrumbs nodes={breadcrumbs} isResponsiveMode={element.getBoundingClientRect().width < 350} setCurrentElement={setCurrentElement} onSelect={onSelect}/>
+                        <Breadcrumbs nodes={breadcrumbs} setCurrentElement={setCurrentElement} onSelect={onSelect}/>
                     </footer>}
             </div>
         </div>

--- a/src/javascript/JContent/EditFrame/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/javascript/JContent/EditFrame/Breadcrumbs/Breadcrumbs.jsx
@@ -1,11 +1,11 @@
 import React, {useCallback} from 'react';
 import PropTypes from 'prop-types';
-import {Breadcrumb, BreadcrumbItem, Dropdown} from '@jahia/moonstone';
+import {Dropdown} from '@jahia/moonstone';
 import {useTranslation} from 'react-i18next';
 import {shallowEqual, useSelector} from 'react-redux';
 import {NodeIcon} from '~/utils';
 
-export const Breadcrumbs = ({nodes, setCurrentElement, onSelect, isResponsiveMode}) => {
+export const Breadcrumbs = ({nodes, setCurrentElement, onSelect}) => {
     const {t} = useTranslation('jcontent');
     const {selection} = useSelector(state => ({
         selection: state.jcontent.selection
@@ -26,39 +26,25 @@ export const Breadcrumbs = ({nodes, setCurrentElement, onSelect, isResponsiveMod
         return false;
     }, [onSelect, selection.length, setCurrentElement]);
 
-    if (isResponsiveMode) {
-        const data = nodes.map(n => ({
-            label: n.name,
-            value: n.path,
-            image: <NodeIcon node={n}/>
-        }));
-
-        return (
-            <Dropdown data={data}
-                      placeholder={t('jcontent:label.contentManager.pageBuilder.breadcrumbs.dropdownLabel')}
-                      onChange={(e, v) => {
-                          handleItemOnClick(e, v.value);
-                      }}
-            />
-        );
-    }
+    const data = nodes.toReversed().map((n, index) => ({
+        label: n.name,
+        value: n.path,
+        image: <NodeIcon node={n} style={{marginLeft: 8 * index}}/>
+    }));
 
     return (
-        <Breadcrumb data-sel-role="pagebuilder-breadcrumb">
-            {nodes.map(n => (
-                <BreadcrumbItem key={n.path}
-                                label={n.name}
-                                icon={<NodeIcon node={n}/>}
-                                onClick={event => handleItemOnClick(event, n.path)}
-                />
-            ))}
-        </Breadcrumb>
+        <Dropdown data={data}
+                  data-sel-role="pagebuilder-itempath-dropdown"
+                  placeholder={t('jcontent:label.contentManager.pageBuilder.breadcrumbs.dropdownLabel')}
+                  onChange={(e, v) => {
+                      handleItemOnClick(e, v.value);
+                  }}
+        />
     );
 };
 
 Breadcrumbs.propTypes = {
     nodes: PropTypes.array,
     setCurrentElement: PropTypes.func,
-    onSelect: PropTypes.func,
-    isResponsiveMode: PropTypes.bool
+    onSelect: PropTypes.func
 };

--- a/tests/cypress/e2e/jcontent/breadcrumbsPageBuilder.cy.ts
+++ b/tests/cypress/e2e/jcontent/breadcrumbsPageBuilder.cy.ts
@@ -11,9 +11,11 @@ describe('Breadcrumbs inside boxes of page builder', () => {
         const module = pageBuilder.getModule('/sites/digitall/home/landing/slider/innovating-technologies', false);
         module.click();
         module.getHeader().select();
-        const breadcrumbs = module.getFooter().getBreadcrumbs();
-        breadcrumbs.shouldHaveCount(3);
+        const breadcrumbs = module.getFooter().getItemPathDropdown().open();
+        breadcrumbs.shouldHaveCount(2);
+
         breadcrumbs.select('landing');
+
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
     });
 
@@ -23,8 +25,8 @@ describe('Breadcrumbs inside boxes of page builder', () => {
         const module = pageBuilder.getModule('/sites/digitall/home/landing/slider/innovating-technologies', false);
         module.click();
         module.getHeader().select();
-        const breadcrumbs = module.getFooter().getBreadcrumbs();
-        breadcrumbs.shouldHaveCount(3);
+        const breadcrumbs = module.getFooter().getItemPathDropdown().open();
+        breadcrumbs.shouldHaveCount(2);
         breadcrumbs.select('landing');
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
         pageBuilder.getModule('/sites/digitall/home/landing/slider/innovating-technologies').hasNoHeaderAndFooter();

--- a/tests/cypress/e2e/jcontent/selection.cy.ignored.ts
+++ b/tests/cypress/e2e/jcontent/selection.cy.ignored.ts
@@ -228,7 +228,9 @@ describe('Multi-selection tests', {testIsolation: false}, () => {
              */
             const module = pageBuilder.getModule('/sites/digitall/home/area-main/area/area/area/area-main/global-network-rich-text', false);
             module.click(); // Bring up footer
-            module.getFooter().getBreadcrumbs().selectPos(5); // Navigate to area-main
+            const dropdown = module.getFooter().getItemPathDropdown();
+            dropdown.open();
+            dropdown.select('area-main');
             module.parentFrame.get().find('[data-clicked="true"]').click({force: true, metaKey: true});
             checkSelectionCount(1);
 

--- a/tests/cypress/e2e/menuActions/areaActions.cy.ignore.ts
+++ b/tests/cypress/e2e/menuActions/areaActions.cy.ignore.ts
@@ -46,7 +46,7 @@ describe('Area actions', () => {
         // Clicking on area header is very tricky due to overlapping contents. Select area header using footer instead.
         const moduleItem = jcontentPageBuilder.getModule('/sites/jcontentSite/home/area-main/test-content1');
         moduleItem.click();
-        moduleItem.getFooter().getBreadcrumbs().select('area-main');
+        moduleItem.getFooter().getItemPathDropdown().open().select('area-main');
 
         jcontentPageBuilder.getModule('/sites/jcontentSite/home/area-main')
             .contextMenu(false)

--- a/tests/cypress/e2e/pageBuilder/clickSelectionAndNavigation.cy.ignored.ts
+++ b/tests/cypress/e2e/pageBuilder/clickSelectionAndNavigation.cy.ignored.ts
@@ -21,7 +21,8 @@ describe('Page builder navigation tests', () => {
         let module = pageBuilder.getModule('/sites/digitall/home/area-main/highlights/our-companies');
         module.click();
         module.getHeader().assertHeaderText('Our Companies');
-        const breadcrumbs = module.getFooter().getBreadcrumbs();
+        const breadcrumbs = module.getFooter().getItemPathDropdown();
+        breadcrumbs.open();
         breadcrumbs.select('highlights');
 
         module = pageBuilder.getModule('/sites/digitall/home/area-main/highlights');
@@ -34,7 +35,8 @@ describe('Page builder navigation tests', () => {
         let module = pageBuilder.getModule('/sites/digitall/home/area-main/highlights/our-companies');
         module.click();
         module.getHeader().assertHeaderText('Our Companies');
-        const breadcrumbs = module.getFooter().getBreadcrumbs();
+        const breadcrumbs = module.getFooter().getItemPathDropdown();
+        breadcrumbs.open();
         breadcrumbs.select('highlights');
 
         module = pageBuilder.getModule('/sites/digitall/home/area-main/highlights');

--- a/tests/cypress/page-object/breadcrumb.ts
+++ b/tests/cypress/page-object/breadcrumb.ts
@@ -15,28 +15,3 @@ export class Breadcrumb extends BaseComponent {
         this.element.click();
     }
 }
-
-export class BreadcrumbPageBuilder extends BaseComponent {
-    static defaultSelector = 'nav[data-sel-role="pagebuilder-breadcrumb"]';
-
-    shouldHaveCount(count: number): void {
-        this.get().find('li').should('have.length', count);
-    }
-
-    select(name: string): void {
-        this.get().find('span').contains(name).click({force: true});
-    }
-
-    selectPos(pos: number) {
-        const truePos = (pos * 2) - 1; // We need to skip the li separators
-        this.get().find(`li:nth-child(${truePos}) span`).click({force: true});
-    }
-
-    addToSelection(name: string): void {
-        this.get().find('span').contains(name).click({force: true, metaKey: true});
-    }
-
-    click() {
-        this.element.click();
-    }
-}

--- a/tests/cypress/page-object/jcontent.ts
+++ b/tests/cypress/page-object/jcontent.ts
@@ -20,7 +20,6 @@ import {Media} from './media';
 import {ContentTable} from './contentTable';
 import {AccordionItem} from './accordionItem';
 import {ContentGrid} from './contentGrid';
-import {BreadcrumbPageBuilder} from './breadcrumb';
 import ClickOptions = Cypress.ClickOptions;
 import VisitOptions = Cypress.VisitOptions;
 import {CompareDialog} from './compareDialog';
@@ -313,8 +312,25 @@ class PageBuilderModuleHeader extends BaseComponent {
 class PageBuilderModuleFooter extends BaseComponent {
     static defaultSelector = '[jahiatype="footer"]';
 
-    getBreadcrumbs(): BreadcrumbPageBuilder {
-        return getComponentByRole(BreadcrumbPageBuilder, 'pagebuilder-breadcrumb', this);
+    getItemPathDropdown(): ItemPathDropdown {
+        return getComponentByRole(ItemPathDropdown, 'pagebuilder-itempath-dropdown', this);
+    }
+}
+
+class ItemPathDropdown extends BaseComponent {
+    static defaultSelector = '[data-sel-role="pagebuilder-itempath-dropdown"]';
+
+    open(): ItemPathDropdown {
+        this.element.click({waitForAnimations: true});
+        return this;
+    }
+
+    shouldHaveCount(length: number) {
+        this.get().find('[role="option"]').should('have.length', length);
+    }
+
+    select(item: string) {
+        this.get().find('[role="option"]').contains(item).click({force: true});
     }
 }
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
This change replaces the long breadcrumb on edit boxes to a dropdown. Also, it reverses order (so it reads item -> parent -> grandparent) and adds padding to show hierarchy. I considered using the treeview dropdown for this, but it does not support having all fields opened by default without additional moonstone changes.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
