### PR TITLE
fix: Fix workflow for publishing test module

### DIFF
--- a/.github/workflows/release-tests-module.yml
+++ b/.github/workflows/release-tests-module.yml
@@ -1,10 +1,16 @@
-name: Publish tests module to Registry
+name: Publish tests module to NPM registry
 on:
-    workflow_dispatch:
-
+  workflow_dispatch:
+    inputs:
+      is_dry_run:
+        description: '(SHOULD ONLY BE RUN ON NON-MASTER branch) Indicate if the workflow triggered is a dry-run of the release'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   npm_publish:
+    name: Build and publish tests module to NPM registry
     runs-on: ubuntu-latest
 
     steps:
@@ -12,12 +18,40 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
-      - run: cd tests
-      - run: corepack enable
-      - run: yarn set version stable
-      - run: yarn
-      - run: whoami && node -v && ls -lah 
-      - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMJS_PUBLISH_TOKEN }}" > .npmrc
-      - run: ls -lah ./
-      - run: yarn build
-      - run: yarn publish-tests
+      - name: Setting up github configuration
+        shell: bash
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config --global user.email "jahia-ci@jahia.com"
+          git config --global user.name "Jahia CI"
+      - name: Setting up NPM publish config/credentials
+        shell: bash
+        run: |
+          echo "registry=https://registry.npmjs.org/" > ./.npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMJS_PUBLISH_TOKEN }}" >> ./.npmrc
+      - name: Build and publish jContent test module
+        shell: bash
+        run: |
+          cd tests
+          npm get
+          ls -lah
+
+          echo; echo "Fetching dependencies..."
+          yarn
+
+          echo; echo "Building tests module..."
+          yarn build
+
+          cat ~/.npmrc
+          if "${{ inputs.is_dry_run }}"; then
+            if ${{ github.ref }} == 'refs/heads/master'; then
+              echo "Dry run should be executed in non-master branch"
+            else
+              echo "Executing npm publish in dry-run mode"
+              yarn publish-tests --dry-run
+            fi
+          else 
+            echo "Publishing jContent tests in npm..."
+            yarn publish-tests
+          fi

--- a/.github/workflows/release-tests-module.yml
+++ b/.github/workflows/release-tests-module.yml
@@ -25,11 +25,12 @@ jobs:
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           git config --global user.email "jahia-ci@jahia.com"
           git config --global user.name "Jahia CI"
-      - name: Setting up NPM publish config/credentials
+      - name: Setting up NPM publish config/credentials in tests/
         shell: bash
         run: |
-          echo "registry=https://registry.npmjs.org/" > ./.npmrc
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMJS_PUBLISH_TOKEN }}" >> ./.npmrc
+          cd tests
+          echo "registry=https://registry.npmjs.org/" > .npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMJS_PUBLISH_TOKEN }}" >> .npmrc
       - name: Build and publish jContent test module
         shell: bash
         run: |
@@ -43,7 +44,6 @@ jobs:
           echo; echo "Building tests module..."
           yarn build
 
-          cat ~/.npmrc
           if "${{ inputs.is_dry_run }}"; then
             if ${{ github.ref }} == 'refs/heads/master'; then
               echo "Dry run should be executed in non-master branch"

--- a/.github/workflows/release-tests-module.yml
+++ b/.github/workflows/release-tests-module.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
+          registry-url: 'https://registry.npmjs.org'
       - name: Setting up github configuration
         shell: bash
         run: |
@@ -25,14 +26,10 @@ jobs:
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           git config --global user.email "jahia-ci@jahia.com"
           git config --global user.name "Jahia CI"
-      - name: Setting up NPM publish config/credentials in tests/
-        shell: bash
-        run: |
-          cd tests
-          echo "registry=https://registry.npmjs.org/" > .npmrc
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMJS_PUBLISH_TOKEN }}" >> .npmrc
       - name: Build and publish jContent test module
         shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
         run: |
           cd tests
           npm get
@@ -44,14 +41,18 @@ jobs:
           echo; echo "Building tests module..."
           yarn build
 
