### PR TITLE
feat: use new PasteAsReference moonstone icon; fix tooltip on getButtonRenderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@jahia/design-system-kit": "^1.1.8",
     "@jahia/icons": "^1.1.2",
     "@jahia/jahia-reporter": "^1.0.3",
-    "@jahia/moonstone": "^2.11.1",
+    "@jahia/moonstone": "^2.11.2",
     "@jahia/react-material": "^3.0.5",
     "@jahia/ui-extender": "^1.1.0",
     "@material-ui/core": "^3.9.3",

--- a/src/javascript/JContent/JContent.actions.jsx
+++ b/src/javascript/JContent/JContent.actions.jsx
@@ -21,6 +21,7 @@ import {
     OpenInBrowser,
     OpenInNew,
     Paste,
+    PasteAsReference,
     Publish,
     Reload,
     Replay,
@@ -288,7 +289,7 @@ export const jContentActions = registry => {
         component: PasteActionComponent
     });
     registry.add('action', 'pasteReference', {
-        buttonIcon: <Paste/>,
+        buttonIcon: <PasteAsReference/>,
         buttonLabel: 'jcontent:label.contentManager.copyPaste.pasteReference',
         hideOnNodeTypes: ['jnt:page', 'jnt:navMenuText', 'jnt:category'],
         referenceTypes: ['jnt:contentReference'],

--- a/src/javascript/utils/getButtonRenderer.jsx
+++ b/src/javascript/utils/getButtonRenderer.jsx
@@ -5,6 +5,31 @@ import React from 'react';
 import {ellipsizeText} from '~/JContent/JContent.utils';
 import {Tooltip} from '@material-ui/core';
 
+const useLabel = labelProps => {
+    const {
+        buttonLabelNamespace,
+        labelStyle,
+        buttonLabel,
+        buttonLabelShort,
+        buttonLabelParams,
+        ellipsis,
+        showTooltip
+    } = labelProps;
+
+    const {t} = useTranslation(buttonLabelNamespace);
+
+    let label = (labelStyle === 'short' && buttonLabelShort) || buttonLabel;
+    label = t(label, buttonLabelParams);
+    if (ellipsis) {
+        label = ellipsizeText(label, ellipsis);
+    }
+
+    return {
+        label: (labelStyle === 'none') ? null : label,
+        tooltipLabel: showTooltip ? label : null
+    };
+};
+
 export const getButtonRenderer = ({labelStyle, showTooltip, ellipsis, defaultButtonProps, defaultTooltipProps} = {}) => {
     const ButtonRenderer = props => {
         const {
@@ -23,20 +48,16 @@ export const getButtonRenderer = ({labelStyle, showTooltip, ellipsis, defaultBut
             buttonProps,
             tooltipProps
         } = props;
-        const {t} = useTranslation(buttonLabelNamespace);
 
-        let label = buttonLabel;
-        if (labelStyle === 'none') {
-            label = null;
-        } else if (labelStyle === 'short' && buttonLabelShort) {
-            label = buttonLabelShort;
-        }
-
-        label = t(label, buttonLabelParams);
-
-        if (ellipsis) {
-            label = ellipsizeText(label, ellipsis);
-        }
+        const {label, tooltipLabel} = useLabel({
+            buttonLabelNamespace,
+            labelStyle,
+            buttonLabel,
+            buttonLabelShort,
+            buttonLabelParams,
+            ellipsis,
+            showTooltip
+        });
 
         if (isVisible === false) {
             return false;
@@ -62,15 +83,11 @@ export const getButtonRenderer = ({labelStyle, showTooltip, ellipsis, defaultBut
             />
         );
 
-        if (showTooltip) {
-            return (
-                <Tooltip title={label} {...defaultTooltipProps} {...tooltipProps}>
-                    {button}
-                </Tooltip>
-            );
-        }
-
-        return button;
+        return (showTooltip) ? (
+            <Tooltip title={tooltipLabel} {...defaultTooltipProps} {...tooltipProps}>
+                {button}
+            </Tooltip>
+        ) : button;
     };
 
     ButtonRenderer.propTypes = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2543,10 +2543,10 @@
     uuid "^8.3.1"
     xml-js "^1.6.11"
 
-"@jahia/moonstone@^2.11.1":
-  version "2.11.1"
-  resolved "https://npm.jahia.com/@jahia%2fmoonstone/-/moonstone-2.11.1.tgz#6198d251ebc87c47c95115b11a38be2c5a04666f"
-  integrity sha512-eLsJrd88+J4BfbdlaqBe3NLz9OFo6GRYCqbFBY+/1naX5W/sqlxU1nU9mAHJDNx3yaQKEoF6irX+Ipxo3M82Kg==
+"@jahia/moonstone@^2.11.2":
+  version "2.11.2"
+  resolved "https://npm.jahia.com/@jahia%2fmoonstone/-/moonstone-2.11.2.tgz#e02c0710a8339315399989562fccc266631e9ac8"
+  integrity sha512-BAOAFizHa7ILUeK8oqzQOUb2YM9gA4lSVInbjtire4Nt4LUcMJrGmzBSZxlDElmHhsD2wl6MmpDXUwR1l2kWjA==
   dependencies:
     "@babel/runtime" "^7.26.7"
     "@jahia/scripts" "^1.3.7"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Bump moonstone version to use new PasteAsReference icon
- Fix `getButtonRenderer` to display tooltip label even if the actual label is not shown