### PR TITLE
fix: Override boundComponent label

### DIFF
--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_bindedComponent.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jmix_bindedComponent.json
@@ -7,6 +7,7 @@
       "fieldSets": [
         {
           "name": "jmix:bindedComponent",
+          "labelKey": "label.contentEditor.boundComponent.label",
           "fields": [
             {
               "rank": 0.0,

--- a/src/main/resources/resources/jcontent_de.properties
+++ b/src/main/resources/resources/jcontent_de.properties
@@ -17,3 +17,4 @@ label.contentEditor.visibilityTab.channels.devices.label=Content-Sichtbarkeit na
 label.contentEditor.visibilityTab.channels.devices.description=Wählen Sie den Kanal, für den der Content in Live sichtbar sein soll
 label.contentEditor.visibilityTab.channels.includeExclude.label=Sichtbarkeit für die gewählten Kanäle
 label.contentEditor.visibilityTab.channels.label=Geräte
+label.contentEditor.boundComponent.label=Target component

--- a/src/main/resources/resources/jcontent_en.properties
+++ b/src/main/resources/resources/jcontent_en.properties
@@ -17,3 +17,4 @@ label.contentEditor.visibilityTab.channels.devices.label=Content visibility by d
 label.contentEditor.visibilityTab.channels.devices.description=Content will be visible in the selected  devices
 label.contentEditor.visibilityTab.channels.includeExclude.label=Visibility result for selected devices
 label.contentEditor.visibilityTab.channels.label=Devices
+label.contentEditor.boundComponent.label=Target component

--- a/src/main/resources/resources/jcontent_fr.properties
+++ b/src/main/resources/resources/jcontent_fr.properties
@@ -17,3 +17,4 @@ label.contentEditor.visibilityTab.channels.devices.label=Visibilité du contenu p
 label.contentEditor.visibilityTab.channels.devices.description=Le contenu sera visible pour les appareils sélectionnés
 label.contentEditor.visibilityTab.channels.includeExclude.label=Choix de visibilité du contenu par appareils
 label.contentEditor.visibilityTab.channels.label=Appareils
+label.contentEditor.boundComponent.label=Composant ciblé


### PR DESCRIPTION
### Description
Override boundComponent label

I also looked into changing viewmode to structured by default but this cannot be done. We can supply a custom selector as part of table config or provide modes that can be made available/hidden but we cannot change what opens by default.

### Checklist
#### Source code
- [x] I've considered the implications on security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] I've considered the implications on performances
- [x] I've considered the implications on migration
- [x] I've considered the implications on code maintainability

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

#### Documentation
- [ ] I've provided inline documentation (Source code)
- [ ] I've provided internal documentation (README, Confluence)
- [ ] I've provided user-facing documentation (Academy)

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
