### PR TITLE
fix: Do not display insertion points for existingNodes which are not children

### DIFF
--- a/src/javascript/JContent/EditFrame/InsertionPoints.jsx
+++ b/src/javascript/JContent/EditFrame/InsertionPoints.jsx
@@ -7,13 +7,19 @@ const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCal
         return null;
     }
 
-    const originalInsertionButtons = [...currentDocument.querySelectorAll(`[type="placeholder"][data-jahia-parent=${clickedElement.element.id}]`)].map(e => ({
+    const clickedPath = clickedElement.element.getAttribute("path");
+
+    const originalInsertionButtons = [...currentDocument.querySelectorAll(`[type="placeholder"][data-jahia-parent=${clickedElement.element.id}]`)]
+        .map(e => ({
         element: e,
         parentNode: nodes?.[e.dataset.jahiaParent && e.ownerDocument.getElementById(e.dataset.jahiaParent).getAttribute('path')]
     }));
 
     // Get all children of the clicked element that are create content buttons [type="placeholder"] and add insertion points for each
-    const childrenElem = [...currentDocument.querySelectorAll(`[type="existingNode"][data-jahia-parent=${clickedElement.element.id}]`)].map(e => ({
+    const childrenElem = [...currentDocument.querySelectorAll(`[type="existingNode"][data-jahia-parent=${clickedElement.element.id}]`)]
+        // Need to make sure that existingNode is not a weakreference but a subnode, which we can do by checking subpath
+        .filter(e => e.getAttribute('path').startsWith(clickedPath))
+        .map(e => ({
         element: e,
         parentNode: nodes?.[e.dataset.jahiaParent && e.ownerDocument.getElementById(e.dataset.jahiaParent).getAttribute('path')]
     }));

--- a/src/javascript/JContent/EditFrame/InsertionPoints.jsx
+++ b/src/javascript/JContent/EditFrame/InsertionPoints.jsx
@@ -11,19 +11,19 @@ const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCal
 
     const originalInsertionButtons = [...currentDocument.querySelectorAll(`[type="placeholder"][data-jahia-parent=${clickedElement.element.id}]`)]
         .map(e => ({
-        element: e,
-        parentNode: nodes?.[e.dataset.jahiaParent && e.ownerDocument.getElementById(e.dataset.jahiaParent).getAttribute('path')]
-    }));
+            element: e,
+            parentNode: nodes?.[e.dataset.jahiaParent && e.ownerDocument.getElementById(e.dataset.jahiaParent).getAttribute('path')]
+        }));
 
     // Get all children of the clicked element that are create content buttons [type="existingNode"] and add insertion points for each
     const childrenElem = [...currentDocument.querySelectorAll(`[type="existingNode"][data-jahia-parent=${clickedElement.element.id}]`)]
         // Need to make sure that existingNode is not a weakreference but a subnode, which we can do by checking subpath
         .filter(e => e.getAttribute('path').startsWith(clickedPath))
         .map(e => ({
-        element: e,
-        parentNode: nodes?.[e.dataset.jahiaParent && e.ownerDocument.getElementById(e.dataset.jahiaParent).getAttribute('path')]
-    }));
-    
+            element: e,
+            parentNode: nodes?.[e.dataset.jahiaParent && e.ownerDocument.getElementById(e.dataset.jahiaParent).getAttribute('path')]
+        }));
+
     // Check only first two elements to know alignment.
     const isVertical = childrenElem.length > 1 && childrenElem[1].element.getBoundingClientRect().left > childrenElem[0].element.getBoundingClientRect().left;
 

--- a/src/javascript/JContent/EditFrame/InsertionPoints.jsx
+++ b/src/javascript/JContent/EditFrame/InsertionPoints.jsx
@@ -7,7 +7,7 @@ const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCal
         return null;
     }
 
-    const clickedPath = clickedElement.element.getAttribute("path");
+    const clickedPath = clickedElement.element.getAttribute('path');
 
     const originalInsertionButtons = [...currentDocument.querySelectorAll(`[type="placeholder"][data-jahia-parent=${clickedElement.element.id}]`)]
         .map(e => ({
@@ -15,7 +15,7 @@ const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCal
         parentNode: nodes?.[e.dataset.jahiaParent && e.ownerDocument.getElementById(e.dataset.jahiaParent).getAttribute('path')]
     }));
 
-    // Get all children of the clicked element that are create content buttons [type="placeholder"] and add insertion points for each
+    // Get all children of the clicked element that are create content buttons [type="existingNode"] and add insertion points for each
     const childrenElem = [...currentDocument.querySelectorAll(`[type="existingNode"][data-jahia-parent=${clickedElement.element.id}]`)]
         // Need to make sure that existingNode is not a weakreference but a subnode, which we can do by checking subpath
         .filter(e => e.getAttribute('path').startsWith(clickedPath))
@@ -23,7 +23,7 @@ const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCal
         element: e,
         parentNode: nodes?.[e.dataset.jahiaParent && e.ownerDocument.getElementById(e.dataset.jahiaParent).getAttribute('path')]
     }));
-
+    
     // Check only first two elements to know alignment.
     const isVertical = childrenElem.length > 1 && childrenElem[1].element.getBoundingClientRect().left > childrenElem[0].element.getBoundingClientRect().left;
 


### PR DESCRIPTION
### Description
Do not display insertion points for existingNodes which are not children.

This avoids the situation where weakreferences are treated as children and are shown insertion points for.

### Checklist
#### Source code
- [ ] I've considered the implications on security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] I've considered the implications on performances
- [ ] I've considered the implications on migration
- [ ] I've considered the implications on code maintainability

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

#### Documentation
- [ ] I've provided inline documentation (Source code)
- [ ] I've provided internal documentation (README, Confluence)
- [ ] I've provided user-facing documentation (Academy)

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