+          echo; echo "Incrementing version for release.."
+          yarn version --prerelease --preid=tests
+          git push --follow-tags 
+
           if "${{ inputs.is_dry_run }}"; then
-            if ${{ github.ref }} == 'refs/heads/master'; then
+            if "${{ github.ref }}" == 'refs/heads/master'; then
               echo "Dry run should be executed in non-master branch"
             else
               echo "Executing npm publish in dry-run mode"
-              yarn publish-tests --dry-run
+              npm publish --provenance --access public --dry-run
             fi
           else 
             echo "Publishing jContent tests in npm..."
-            yarn publish-tests
+            npm publish --provenance --access public
           fi

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint:scss:fix": "yarn lint:scss --fix",
     "lint": "yarn lint:scss && yarn lint:js",
     "lint:fix": "yarn lint:js:fix && yarn lint:scss:fix && cd tests && yarn lint:fix && cd ..",
-    "sync-pom": "sync-pom-version --use-yarn"
+    "sync-pom": "sync-pom-version --use-yarn",
+    "sync-pom-tests": "sync-pom-version --use-yarn --package-file=tests/package.json"
   },
   "description": "jContent for Jahia",
   "main": "index.js",

--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,16 @@
                             <arguments>sync-pom</arguments>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>sync-pom-tests</id>
+                        <phase>none</phase>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>sync-pom-tests</arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -311,7 +321,7 @@
                             <goal>checkin</goal>
                         </goals>
                         <configuration>
-                            <includes>package.json</includes>
+                            <includes>package.json,tests/package.json</includes>
                             <message>[maven-scm-plugin] [skip ci] synchronize package.json</message>
                         </configuration>
                     </execution>
