### PR TITLE
fix: Allow empty values for number validation; add error messages

### DIFF
--- a/src/javascript/ContentEditor/validation/validate.js
+++ b/src/javascript/ContentEditor/validation/validate.js
@@ -71,16 +71,17 @@ const colorFieldValidation = (values, field) => {
 };
 
 const rangeFieldValidation = (values, field) => {
-    const error = 'invalidRange';
     const supportedTypes = ['LONG', 'DECIMAL', 'DOUBLE'];
     if (!supportedTypes.includes(field.requiredType) || !values[field.name]) {
         return;
     }
 
-    const fieldValues = Array.isArray(values[field.name]) ? values[field.name] : [values[field.name]];
+    let fieldValues = Array.isArray(values[field.name]) ? values[field.name] : [values[field.name]];
+    // Ok to not validate empty (undefined) values; they are ignored when saving
+    fieldValues = fieldValues.filter(value => typeof value !== 'undefined');
     // If one value is invalid, error !
     if (fieldValues.some(value => isNaN(value))) {
-        return error;
+        return 'invalidNumber';
     }
 
     if (!field.valueConstraints || field.valueConstraints.length === 0) {
@@ -107,7 +108,7 @@ const rangeFieldValidation = (values, field) => {
                 return true;
             }
         })
-        .some(isConstraintRespected => isConstraintRespected === true) ? undefined : error;
+        .some(isConstraintRespected => isConstraintRespected === true) ? undefined : 'invalidRange';
 };
 
 const patternFieldValidation = (values, field) => {

--- a/src/javascript/ContentEditor/validation/validate.spec.js
+++ b/src/javascript/ContentEditor/validation/validate.spec.js
@@ -406,7 +406,7 @@ describe('validate', () => {
             const values = {
                 field1: undefined,
                 field2: [undefined],
-                field3: [undefined, 20, 55, undefined],
+                field3: [undefined, 20, 55, undefined]
             };
 
             // No errors when field is not defined
@@ -415,7 +415,7 @@ describe('validate', () => {
 
         it('should trigger errors when field is not a number', () => {
             const {sections} = buildSections({
-                requiredType: 'LONG',
+                requiredType: 'LONG'
             });
             const values = {
                 field1: '3!',

--- a/src/javascript/ContentEditor/validation/validate.spec.js
+++ b/src/javascript/ContentEditor/validation/validate.spec.js
@@ -399,6 +399,40 @@ describe('validate', () => {
     });
 
     describe('range', () => {
+        it('should not produce errors on empty (undefined) values as they are ignored during save', () => {
+            const {sections} = buildSections({
+                requiredType: 'LONG'
+            });
+            const values = {
+                field1: undefined,
+                field2: [undefined],
+                field3: [undefined, 20, 55, undefined],
+            };
+
+            // No errors when field is not defined
+            expect(validate(sections)(values)).toEqual({});
+        });
+
+        it('should trigger errors when field is not a number', () => {
+            const {sections} = buildSections({
+                requiredType: 'LONG',
+            });
+            const values = {
+                field1: '3!',
+                field2: 'two',
+                field3: 'undefined',
+                field4: '3235'
+            };
+
+            const result = validate(sections)(values);
+            expect(result).toEqual({
+                field1: 'invalidNumber',
+                field2: 'invalidNumber',
+                field3: 'invalidNumber',
+                field4: undefined
+            });
+        });
+
         it('should trigger errors when field is out of range for LONG', () => {
             const {sections} = buildSections({
                 requiredType: 'LONG',

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -711,10 +711,12 @@
         "errors": {
           "invalidDate": "Bitte geben Sie ein gültiges Datum ein",
           "invalidColor": "Bitte geben Sie einen gültigen Farbcode an",
-          "invalidPattern": "Die Eingabe entspricht nicht den Vorgaben der Content-Typ-Definition.",
+          "invalidPattern": "Die Eingabe entspricht nicht den Vorgaben der Content-Typ-Definition",
+          "invalidNumber": "Bitte geben Sie eine gültige Nummer ein",
+          "invalidRange": "Die Eingabe entspricht nicht den Vorgaben der Content-Typ-Definition",
           "invalidSystemName": "Systemname darf nicht die folgenden Sonderzeichen enthalten: '/:*?\"<>|%'",
           "required": "",
-          "alreadyExist": "Ein Element mit demselben Systemnamen ist bereits vorhanden. Bitte wählen Sie ein anderes aus.",
+          "alreadyExist": "Ein Element mit demselben Systemnamen ist bereits vorhanden. Bitte wählen Sie ein anderes aus",
           "maxLength": "Maximal {{selectorOptions.maxLength}} Zeichen.",
           "invalidLink": "Der Link {{0}} ist defekt",
           "constraintViolation": "{{0}}"

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -722,10 +722,12 @@
         "errors": {
           "invalidDate": "Please provide a valid date value",
           "invalidColor": "Please provide a valid color code",
-          "invalidPattern": "The value does not match the constraints defined in the content type definitions file.",
+          "invalidPattern": "The value does not match the constraints defined in the content type definitions file",
+          "invalidNumber": "Please provide a valid number",
+          "invalidRange": "The value does not match the constraints defined in the content type definitions file",
           "invalidSystemName": "System name cannot consist of special characters such as '/:*?\"<>|%'",
           "required": "",
-          "alreadyExist": "An item with the same system name already exists, please choose another one.",
+          "alreadyExist": "An item with the same system name already exists, please choose another one",
           "maxLength": "{{selectorOptions.maxLength}} characters maximum",
           "invalidLink": "The link {{0}} is broken",
           "constraintViolation": "{{0}}"

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -712,7 +712,9 @@
         "errors": {
           "invalidDate": "La date est mal formatée",
           "invalidColor": "Veuillez fournir un code couleur valide",
-          "invalidPattern": "La valeur ne correspond pas aux contraintes définies dans le fichier de définition des types de contenu.",
+          "invalidPattern": "La valeur ne correspond pas aux contraintes définies dans le fichier de définition des types de contenu",
+          "invalidNumber": "Veuillez fournir un numéro valide",
+          "invalidRange": "La valeur ne correspond pas aux contraintes définies dans le fichier de définition des types de contenu",
           "invalidSystemName": "Le nom système ne peut contenir les caractères suivants ‘/:*?\"<>|%’",
           "required": "",
           "alreadyExist": "Il y a déjà un objet avec ce nom système, veuillez en choisir un autre",


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Skip number/range validation for empty (undefined) values
- Create two separate error names (invalid number, invalid range) for more accurate display message
- Add error display messages and translations
- Add test cases for empty values