### PR TITLE
BACKLOG-23408: Use context for header icon if available

### DIFF
--- a/src/javascript/JContent/EditFrame/DefaultBar.jsx
+++ b/src/javascript/JContent/EditFrame/DefaultBar.jsx
@@ -43,7 +43,7 @@ export const LabelBar = ({node, area}) => {
                 <Chip variant="default"
                       color="accent"
                       label={area.isArea ? 'Area' : area.isAbsolute ? 'Absolute Area' : 'List'}
-                      icon={area.isList ? toIconComponent('/modules/assets/icons/jnt_contentList.png') : <Area/>}/>
+                      icon={area.isList ? toIconComponent(`${window.contextJsParameters.contextPath}/modules/assets/icons/jnt_contentList.png`) : <Area/>}/>
             </>
         );
     }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

Use context if available