### PR TITLE
BACKLOG-23547: Unable to edit page's system name

### DIFF
--- a/src/javascript/ContentEditor/registerLegacyGwt.jsx
+++ b/src/javascript/ContentEditor/registerLegacyGwt.jsx
@@ -1,14 +1,17 @@
 import {enqueueSnackbar} from 'notistack';
 
 export const registerLegacyGwt = registry => {
-    const pcNavigateTo = path => registry.get('redux-action', 'pagecomposerNavigateTo').action(path);
+    const pcNavigateToAction = registry.get('redux-action', 'pagecomposerNavigateTo');
+    const pcNavigateTo = pcNavigateToAction ? path => pcNavigateToAction.action(path) : null;
 
     registry.add('content-editor-config', 'gwtedit', {
         editCallback: (updatedNode, originalNode) => {
             // Trigger Page Composer to reload iframe if system name was renamed
             if (originalNode.path !== updatedNode.path) {
                 const dispatch = window.jahia.reduxStore.dispatch;
-                dispatch(pcNavigateTo({oldPath: originalNode.path, newPath: updatedNode.path}));
+                if (pcNavigateTo) {
+                    dispatch(pcNavigateTo({oldPath: originalNode.path, newPath: updatedNode.path}));
+                }
             }
         },
         onClosedCallback: (envProps, needRefresh) => {
@@ -35,10 +38,12 @@ export const registerLegacyGwt = registry => {
                 const dispatch = window.jahia.reduxStore.dispatch;
                 // Legacy page composer
                 const currentPcPath = window.jahia.reduxStore.getState().pagecomposer?.currentPage?.path;
-                dispatch(pcNavigateTo({
-                    oldPath: currentPcPath,
-                    newPath: encodeURIComponent(config.newPath).replaceAll('%2F', '/')
-                }));
+                if (pcNavigateTo) {
+                    dispatch(pcNavigateTo({
+                        oldPath: currentPcPath,
+                        newPath: encodeURIComponent(config.newPath).replaceAll('%2F', '/')
+                    }));
+                }
 
                 // Refresh content in repository explorer to see added page
                 if (window.authoringApi.refreshContent && window.location.pathname.endsWith('/jahia/repository-explorer')) {

--- a/src/javascript/ContentEditor/registerLegacyGwt.jsx
+++ b/src/javascript/ContentEditor/registerLegacyGwt.jsx
@@ -1,15 +1,16 @@
 import {enqueueSnackbar} from 'notistack';
 
+const booleanValue = v => typeof v === 'string' ? v === 'true' : Boolean(v);
+
 export const registerLegacyGwt = registry => {
-    const pcNavigateToAction = registry.get('redux-action', 'pagecomposerNavigateTo');
-    const pcNavigateTo = pcNavigateToAction ? path => pcNavigateToAction.action(path) : null;
+    const pcNavigateTo = path => registry.get('redux-action', 'pagecomposerNavigateTo').action(path);
 
     registry.add('content-editor-config', 'gwtedit', {
         editCallback: (updatedNode, originalNode) => {
             // Trigger Page Composer to reload iframe if system name was renamed
-            if (originalNode.path !== updatedNode.path) {
-                const dispatch = window.jahia.reduxStore.dispatch;
-                if (pcNavigateTo) {
+            if (!booleanValue(contextJsParameters.config.jcontent?.hideLegacyPageComposer)) {
+                if (originalNode.path !== updatedNode.path) {
+                    const dispatch = window.jahia.reduxStore.dispatch;
                     dispatch(pcNavigateTo({oldPath: originalNode.path, newPath: updatedNode.path}));
                 }
             }
@@ -37,8 +38,8 @@ export const registerLegacyGwt = registry => {
             if (config.newPath) {
                 const dispatch = window.jahia.reduxStore.dispatch;
                 // Legacy page composer
-                const currentPcPath = window.jahia.reduxStore.getState().pagecomposer?.currentPage?.path;
-                if (pcNavigateTo) {
+                if (!booleanValue(contextJsParameters.config.jcontent?.hideLegacyPageComposer)) {
+                    const currentPcPath = window.jahia.reduxStore.getState().pagecomposer?.currentPage?.path;
                     dispatch(pcNavigateTo({
                         oldPath: currentPcPath,
                         newPath: encodeURIComponent(config.newPath).replaceAll('%2F', '/')


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

https://jira.jahia.org/browse/BACKLOG-23547

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
Fix an error happening when updating the system name of a page model.
The issue happens when the legacy Page Composer is hidden (via the configuration `hideLegacyPageComposer`) as the actions are not registered in this case (see [this line](https://github.com/Jahia/jahia-page-composer/blob/3263d2df1525dfd33460cf96709b01f53d8b6e1d/src/javascript/PageComposer/PageComposer.register.js#L12) in _Page Composer_), leading to a `TypeError`.
