### PR TITLE
feat: change sharing of ContentStatuses to have language defined on e…

### DIFF
--- a/src/javascript/shared/index.js
+++ b/src/javascript/shared/index.js
@@ -8,7 +8,7 @@ export {default as UploadTransformComponent} from '../JContent/ContentRoute/Cont
 export {ContentEmptyDropZone} from '../JContent/ContentRoute/ContentLayout/ContentTable/ContentEmptyDropZone';
 export {default as FilesGridEmptyDropZone} from '../JContent/ContentRoute/ContentLayout/FilesGrid/FilesGridEmptyDropZone';
 export {ContentNotFound} from '../JContent/ContentRoute/ContentLayout/ContentTable/ContentNotFound';
-export {ContentStatuses} from '../JContent/ContentRoute/ContentStatuses/ContentStatuses';
+export {default as ContentStatuses} from '../JContent/ContentRoute/ContentStatuses';
 export {EmptyTable} from '../JContent/ContentRoute/ContentLayout/ContentTable/EmptyTable';
 export {ContentListHeader} from '../JContent/ContentRoute/ContentLayout/ContentTable/ContentListHeader';
 export {ContentTableWrapper} from '../JContent/ContentRoute/ContentLayout/ContentTable/ContentTableWrapper';


### PR DESCRIPTION
…xternal usage

### Description
With the recent changes done in https://github.com/Jahia/jcontent/commit/8fd304eb4238abf6f3b411c8637bee3130b8efab, 
The language is necessary, otherwise an error will happen due to language.toUpperCase().
The language is defined by the ContentStatusesContainer. So instead of sharing ContentStatuses, we are now sharing ContentStatusesContainer to have the language defined when it's used in external modules 

### Checklist
#### Source code
- [x] I've considered the implications on security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] I've considered the implications on performances
- [x] I've considered the implications on migration
- [x] I've considered the implications on code maintainability

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

#### Documentation
- [ ] I've provided inline documentation (Source code)
- [ ] I've provided internal documentation (README, Confluence)
- [ ] I've provided user-facing documentation (Academy)

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
