### PR TITLE
test: Re-enable context menu refactor tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
           - cypress.config-menuActions.ts
           - cypress.config-pageBuilder.ts
           - cypress.config-pickers.ts
-#          - cypress.config-categoryManager.ts
+          - cypress.config-categoryManager.ts
     timeout-minutes: 120
     steps:
       - uses: jahia/jahia-modules-action/helper@v2

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -90,7 +90,7 @@ jobs:
           - cypress.config-menuActions.ts
           - cypress.config-pageBuilder.ts
           - cypress.config-pickers.ts
-          # - cypress.config-categoryManager.ts
+          - cypress.config-categoryManager.ts
     timeout-minutes: 120
     steps:
       - uses: jahia/jahia-modules-action/helper@v2

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -68,7 +68,7 @@ jobs:
           - cypress.config-menuActions.ts
           - cypress.config-pageBuilder.ts
           - cypress.config-pickers.ts
-          # - cypress.config-categoryManager.ts
+          - cypress.config-categoryManager.ts
     steps:
       - uses: jahia/jahia-modules-action/helper@v2
       - uses: KengoTODA/actions-setup-docker-compose@main

--- a/tests/cypress.config.common.ts
+++ b/tests/cypress.config.common.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 
 export const baseConfig = {
     chromeWebSecurity: false,
-    defaultCommandTimeout: 60000,
+    defaultCommandTimeout: 20000,
     pageLoadTimeout: 60000,
     requestTimeout: 60000,
     responseTimeout: 60000,

--- a/tests/cypress/e2e/jcontent/categoryManager.cy.ts
+++ b/tests/cypress/e2e/jcontent/categoryManager.cy.ts
@@ -1,5 +1,5 @@
 import {CategoryManager} from '../../page-object';
-import {BaseComponent, Button, deleteNode, Dropdown, getComponentByAttr} from '@jahia/cypress';
+import {BaseComponent, Button, deleteNode, Dropdown, getComponentByAttr, getComponentByRole} from '@jahia/cypress';
 import * as path from 'path';
 
 describe('Category Manager', {defaultCommandTimeout: 10000}, () => {
@@ -143,7 +143,8 @@ describe('Category Manager', {defaultCommandTimeout: 10000}, () => {
         cy.exec(`mkdir -p ${downloadsFolder}`, {failOnNonZeroExit: false});
 
         // Export zip
-        categoryManager.getTreeItem('companies').contextMenu().select('Export');
+        categoryManager.getTreeItem('companies').click();
+        categoryManager.getBrowseControlMenu().selectByRole('export');
         const dialog = getComponentByAttr(BaseComponent, 'data-cm-role', 'export-options');
         dialog.should('be.visible');
         getComponentByAttr(Dropdown, 'data-cm-role', 'select-workspace', dialog).select('Staging and live content');
@@ -157,7 +158,8 @@ describe('Category Manager', {defaultCommandTimeout: 10000}, () => {
         }), {timeout: 30000, interval: 1000, errorMsg: 'Unable to download companies.zip'});
 
         // Import zip
-        categoryManager.getTreeItem('import-zip').contextMenu().select('Import content');
+        categoryManager.getTreeItem('import-zip').click();
+        categoryManager.getBrowseControlMenu().selectByRole('import');
         cy.get('#file-upload-input').selectFile(path.join(downloadsFolder, 'companies.zip'), {force: true});
         categoryManager.getTreeItem('import-zip').get()
             .find('.moonstone-treeView_itemToggle svg').should('be.visible');
@@ -170,7 +172,8 @@ describe('Category Manager', {defaultCommandTimeout: 10000}, () => {
         const downloadsFolder = Cypress.config('downloadsFolder');
 
         // Export xml
-        categoryManager.getTreeItem('companies').contextMenu().select('Export');
+        categoryManager.getTreeItem('companies').click();
+        categoryManager.getBrowseControlMenu().selectByRole('export');
         const dialog = getComponentByAttr(BaseComponent, 'data-cm-role', 'export-options');
         dialog.should('be.visible');
         getComponentByAttr(Dropdown, 'data-cm-role', 'select-workspace', dialog).select('Staging content only');
@@ -184,7 +187,8 @@ describe('Category Manager', {defaultCommandTimeout: 10000}, () => {
         }), {timeout: 30000, interval: 1000, errorMsg: 'Unable to download companies.xml'});
 
         // Import xml
-        categoryManager.getTreeItem('import-xml').contextMenu().select('Import content');
+        categoryManager.getTreeItem('import-xml').click();
+        categoryManager.getBrowseControlMenu().selectByRole('import');
         cy.get('#file-upload-input').selectFile({
             contents: path.join(downloadsFolder, 'companies.xml'),
             mimeType: 'text/xml' // Need to override default mimeType application/xml

--- a/tests/cypress/e2e/jcontent/navigation.cy.ts
+++ b/tests/cypress/e2e/jcontent/navigation.cy.ts
@@ -14,6 +14,7 @@ describe('Content navigation', () => {
         });
         enableModule('jcontent-test-module', 'mySite1');
         enableModule('events', 'mySite1');
+        enableModule('events', 'mySite3');
         addNode({parentPathOrId: '/sites/mySite1/contents', primaryNodeType: 'jnt:event', name: 'test-event'});
         addNode({parentPathOrId: '/sites/mySite3/contents', primaryNodeType: 'jnt:event', name: 'test-event'});
         addNode({
@@ -63,12 +64,9 @@ describe('Content navigation', () => {
         jcontent.shouldBeInMode('List');
     });
 
-    // TODO check if still valid since openInPageBuilder is missing
-    it.skip('can open news in page builder', () => {
-        const jc = JContent.visit('mySite1', 'en', 'content-folders/contents');
-        jc.getTable().getRowByLabel('test-event').contextMenu().selectByRole('openInPageBuilder');
-        cy.frameLoaded('#page-builder-frame-1');
-        jc.shouldBeInMode('Page Builder - Beta');
+    it('can open event in page builder', () => {
+        const jc = JContent.visit('mySite1', 'en', 'content-folders/contents/test-event');
+        jc.switchToPageBuilder();
         jc.getAccordionItem('content-folders').getTreeItem('contents').get().invoke('attr', 'aria-current').should('eq', 'page');
         cy.get('.moonstone-chip').find('span').contains('Event').should('be.visible');
         cy.get('h1').contains('test-event');
@@ -83,10 +81,9 @@ describe('Content navigation', () => {
         cy.get('h1').contains('contents');
     });
 
-    // TODO check if still valid since openInPageBuilder is missing
-    it.skip('Display popup when viewing content that does not have valid template', () => {
-        const jc = JContent.visit('mySite3', 'en', 'content-folders/contents');
-        jc.getTable().getRowByLabel('test-event').contextMenu().selectByRole('openInPageBuilder');
+    it('Display popup when viewing content that does not have valid template', () => {
+        const jc = JContent.visit('mySite3', 'en', 'content-folders/contents/test-event');
+        jc.switchToPageBuilder();
         cy.get('[data-sel-role="node-content-dialog"]')
             .should('be.visible')
             .find('#form-dialog-title')

--- a/tests/cypress/e2e/menuActions/preview.cy.ts
+++ b/tests/cypress/e2e/menuActions/preview.cy.ts
@@ -1,6 +1,6 @@
 import {JContent} from '../../page-object';
 
-describe('Lock tests', () => {
+describe('Menu actions preview tests', () => {
     before(() => {
         cy.loginAndStoreSession(); // Edit in chief
     });

--- a/tests/cypress/page-object/categoryManager.ts
+++ b/tests/cypress/page-object/categoryManager.ts
@@ -2,6 +2,7 @@ import {ContentEditor} from './contentEditor';
 import {SmallTextField} from './fields';
 import {JContent} from './jcontent';
 import {AccordionItem, TreeItem} from './accordionItem';
+import {Button, getComponentByRole} from '@jahia/cypress';
 
 export class CategoryManager extends JContent {
     categoryAccordion: AccordionItem;
@@ -35,7 +36,8 @@ export class CategoryManager extends JContent {
 
     createCategoryNav(parentName: string, fields: {title?: string, name?: string}) {
         const accordionItem = this.getAccordionItem();
-        accordionItem.getTreeItem(parentName).contextMenu().select('New category');
+        accordionItem.getTreeItem(parentName).click();
+        getComponentByRole(Button, 'jnt:category').click(); // New Category header menu
         this.editFields(fields).create();
     }
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Re-enabling the rest of disabled tests from https://github.com/Jahia/jcontent/pull/1419/commits/374abd6bc7f208f379a13e8cdf8b3d241551f638
- categoryManager tests
- jcontent/navigation tests

Some of disabled tests related to context menu refactor have already been re-enabled here https://github.com/Jahia/jcontent/pull/1580

Also reducing command timeout to reduce failure waits on runs

