### PR TITLE
fix: Add unzip action in context menu

### DIFF
--- a/src/javascript/JContent.assignActionAndMenuTargets.js
+++ b/src/javascript/JContent.assignActionAndMenuTargets.js
@@ -152,6 +152,7 @@ const actionTargetAssignments = {
         'replaceFile',
         'locate',
         'preview',
+        'unzip',
         'downloadFile',
         'downloadAsZip',
         'fileUpload',

--- a/src/javascript/JContent.assignActionAndMenuTargets.js
+++ b/src/javascript/JContent.assignActionAndMenuTargets.js
@@ -191,6 +191,7 @@ const actionTargetAssignments = {
         'replaceFile',
         'locate',
         'preview',
+        'unzip',
         'downloadFile',
         'downloadAsZip',
         'fileUpload',

--- a/tests/cypress/e2e/pickers/editoriallink.cy.ts
+++ b/tests/cypress/e2e/pickers/editoriallink.cy.ts
@@ -1,7 +1,7 @@
 import {contentTypes} from '../../fixtures/contentEditor/pickers/contentTypes';
 import gql from 'graphql-tag';
 import {JContent} from '../../page-object/jcontent';
-import {SecondaryNav} from "@jahia/cypress";
+import {SecondaryNav} from '@jahia/cypress';
 
 describe('Picker - Editorial link', {testIsolation: false}, () => {
     const siteKey = 'digitall';

--- a/tests/cypress/e2e/pickers/editoriallink.cy.ts
+++ b/tests/cypress/e2e/pickers/editoriallink.cy.ts
@@ -1,6 +1,7 @@
 import {contentTypes} from '../../fixtures/contentEditor/pickers/contentTypes';
 import gql from 'graphql-tag';
 import {JContent} from '../../page-object/jcontent';
+import {SecondaryNav} from "@jahia/cypress";
 
 describe('Picker - Editorial link', {testIsolation: false}, () => {
     const siteKey = 'digitall';
@@ -91,6 +92,10 @@ describe('Picker - Editorial link', {testIsolation: false}, () => {
                 const allTypes = texts.sort().every(content => ['Content Folder', 'Person portrait', 'Article (title and introduction)'].includes(content));
                 expect(allTypes).to.be.true;
             });
+
+        // Verify whole left nav is gone
+        picker.get().find(SecondaryNav.defaultSelector, {timeout: 2000}).should('not.exist');
+
         picker.cancel();
         contentEditor.cancel();
     });

--- a/tests/cypress/e2e/pickers/search.cy.ts
+++ b/tests/cypress/e2e/pickers/search.cy.ts
@@ -59,6 +59,7 @@ describe('Picker tests - Search', () => {
 
     it('Editorial Picker- Search for tab - letter by letter', () => {
         const picker = contentEditor.getPickerField('jdmix:hasLink_internalLink').open();
+        picker.switchSearchContext('Digitall');
         picker.search('t');
         picker.verifyResultsAtLeast(82);
         picker.search('a');
@@ -67,19 +68,11 @@ describe('Picker tests - Search', () => {
         picker.verifyResultsLength(7);
     });
 
-    it('Editorial Picker- Search for tab - ensure all accordions are closed', () => {
-        const picker = contentEditor.getPickerField('jdmix:hasLink_internalLink').open();
-        picker.search('tab');
-        picker.verifyResultsLength(7);
-        picker.getTableRow('Taber').should('be.visible');
-        // Verify whole left nav is gone
-        picker.get().find(SecondaryNav.defaultSelector, {timeout: 2000}).should('not.exist');
-    });
-
     it('Editorial Picker- Search for tab and them empty search - ensure previous context is restored', () => {
         const picker = contentEditor.getPickerField('jdmix:hasLink_internalLink').open();
         picker.wait();
 
+        picker.switchSearchContext('Digitall');
         picker.getTab('content').click().then(tabItem => {
             picker.wait();
             cy.wrap(tabItem).should('have.class', 'moonstone-selected');


### PR DESCRIPTION
- Add unzip action in context menu and 3 dots menu
- Also adjust editoriallink picker test as result from this change https://github.com/Jahia/jahia-base-demo-components/pull/25
  - add selection of search context to digitall for consistency
  - Moved check of accordions to editoriallink test suite instead of search test suite