### PR TITLE
BACKLOG-23509: Fix contrast of three dots menu in the secondary navigation

### DIFF
--- a/src/javascript/JContent/ContentTree/StatusIcon.jsx
+++ b/src/javascript/JContent/ContentTree/StatusIcon.jsx
@@ -14,7 +14,7 @@ export const StatusIcon = ({isLocked, isNotPublished, path, contentMenu, ...prop
             </span>
             {contentMenu && (
                 <span className={styles.ContentTree_ItemMenuIcon}>
-                    <DisplayAction isReversed actionKey={contentMenu} path={path} render={ButtonRendererNoLabel} buttonProps={{variant: 'ghost', size: 'small'}} {...props}/>
+                    <DisplayAction actionKey={contentMenu} path={path} render={ButtonRendererNoLabel} buttonProps={{variant: 'ghost', size: 'small', isReversed: true}} {...props}/>
                 </span>
             )}
         </>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
The prop `isReversed` badly passed into a `DisplayAction`
