### PR TITLE
fix: Prevent sorting of categories in Category Manager

### DIFF
--- a/src/javascript/JContent/CategoriesRoute/CategoriesLayout/CategoriesLayout.jsx
+++ b/src/javascript/JContent/CategoriesRoute/CategoriesLayout/CategoriesLayout.jsx
@@ -49,7 +49,7 @@ export const CategoriesLayout = ({
                                       isStructured={isStructured}
                                       isLoading={isLoading}
                                       selector={selector}
-                                      columns={[selection, name, visibleActions]}
+                                      columns={[selection, {...name, sortable: false}, visibleActions]}
                             />
                     </ErrorBoundary>
                 </Paper>


### PR DESCRIPTION
### Description
Prevent sorting categories

