### PR TITLE
feat: take into account showOnNodeTypes property in paste action

### DIFF
--- a/src/javascript/JContent/actions/copyPaste/pasteAction.jsx
+++ b/src/javascript/JContent/actions/copyPaste/pasteAction.jsx
@@ -54,6 +54,10 @@ export const PasteActionComponent = withNotifications()(({path, referenceTypes, 
         nodeChecksProps.hideOnNodeTypes = others.hideOnNodeTypes;
     }
 
+    if (others.showOnNodeTypes) {
+        nodeChecksProps.showOnNodeTypes = others.showOnNodeTypes;
+    }
+
     if (others.hidePasteOnPage) {
         nodeChecksProps.hideOnNodeTypes = [...(nodeChecksProps.hidePasteOnPage || []), 'jnt:page'];
     }


### PR DESCRIPTION
Allow to use showOnNodeTypes in paste action. It allows to pass this props when overriding the paste action