### PR TITLE
BACKLOG-23519: Do not display actions when something is selected

### DIFF
--- a/src/javascript/JContent/EditFrame/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes.jsx
@@ -501,7 +501,7 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
                              selection.includes(node.path) ||
                              (selection.length > 0 && !selection.some(selectionElement => isDescendant(node.path, selectionElement)) && element === el)}
                          isHeaderHighlighted={isDescendant(currentElement?.path, node.path)}
-                         isActionsHidden={selection.length > 0 && !selection.includes(node.path) && element === el}
+                         isActionsHidden={selection.length > 0}
                          currentFrameRef={currentFrameRef}
                          rootElementRef={rootElement}
                          element={element}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

Do not display actions when something is selected. Same behaviour as for list mode.