### PR TITLE
fix: Add node checks on actions

### DIFF
--- a/src/javascript/JContent/actions/clearAllLocksAction.jsx
+++ b/src/javascript/JContent/actions/clearAllLocksAction.jsx
@@ -19,7 +19,7 @@ export const ClearAllLocksActionComponent = ({path, render: Render, loading: Loa
         return (Loading && <Loading {...others}/>) || false;
     }
 
-    const isVisible = res.checksResult && res.node.operationsSupport.lock && res.node.lockTypes !== null && res.node.lockTypes.values.indexOf(' deletion :deletion') === -1;
+    const isVisible = res.checksResult && res.node && res.node.operationsSupport.lock && res.node.lockTypes !== null && res.node.lockTypes.values.indexOf(' deletion :deletion') === -1;
 
     return (
         <Render

--- a/src/javascript/JContent/actions/copyPaste/CopyCutActionComponent.jsx
+++ b/src/javascript/JContent/actions/copyPaste/CopyCutActionComponent.jsx
@@ -53,7 +53,7 @@ export const CopyCutActionComponent = withNotifications()(({
     const isVisible = res.checksResult && !JahiaAreasUtil.isJahiaArea(path) &&
         (res.node ?
             !hasMixin(res.node, 'jmix:markedForDeletionRoot') :
-            res.nodes.reduce((acc, node) => acc && !hasMixin(node, 'jmix:markedForDeletionRoot'), true)
+            res.nodes?.reduce((acc, node) => acc && !hasMixin(node, 'jmix:markedForDeletionRoot'), true)
         );
     const isEnabled = !others.hideIfHasNoSubPages || (res.node?.['subNodesCount_jnt:page'] + res.node?.['subNodesCount_jmix:navMenuItem']) !== 0;
 

--- a/src/javascript/JContent/actions/copyPaste/CopyMenuComponent.jsx
+++ b/src/javascript/JContent/actions/copyPaste/CopyMenuComponent.jsx
@@ -21,7 +21,7 @@ export const CopyMenuComponent = ({path, render: Render, loading: Loading, ...ot
     const isVisible = res.checksResult && !JahiaAreasUtil.isJahiaArea(path) &&
         (res.node ?
             !hasMixin(res.node, 'jmix:markedForDeletionRoot') :
-            res.nodes.reduce((acc, node) => acc && !hasMixin(node, 'jmix:markedForDeletionRoot'), true)
+            res.nodes?.reduce((acc, node) => acc && !hasMixin(node, 'jmix:markedForDeletionRoot'), true)
         );
 
     if (!isVisible) {

--- a/src/javascript/JContent/actions/copyPaste/pasteAction.jsx
+++ b/src/javascript/JContent/actions/copyPaste/pasteAction.jsx
@@ -73,7 +73,7 @@ export const PasteActionComponent = withNotifications()(({path, referenceTypes, 
 
     const nodeTypesToSkip = type === copyPasteConstants.COPY_PAGE ? ['jnt:page', 'jmix:navMenuItem'] : [];
 
-    let isVisible = res.checksResult && res.node.allowedChildNodeTypes.length > 0 && !childrenLimitReachedOrExceeded(res?.node);
+    let isVisible = res.checksResult && res.node?.allowedChildNodeTypes.length > 0 && !childrenLimitReachedOrExceeded(res?.node);
     let isEnabled = true;
 
     if (nodes.length === 0) {

--- a/src/javascript/JContent/actions/deleteActions/undeleteAction.jsx
+++ b/src/javascript/JContent/actions/deleteActions/undeleteAction.jsx
@@ -38,7 +38,7 @@ export const UndeleteActionComponent = ({path, paths, buttonProps, onDeleted, re
         return (Loading && <Loading {...others}/>) || false;
     }
 
-    const isVisible = res.checksResult && (res.node ? checkAction(res.node) : res.nodes.reduce((acc, node) => acc && checkAction(node), true));
+    const isVisible = res.checksResult && (res.node ? checkAction(res.node) : res.nodes?.reduce((acc, node) => acc && checkAction(node), true));
 
     return (
         <Render

--- a/src/javascript/JContent/actions/exportAction/exportAction.jsx
+++ b/src/javascript/JContent/actions/exportAction/exportAction.jsx
@@ -19,7 +19,7 @@ export const ExportActionComponent = ({path, render: Render, loading: Loading, .
             onClick={() => {
                 componentRenderer.render('exportDialog', Export, {
                         isOpen: true,
-                        path: res.node.path,
+                        path: res.node?.path,
                         onClose: () => {
                             componentRenderer.setProperties('exportDialog', {isOpen: false});
                         },

--- a/src/javascript/JContent/actions/flushCacheAction/FlushCacheAction.jsx
+++ b/src/javascript/JContent/actions/flushCacheAction/FlushCacheAction.jsx
@@ -28,7 +28,7 @@ export const FlushCacheActionComponent = ({path, render: Render, loading: Loadin
         return (Loading && <Loading {...others}/>) || false;
     }
 
-    const isVisible = res.checksResult && showOnNodeTypes.some(nt => res?.node[nt]) && (!isSiteFlush || isSiteFlush === isHomePage);
+    const isVisible = res.checksResult && showOnNodeTypes.some(nt => res.node?.[nt]) && (!isSiteFlush || isSiteFlush === isHomePage);
 
     return (
         <Render

--- a/src/javascript/JContent/actions/lockAction.jsx
+++ b/src/javascript/JContent/actions/lockAction.jsx
@@ -22,7 +22,7 @@ export const LockActionComponent = ({path, render: Render, loading: Loading, ...
         return (Loading && <Loading {...others}/>) || false;
     }
 
-    const isVisible = res.checksResult &&
+    const isVisible = res.checksResult && res.node &&
         res.node.operationsSupport.lock &&
         res.node.lockTypes === null &&
         (!res.node['jnt:page'] || res.node.lockPageAction) &&

--- a/src/javascript/JContent/actions/subContentsAction.jsx
+++ b/src/javascript/JContent/actions/subContentsAction.jsx
@@ -27,7 +27,7 @@ export const SubContentsActionComponent = ({path, render: Render, loading: Loadi
     }
 
     const isContainerType = ['jnt:page', 'jnt:folder', 'jnt:contentFolder'].includes(res?.node?.primaryNodeType?.name);
-    const hasSubNodes = subNodesType.some(type => (res?.node[`subNodesCount_${type}`] || 0) > 0);
+    const hasSubNodes = subNodesType.some(type => (res?.node?.[`subNodesCount_${type}`] || 0) > 0);
     const isPageBuilderView = viewMode === JContentConstants.tableView.viewMode.PAGE_BUILDER;
 
     const isVisible = res.checksResult && !isInSearchMode(mode) && (isContainerType || (hasSubNodes && !isPageBuilderView));

--- a/src/javascript/JContent/actions/unlockAction.jsx
+++ b/src/javascript/JContent/actions/unlockAction.jsx
@@ -20,7 +20,7 @@ export const UnlockActionComponent = ({path, render: Render, loading: Loading, .
         return (Loading && <Loading {...others}/>) || false;
     }
 
-    const isVisible = res.checksResult &&
+    const isVisible = res.checksResult && res.node &&
         res.node.operationsSupport.lock &&
         res.node.lockTypes !== null &&
         res.node.lockTypes.values.indexOf(' deletion :deletion') === -1 &&

--- a/src/javascript/JContent/actions/viewUsages.jsx
+++ b/src/javascript/JContent/actions/viewUsages.jsx
@@ -71,8 +71,8 @@ export const ViewUsagesComponent = ({path, render: Render, loading: Loading, usa
             onClick={() => {
                 componentRenderer.render('usagesDialog', UsagesDialog, {
                         isOpen: true,
-                        path: res.node.path,
-                        name: res.node.displayName,
+                        path: res.node?.path,
+                        name: res.node?.displayName,
                         language,
                         onClose: () => {
                             componentRenderer.setProperties('usagesDialog', {isOpen: false});

--- a/src/javascript/JContent/actions/zipUnzip/unzipAction.jsx
+++ b/src/javascript/JContent/actions/zipUnzip/unzipAction.jsx
@@ -33,7 +33,7 @@ export const UnzipActionComponent = withNotifications()(({path, paths, render: R
         return (Loading && <Loading {...others}/>) || false;
     }
 
-    let isVisible = res.checksResult && (res.node.mimeType === 'application/zip' || res.node.mimeType === 'application/x-zip-compressed') && !isMarkedForDeletion(res.node);
+    let isVisible = res.checksResult && res.node && (res.node.mimeType === 'application/zip' || res.node.mimeType === 'application/x-zip-compressed') && !isMarkedForDeletion(res.node);
 
     return (
         <Render
@@ -43,7 +43,7 @@ export const UnzipActionComponent = withNotifications()(({path, paths, render: R
             onClick={() => {
                 componentRenderer.render('progressOverlay', TransparentLoaderOverlay);
                 client.mutate({
-                    variables: {pathOrId: res.node.path, path: res.node.parent.path},
+                    variables: {pathOrId: res.node?.path, path: res.node?.parent.path},
                     mutation: zipUnzipMutations.unzip
                 }).then(() => {
                     triggerRefetchAll();

--- a/src/javascript/JContent/actions/zipUnzip/zipAction.jsx
+++ b/src/javascript/JContent/actions/zipUnzip/zipAction.jsx
@@ -42,11 +42,11 @@ export const ZipActionComponent = withNotifications()(({path, paths, render: Ren
             isVisible={isVisible}
             enabled={isVisible}
             onClick={() => {
-                let name = res.node ? res.node.name : (res.nodes.length > 1 ? res.nodes[0].parent.name : res.nodes[0].name);
+                let name = res.node ? res.node.name : (res.nodes?.length > 1 ? res.nodes[0].parent.name : res.nodes?.[0].name);
                 let nameWithoutExtension = removeFileExtension(name);
-                let paths = res.node ? [res.node.path] : res.nodes.map(n => n.path);
-                let uuid = res.node ? res.node.uuid : res.nodes[0].uuid;
-                let parentPath = res.node ? res.node.parent.path : res.nodes[0].parent.path;
+                let paths = res.node ? [res.node.path] : res.nodes?.map(n => n.path);
+                let uuid = res.node ? res.node.uuid : res.nodes?.[0].uuid;
+                let parentPath = res.node ? res.node.parent.path : res.nodes?.[0].parent.path;
 
                 // Query to have zip files in the same directory with the same name to add a counter
                 let siblings = client.query({


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->


- Fixed subContentsAction due to async timing issue for fetching undefined values
- Also added checks to the rest of actions as well for any `useNodeCheck` fetches 

Test already exists for the original scenario https://github.com/Jahia/jcontent/blob/master/tests/cypress/e2e/menuActions/deleteAdvanced.cy.ts#L67
