### PR TITLE
DMF-6407: do not redirect when changing template

### DIFF
--- a/src/javascript/JContent/EditFrame/EditFrame.jsx
+++ b/src/javascript/JContent/EditFrame/EditFrame.jsx
@@ -118,7 +118,7 @@ export const EditFrame = () => {
             const framePath = _currentDocument.querySelector('[jahiatype=mainmodule]')?.getAttribute('path');
             const frameLanguage = _currentDocument.querySelector('[jahiatype=mainmodule]')?.getAttribute('locale');
             const frameTemplate = _currentDocument.querySelector('[jahiatype=mainmodule]')?.getAttribute('template');
-            if (framePath && (framePath !== path || frameLanguage !== language || frameTemplate !== template)) {
+            if (framePath && (framePath !== path || frameLanguage !== language)) {
                 console.debug('Updating path to', framePath, 'and language to', frameLanguage, 'in redux', 'template', frameTemplate, 'older path', path, 'older language', language, 'older template', template);
                 dispatch(batchActions([
                     cmGoto({path: framePath, language: frameLanguage, template: frameTemplate}),


### PR DESCRIPTION
### Why this modification:
In jExperience we are using a variant shitcher which allow to switch between variants of the experiences.
When switching between variants, the node might not have the same template.
As the template value can change, the condition frameTemplate !== template can be true. If it's the case, It execute a redirect to the page. 
The problem is that when a redirect is done, the variant switcher is reloaded and reset, so the first variant is dispalyed.

### Some history:
The changes has been included here https://github.com/Jahia/jcontent/pull/1184/files#diff-f3b9133b136957e52dfa17cae204d681b7b8a916ff084e9d4d0302c5f757c288R121
to fix an issue described in https://jira.jahia.org/browse/BACKLOG-21951. 
But I tried to reproduce the issue with the modification done in this PR and the issue is not reproducible. 
I also executed the tests Should switch site and kept track of templates" and "Should switch accordion and kept track of templates" which are mentionned here https://jira.jahia.org/browse/BACKLOG-21951?focusedId=161750&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-161750
and the tests are green.
So it seems that removing the check will not cause issue.

### With the modification:
With the modification, the redirect is not done anymore when the template value is changed. 
