### PR TITLE
fix: Check parent first when determining nodetypes for insertion points

### DIFF
--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -52,11 +52,11 @@ const useElemAttributes = ({element, parent}) => {
     const nodeName = element.getAttribute('path').split('/').pop();
 
     let nodeTypes = null;
-    if (element.getAttribute('nodetypes')) {
-        nodeTypes = element.getAttribute('nodetypes').split(' ');
-    } else if (parent.getAttribute('nodetypes') &&
+    if (parent.getAttribute('nodetypes') &&
         (parent.getAttribute('type') === 'area' || parent.getAttribute('type') === 'absoluteArea')) {
         nodeTypes = parent.getAttribute('nodetypes').split(' ');
+    } else if (element.getAttribute('nodetypes')) {
+        nodeTypes = element.getAttribute('nodetypes').split(' ');
     }
 
     // Extract limit defined on template set


### PR DESCRIPTION
### Description
Check parent first when determining nodetypes

### Checklist
#### Source code
- [ ] I've considered the implications on security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] I've considered the implications on performances
- [ ] I've considered the implications on migration
- [ ] I've considered the implications on code maintainability

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

#### Documentation
- [ ] I've provided inline documentation (Source code)
- [ ] I've provided internal documentation (README, Confluence)
- [ ] I've provided user-facing documentation (Academy)

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
