### PR TITLE
build: partial revert for syncing test module version on release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,16 +299,6 @@
                             <arguments>sync-pom</arguments>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>sync-pom-tests</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>sync-pom-tests</arguments>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -321,7 +311,7 @@
                             <goal>checkin</goal>
                         </goals>
                         <configuration>
-                            <includes>package.json,tests/package.json</includes>
+                            <includes>package.json</includes>
                             <message>[maven-scm-plugin] [skip ci] synchronize package.json</message>
                         </configuration>
                     </execution>
@@ -331,8 +321,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
-                    <preparationGoals>clean verify frontend:yarn@sync-pom frontend:yarn@sync-pom-tests scm:checkin@package-json</preparationGoals>
-                    <completionGoals>frontend:yarn@sync-pom frontend:yarn@sync-pom-tests scm:checkin@package-json</completionGoals>
+                    <preparationGoals>clean verify frontend:yarn@sync-pom scm:checkin@package-json</preparationGoals>
+                    <completionGoals>frontend:yarn@sync-pom scm:checkin@package-json</completionGoals>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->


Partial revert from https://github.com/Jahia/jcontent/pull/1425 as it seems to be causing test modules to be deployed now.