### PR TITLE
QA-15374: Add render dialog check only if there is an error

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentRoute.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentRoute.jsx
@@ -126,7 +126,7 @@ export const ContentRoute = () => {
                     </ErrorBoundary>
                 </LoaderSuspense>
             </MainLayout>
-            <NonDisplayableNodeDialog hasCancel={false} {...dialogProps}/>;
+            {renderCheck.error && <NonDisplayableNodeDialog hasCancel={false} {...dialogProps}/>}
         </>
     );
 };


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
...

Adding render dialog check is causing some alignment issues in page builder; and also only during tests.

Add/render the dialog component only if there are any render errors.
