### PR TITLE
fix: Add check when adding targets to action

### DIFF
--- a/src/javascript/JContent.assignActionAndMenuTargets.js
+++ b/src/javascript/JContent.assignActionAndMenuTargets.js
@@ -24,7 +24,13 @@ const assignTargetsForActions = (targetActions, registry) => {
 
     // Assign target arrays
     Object.keys(actionTargets).forEach(key => {
-        registry.get('action', key).targets = actionTargets[key];
+        const action = registry.get('action', key);
+        if (!action) {
+            console.debug(`Unable to set target for action ${key}`);
+            return;
+        }
+
+        action.targets = actionTargets[key];
     });
 };
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

Adding a check since triggering an error https://bamboo-qa-prod.int.jahia.com/bamboo/browse/FTMT-STCE-9547, although can't replicate on other rqa envs.

Will monitor next run
