### PR TITLE
fix: Reset clicked element once modified

### DIFF
--- a/src/javascript/JContent/EditFrame/Box.jsx
+++ b/src/javascript/JContent/EditFrame/Box.jsx
@@ -133,7 +133,6 @@ export const Box = React.memo(({
         entries,
         onSaved: () => {
             onSaved();
-            setClickedElement(undefined);
         },
         pos: {before: element.dataset.prevPos, after: element.dataset.nextPos}
     });

--- a/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
@@ -279,11 +279,6 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
         [n.path]: n
     }), {}), [data?.jcr]);
 
-    // Update clickedElement if it doesn't exist anymore
-    if (clickedElement && data?.jcr.nodesByPath && !nodes[clickedElement?.path]) {
-        setClickedElement(undefined);
-    }
-
     const getBreadcrumbsForPath = _path => {
         const breadcrumbs = [];
         const node = nodes[_path];

--- a/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
@@ -73,6 +73,13 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
     const [placeholders, setPlaceholders] = useState([]);
     const [modules, setModules] = useState([]);
 
+    // When document is updated after save, clicked element in memory no longer matches what's in the DOM
+    useEffect(() => {
+        if (clickedElement && !currentDocument.getElementById(clickedElement.element.getAttribute('id'))) {
+            setClickedElement(undefined);
+        }
+    }, [currentDocument, clickedElement, setClickedElement]);
+
     const onMouseOver = useCallback(event => {
         event.stopPropagation();
         const target = event.currentTarget;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

Reset clicked element once modified