### PR TITLE
fix: change order of information displayed in DefaultBar

### DIFF
--- a/src/javascript/JContent/EditFrame/DefaultBar.jsx
+++ b/src/javascript/JContent/EditFrame/DefaultBar.jsx
@@ -39,11 +39,11 @@ export const LabelBar = ({node, area, dragProps}) => {
     if (area) {
         return (
             <>
-                <Typography isNowrap weight="bold" variant="caption">{title}</Typography>
                 <Chip variant="default"
                       color="accent"
                       label={area.isArea ? 'Area' : area.isAbsolute ? 'Absolute Area' : 'List'}
                       icon={area.isList ? toIconComponent(`${window.contextJsParameters.contextPath}/modules/assets/icons/jnt_contentList.png`) : <Area/>}/>
+                <Typography isNowrap weight="bold" variant="caption">{title}</Typography>
             </>
         );
     }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

In order to have consistency in Page Builder when jExprerience is deployed is needed.
I changed the order of information displayed in DefaultBar to have the chip for the content type first and then the item's label.