@@ -321,8 +331,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
-                    <preparationGoals>clean verify frontend:yarn@sync-pom scm:checkin@package-json</preparationGoals>
-                    <completionGoals>frontend:yarn@sync-pom scm:checkin@package-json</completionGoals>
+                    <preparationGoals>clean verify frontend:yarn@sync-pom frontend:yarn@sync-pom-tests scm:checkin@package-json</preparationGoals>
+                    <completionGoals>frontend:yarn@sync-pom frontend:yarn@sync-pom-tests scm:checkin@package-json</completionGoals>
                 </configuration>
             </plugin>
             <plugin>

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,18 @@
+[![CircleCI](https://circleci.com/gh/Jahia/jcontent/tree/master.svg?style=svg)](https://circleci.com/gh/Jahia/jcontent/tree/master)
+![GitHub tag (latest by version)](https://img.shields.io/github/v/tag/Jahia/jContent?sort=semver)
+![License](https://img.shields.io/github/license/jahia/jcontent)
+
+<a href="https://www.jahia.com/">
+    <img src="https://www.jahia.com/modules/jahiacom-templates/images/jahia-3x.png" alt="Jahia logo" title="Jahia" align="right" height="60" />
+</a>
+
+# Publishing jContent test module
+
+Trigger `Publish tests module to NPM registry` workflow [here](https://github.com/Jahia/jcontent/actions/workflows/release-tests-module.ymlhttps:/). This will:
+
+- Increment current version and use this as the release version
+- Create a tag, then push version change commit and tag to the branch where workflow is initiated.
+- Publish module to NPM registry
+
+> [!IMPORTANT] 
+> Note: Option to trigger a dry-run in the workflow is also available, which does all the above steps except for the actual publishing step. This includes creating a tag and committing the version change, so it's important to run the dry-run worfklow on a separate branch.

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,7 @@ Contains cypress page objects and utils for implementing jContent-related tests 
 Trigger `Publish tests module to NPM registry` workflow [here](https://github.com/Jahia/jcontent/actions/workflows/release-tests-module.ymlhttps:/). This will:
 
 - Increment current version and use this as the release version
+  - If publishing test module first time after release, the `SNAPSHOT` prerelease identifier will be automatically reset back to `tests.0`
 - Create a tag, then push version change commit and tag to the branch where workflow is initiated.
 - Publish module to [NPM registry](https://www.npmjs.com/package/@jahia/jcontent-cypress)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,13 +6,17 @@
     <img src="https://www.jahia.com/modules/jahiacom-templates/images/jahia-3x.png" alt="Jahia logo" title="Jahia" align="right" height="60" />
 </a>
 
-# Publishing jContent test module
+# jContent test module
+
+Contains cypress page objects and utils for implementing jContent-related tests in cypress.
+
+### Publishing test module
 
 Trigger `Publish tests module to NPM registry` workflow [here](https://github.com/Jahia/jcontent/actions/workflows/release-tests-module.ymlhttps:/). This will:
 
 - Increment current version and use this as the release version
 - Create a tag, then push version change commit and tag to the branch where workflow is initiated.
-- Publish module to NPM registry
+- Publish module to [NPM registry](https://www.npmjs.com/package/@jahia/jcontent-cypress)
 
-> [!IMPORTANT] 
-> Note: Option to trigger a dry-run in the workflow is also available, which does all the above steps except for the actual publishing step. This includes creating a tag and committing the version change, so it's important to run the dry-run worfklow on a separate branch.
+> [!IMPORTANT]
+> Option to trigger a dry-run in the workflow is also available, which does all the above steps except for the actual publishing step. This includes creating a tag and committing the version change, so it's important to run the dry-run worfklow on a separate branch.

--- a/tests/package.json
+++ b/tests/package.json
@@ -12,7 +12,6 @@
     "report:merge": "mochawesome-merge results/reports/mochawesome*.json > results/reports/report.json && rm results/reports/mochawesome*.json",
     "report:html": "marge --inline results/reports/report.json --reportDir results/reports/",
     "build": "tsc -p ./lib-tsconfig.json",
-    "publish-tests": "yarn version --prerelease --preid=tests && npm publish --access public",
     "lint:js": "eslint --ext js,ts cypress",
     "lint:js:fix": "yarn lint:js --fix cypress",
     "lint:fix": "yarn lint:js:fix --resolve-plugins-relative-to ."

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jahia/jcontent-cypress",
   "private": false,
-  "version": "3.2.0-tests.2",
+  "version": "3.3.0",
   "scripts": {
     "instrument": "nyc instrument --compact=false cypress instrumented",
     "e2e:ci": "cypress run --browser chrome",

--- a/tests/package.json
+++ b/tests/package.json
@@ -12,7 +12,7 @@
     "report:merge": "mochawesome-merge results/reports/mochawesome*.json > results/reports/report.json && rm results/reports/mochawesome*.json",
     "report:html": "marge --inline results/reports/report.json --reportDir results/reports/",
     "build": "tsc -p ./lib-tsconfig.json",
-    "publish-tests": "yarn version --prerelease --preid=tests && git push --follow-tags && npm publish --access public",
+    "publish-tests": "yarn version --prerelease --preid=tests && npm publish --access public",
     "lint:js": "eslint --ext js,ts cypress",
     "lint:js:fix": "yarn lint:js --fix cypress",
     "lint:fix": "yarn lint:js:fix --resolve-plugins-relative-to ."

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jahia/jcontent-cypress",
   "private": false,
-  "version": "3.3.0",
+  "version": "3.2.0-tests.1",
   "scripts": {
     "instrument": "nyc instrument --compact=false cypress instrumented",
     "e2e:ci": "cypress run --browser chrome",


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Create a manual trigger for publishing test module that:
  - increments test module version
  - create tag and push version change commit to github
  - do yarn build and npm publish to npm registry
- Include dryRun flag that disables npm publish (but still pushes commit and tag)
- Added README in `/tests` folder
- Automatically sync test module major version during jcontent releases
  - increment of version needs to happen before publish because of this

### Notes
- Refactored usage of package script as it's not taking into account npm config. Manually execute in bash instead.
- npm config is set up through setup-node action by specifying `registry-url` and `NODE_AUTH_TOKEN` env

