### PR TITLE
test: Added cypress tests for page builder content status

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentStatuses/Status.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/Status.jsx
@@ -13,7 +13,8 @@ import {
     Warning,
     Language,
     Group,
-    Visibility
+    Visibility,
+    Hidden
 } from '@jahia/moonstone';
 
 export const config = {
@@ -63,7 +64,7 @@ export const config = {
     },
     notVisible: {
         color: 'default',
-        icon: <Visibility/>
+        icon: <Hidden/>
     }
 };
 
@@ -75,13 +76,14 @@ const Status = ({type, tooltip, isDisabled, hasLabel, labelParams, ...props}) =>
     const hasDefinedLabel = label !== `label.contentManager.contentStatus.${type}`;
     return (
         <Chip
-        label={(hasLabel && hasDefinedLabel) ? label : null}
-        isDisabled={isDisabled}
-        title={tooltip || label}
-        data-sel-role="content-status"
-        {...config[type]}
-        {...props}
-    />
+            label={(hasLabel && hasDefinedLabel) ? label : null}
+            isDisabled={isDisabled}
+            title={tooltip || label}
+            data-sel-role="content-status"
+            data-status-type={type}
+            {...config[type]}
+            {...props}
+        />
     );
 };
 

--- a/src/javascript/JContent/ContentRoute/ToolBar/ContentStatusSelector/ContentStatusSelector.jsx
+++ b/src/javascript/JContent/ContentRoute/ToolBar/ContentStatusSelector/ContentStatusSelector.jsx
@@ -6,19 +6,19 @@ import {useTranslation} from 'react-i18next';
 import {setActiveContentStatus} from '~/JContent/redux/contentStatus.redux';
 import styles from './ContentStatusSelector.scss';
 
+const {PUBLISHED, PERMISSIONS, VISIBILITY, NO_STATUS} = JContentConstants.statusView;
+const icons = {
+    [NO_STATUS]: <Not/>,
+    [PUBLISHED]: <Cloud/>,
+    [VISIBILITY]: <Visibility/>,
+    [PERMISSIONS]: <Group/>
+};
+
 export const ContentStatusSelector = () => {
-    const {PUBLISHED, PERMISSIONS, VISIBILITY, NO_STATUS} = JContentConstants.statusView;
     const statusMode = useSelector(state => state.jcontent.contentStatus.active) || NO_STATUS;
     const contentStatus = useSelector(state => state.jcontent.contentStatus.statusPaths, shallowEqual);
     const {t} = useTranslation('jcontent');
     const dispatch = useDispatch();
-
-    const icons = {
-        [NO_STATUS]: <Not/>,
-        [PUBLISHED]: <Cloud/>,
-        [VISIBILITY]: <Visibility/>,
-        [PERMISSIONS]: <Group/>
-    };
 
     const dropdownData = Object.values(JContentConstants.statusView).map(v => ({
         label: t(`jcontent:label.contentManager.contentStatusSelector.${v}`),

--- a/src/javascript/JContent/EditFrame/Box/Box.jsx
+++ b/src/javascript/JContent/EditFrame/Box/Box.jsx
@@ -282,7 +282,9 @@ export const Box = React.memo(({
     return (
         <div ref={rootDiv}
              className={clsx(styles.root, isBarAlwaysDisplayed ? styles.alwaysDisplayedZIndex : styles.defaultZIndex)}
-             data-node-path={node.path}
+             data-sel-role="page-builder-box"
+             data-jahia-path={node.path}
+             data-jahia-id={element.getAttribute('id')}
              style={currentOffset}
         >
             <div className={clsx(

--- a/src/javascript/JContent/EditFrame/Deleted.jsx
+++ b/src/javascript/JContent/EditFrame/Deleted.jsx
@@ -35,6 +35,8 @@ export const Deleted = ({element, addIntervalCallback}) => {
     return (
         <div ref={ref}
              className={clsx(styles.root)}
+             data-sel-role="infos-deleted"
+             data-jahia-path={element.getAttribute('path')}
              style={currentOffset}
         >
             <Status type="markedForDeletion" hasLabel={false} className={styles.badge} variant="bright"/>

--- a/tests/cypress/e2e/contentEditor/copyFromOneLanguageToCurrentLanguage.cy.ts
+++ b/tests/cypress/e2e/contentEditor/copyFromOneLanguageToCurrentLanguage.cy.ts
@@ -38,7 +38,7 @@ const setCopyLanguage = uuid => {
 describe('test copyFromOneLanguageToCurrentLanguage', () => {
     before('Create testsites', () => {
         cy.login();
-        createSite(TwoLanguagesSiteKey, {languages: 'en,fr', templateSet: 'dx-base-demo-template', serverName: 'localhost', locale: 'en'});
+        createSite(TwoLanguagesSiteKey, {languages: 'en,fr', templateSet: 'dx-base-demo-templates', serverName: 'localhost', locale: 'en'});
         createSite(OneLanguageSiteKey, {templateSet: 'qa-simpleTemplateSet', serverName: 'localhost', locale: 'en'});
         createUser(editorLogin.username, editorLogin.password);
         grantRoles(`/sites/${TwoLanguagesSiteKey}`, ['editor'], editorLogin.username, 'USER');

--- a/tests/cypress/e2e/jcontent/menu.cy.ts
+++ b/tests/cypress/e2e/jcontent/menu.cy.ts
@@ -39,7 +39,11 @@ describe('Menu tests', () => {
         const navAccordion = jcontent.getSecondaryNavAccordion();
         navAccordion.click('pages');
         navAccordion.getContent().get('div[data-cm-role="rootpath-context-menu-holder"]').rightclick('top', {scrollBehavior: 'top'});
-        getComponentBySelector(Menu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)').selectByRole('jnt:page');
+        // There's a bug in selectByRole that needs to be fixed
+        // then revert back to helper function; temp fix to revert when released. https://github.com/Jahia/jahia-cypress/pull/125/files
+        // getComponentBySelector(Menu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)').selectByRole('jnt:page');
+        getComponentBySelector(Menu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)')
+            .get().find('.moonstone-menuItem[data-sel-role="jnt:page"]').trigger('click');
         const contentEditor = new ContentEditor();
         contentEditor.getSmallTextField('jnt:page_jcr:title').get().find('input[type="text"]').should('be.visible')
             .clear({force: true}).type('New Root Level Page', {force: true})

--- a/tests/cypress/e2e/jcontent/preview.cy.ts
+++ b/tests/cypress/e2e/jcontent/preview.cy.ts
@@ -9,7 +9,7 @@ describe('JContent preview tests', () => {
         enableModule('jcontent-test-module', 'jcontentSite');
         cy.loginAndStoreSession(); // Edit in chief
         const jcontent = JContent.visit('jcontentSite', 'en', 'pages/home');
-        jcontent.publishAll();
+        jcontent.publish();
         cy.get('button[data-sel-role="openInLive"]', {timeout: 5000}).should('be.visible');
     });
 

--- a/tests/cypress/e2e/menuActions/delete.cy.ts
+++ b/tests/cypress/e2e/menuActions/delete.cy.ts
@@ -1,5 +1,5 @@
 import {JContent} from '../../page-object';
-import {createSite, deleteSite, enableModule, getComponent, getComponentByRole, publishAndWaitJobEnding} from '@jahia/cypress';
+import {createSite, deleteSite, enableModule, getComponent, publishAndWaitJobEnding} from '@jahia/cypress';
 import {DeleteDialog, DeletePermanentlyDialog} from '../../page-object/deleteDialog';
 
 describe('delete tests', () => {

--- a/tests/cypress/e2e/menuActions/delete.cy.ts
+++ b/tests/cypress/e2e/menuActions/delete.cy.ts
@@ -1,17 +1,9 @@
 import {JContent} from '../../page-object';
-import {createSite, deleteSite, enableModule, publishAndWaitJobEnding} from '@jahia/cypress';
+import {createSite, deleteSite, enableModule, getComponent, getComponentByRole, publishAndWaitJobEnding} from '@jahia/cypress';
+import {DeleteDialog, DeletePermanentlyDialog} from '../../page-object/deleteDialog';
 
 describe('delete tests', () => {
     const siteKey = 'jContentSite-delete';
-
-    const confirmMarkForDeletion = verifyMsg => {
-        const dialogCss = '[data-sel-role="delete-mark-dialog"]';
-        cy.get(dialogCss)
-            .should('contain', verifyMsg)
-            .find('[data-sel-role="delete-mark-button"]')
-            .click();
-        cy.get(dialogCss).should('not.exist');
-    };
 
     before(() => {
         createSite(siteKey);
@@ -32,12 +24,7 @@ describe('delete tests', () => {
     it('Can cancel mark for deletion', function () {
         const jcontent = JContent.visit(siteKey, 'en', 'pages/home/test-pageDelete1');
         jcontent.getAccordionItem('pages').getTreeItem('test-pageDelete1').contextMenu().select('Delete');
-
-        const dialogCss = '[data-sel-role="delete-mark-dialog"]';
-        cy.get(dialogCss)
-            .find('[data-sel-role="cancel-button"]')
-            .click();
-        cy.get(dialogCss).should('not.exist');
+        getComponent(DeleteDialog).close();
     });
 
     it('Can mark root and subnodes for deletion', function () {
@@ -45,7 +32,7 @@ describe('delete tests', () => {
         jcontent.getAccordionItem('pages').getTreeItem('test-pageDelete1').contextMenu().select('Delete');
 
         cy.log('Verify dialog opens and can be mark for deletion');
-        confirmMarkForDeletion('You are about to delete 5 items, including 3 page(s)');
+        getComponent(DeleteDialog).markForDeletion('You are about to delete 5 items, including 3 page(s)');
 
         cy.log('Verify menu and subpages has been marked for deletion');
         cy.apollo({
@@ -70,12 +57,7 @@ describe('delete tests', () => {
         jcontent.getAccordionItem('pages').getTreeItem('test-subpage1').contextMenu().select('Delete (permanently)');
 
         cy.log('Verify dialog opens and cannot be deleted permanently');
-        const dialogCss = '[data-sel-role="delete-permanently-dialog"]';
-        cy.get(dialogCss)
-            .should('contain', 'cannot currently be deleted')
-            .find('[data-sel-role="close-button"]')
-            .click();
-        cy.get(dialogCss).should('not.exist');
+        getComponent(DeletePermanentlyDialog).assertMessage('cannot currently be deleted').close();
     });
 
     it('Cannot undelete non-root node', function () {

--- a/tests/cypress/e2e/menuActions/deleteAdvanced.cy.ts
+++ b/tests/cypress/e2e/menuActions/deleteAdvanced.cy.ts
@@ -6,7 +6,6 @@ import {
     deleteSite,
     enableModule,
     getComponent,
-    getComponentByRole,
     markForDeletion,
     publishAndWaitJobEnding
 } from '@jahia/cypress';

--- a/tests/cypress/e2e/pageBuilder/contentStatus.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/contentStatus.cy.ts
@@ -1,0 +1,160 @@
+import {JContent, JContentPageBuilder} from '../../page-object/jcontent';
+import {
+    Button,
+    createSite,
+    createUser,
+    deleteSite,
+    deleteUser,
+    enableModule,
+    getComponent,
+    getComponentByRole,
+    grantRoles,
+    markForDeletion
+} from '@jahia/cypress';
+import {UndeleteDialog} from '../../page-object/deleteDialog';
+
+describe('Page builder - content status', () => {
+    let jContentPageBuilder: JContentPageBuilder;
+    const siteKey = 'contentStatusSite';
+    const user = {name: 'myUser', password: 'password'};
+
+    function getContent(page: string, relPath: string) {
+        return jContentPageBuilder.getModule(`/sites/${siteKey}/home/${page}/area-main/${relPath}`);
+    }
+
+    before(() => {
+        createSite(siteKey, {
+            languages: 'en,fr,de',
+            templateSet: 'dx-base-demo-templates',
+            serverName: 'localhost',
+            locale: 'en'
+        });
+        enableModule('qa-module', siteKey);
+        cy.apollo({
+            mutationFile: 'pageBuilder/contentStatus.graphql',
+            variables: {homePath: `/sites/${siteKey}/home`}
+        });
+        createUser(user.name, user.password);
+    });
+
+    after(() => {
+        cy.logout();
+        deleteUser(user.name);
+        deleteSite(siteKey);
+    });
+
+    describe('test always-on statuses', {testIsolation: false}, () => {
+        const page = 'alwaysPage';
+        before(() => {
+            markForDeletion(`/sites/${siteKey}/home/${page}/area-main/wip-for-deletion`);
+            cy.loginAndStoreSession();
+            jContentPageBuilder = JContent
+                .visit(siteKey, 'en', `pages/home/${page}`)
+                .switchToPageBuilder();
+        });
+
+        it('should display WIP status', () => {
+            getContent(page, 'wip-all').getBoxStatus('workInProgress').should('be.visible');
+            getContent(page, 'wip-en').getBoxStatus('workInProgress').should('be.visible');
+
+            cy.log('Should not display status when deleted');
+            getContent(page, 'wip-for-deletion').getForDeletionStatus().should('be.visible');
+            // No content statuses to display means no box is rendered
+            getContent(page, 'wip-for-deletion').assertNoBox();
+
+            cy.log('Should display status when undeleted');
+            getContent(page, 'wip-for-deletion').select();
+            getComponentByRole(Button, 'undelete').click();
+            getComponent(UndeleteDialog).undelete();
+            jContentPageBuilder.clearSelection();
+            getContent(page, 'wip-for-deletion').getBoxStatus('workInProgress').should('be.visible');
+
+            cy.log('wip-en should have no WIP status for FR language');
+            jContentPageBuilder.getLanguageSwitcher().select('fr');
+            getContent(page, 'wip-en').getBoxStatus('noTranslation').should('be.visible').and('contain', 'FR');
+            getContent(page, 'wip-en').assertNoBoxStatus('workInProgress');
+        });
+
+        it('should display no visibility (language), untranslated badges', () => {
+            cy.log('should display untranslated badge');
+            getContent(page, 'wip-all').getBoxStatus('workInProgress').should('be.visible');
+            getContent(page, 'wip-all').getBoxStatus('noTranslation').should('be.visible').and('contain', 'FR');
+            getContent(page, 'wip-all').getBox().should('contain', 'Nothing to display');
+
+            cy.log('should display untranslated badge (with visible content)');
+            getContent(page, 'visibility-lang-with-display-content').getBoxStatus('noTranslation').should('be.visible').and('contain', 'FR');
+            getContent(page, 'visibility-lang-with-display-content').getBox().should('not.contain', 'Nothing to display');
+
+            cy.log('should display no visibility badge');
+            getContent(page, 'visibility-lang').getBoxStatus('notVisible').should('be.visible');
+            getContent(page, 'visibility-lang').getBox().should('contain', 'Nothing to display');
+        });
+    });
+
+    describe('Publication status', {testIsolation: false}, () => {
+        const page = 'publicationPage';
+        before(() => {
+            cy.loginAndStoreSession();
+            jContentPageBuilder = JContent
+                .visit(siteKey, 'en', `pages/home/${page}`)
+                .switchToPageBuilder();
+        });
+
+        it('does not show any publication status when page is not published', () => {
+            jContentPageBuilder.getStatusSelector().assertCount('published', 0);
+            jContentPageBuilder.getStatusSelector().showPublication();
+            getContent(page, 'wip-all').getBoxStatus('workInProgress').should('be.visible');
+            getContent(page, 'wip-all').getBoxStatus('workInProgress').should('be.visible');
+            getContent(page, 'wip-en').assertNoBoxStatus('notPublished');
+            getContent(page, 'wip-en').assertNoBoxStatus('notPublished');
+        });
+
+        it('shows publication status when page is published', () => {
+            cy.get('[data-sel-role="publishMenu').click();
+            jContentPageBuilder.publishAll();
+
+            jContentPageBuilder.getStatusSelector().assertCount('published', 2);
+            jContentPageBuilder.getStatusSelector().showPublication();
+            getContent(page, 'wip-all').getBoxStatus('workInProgress').should('be.visible');
+            getContent(page, 'wip-all').getBoxStatus('workInProgress').should('be.visible');
+            getContent(page, 'wip-en').getBoxStatus('notPublished').should('be.visible');
+            getContent(page, 'wip-en').getBoxStatus('notPublished').should('be.visible');
+        });
+    });
+
+    describe('Visibility and permissions status', {testIsolation: false}, () => {
+        const page = 'visibilityPermissionPage';
+        before(() => {
+            // Add ACL permission override
+            grantRoles(`/sites/${siteKey}/home/${page}/area-main/permission`, ['editor'], user.name, 'USER');
+            cy.loginAndStoreSession();
+            jContentPageBuilder = JContent
+                .visit(siteKey, 'en', `pages/home/${page}`)
+                .switchToPageBuilder();
+        });
+
+        it('shows visibility status', () => {
+            jContentPageBuilder.getStatusSelector().assertCount('visibility', 2);
+            getContent(page, 'visibility-lang').assertNoBox();
+            getContent(page, 'visibility-datetime').assertNoBox();
+
+            jContentPageBuilder.getStatusSelector().showVisibility();
+            getContent(page, 'visibility-lang').getBoxStatus('visibilityConditions').should('be.visible');
+            getContent(page, 'visibility-datetime').getBoxStatus('visibilityConditions').should('be.visible');
+        });
+
+        it('shows permission status', () => {
+            jContentPageBuilder.getStatusSelector().assertCount('permissions', 1);
+            jContentPageBuilder.getStatusSelector().showPermission();
+            getContent(page, 'permission').getBoxStatus('permissions').should('be.visible');
+        });
+
+        it('does not include to status count when marked for deletion', () => {
+            jContentPageBuilder.getStatusSelector().assertCount('permissions', 1);
+            jContentPageBuilder.getStatusSelector().showPermission();
+            markForDeletion(getContent(page, 'permission').path);
+            jContentPageBuilder.refresh();
+            jContentPageBuilder.getStatusSelector().assertCount('permissions', 0);
+        });
+    });
+});

--- a/tests/cypress/e2e/pageBuilder/contentStatus.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/contentStatus.cy.ts
@@ -1,17 +1,13 @@
 import {JContent, JContentPageBuilder} from '../../page-object/jcontent';
 import {
-    Button,
     createSite,
     createUser,
     deleteSite,
     deleteUser,
     enableModule,
-    getComponent,
-    getComponentByRole,
     grantRoles,
     markForDeletion
 } from '@jahia/cypress';
-import {UndeleteDialog} from '../../page-object/deleteDialog';
 
 describe('Page builder - content status', () => {
     let jContentPageBuilder: JContentPageBuilder;

--- a/tests/cypress/e2e/pageBuilder/contentStatus.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/contentStatus.cy.ts
@@ -48,12 +48,13 @@ describe('Page builder - content status', () => {
         before(() => {
             markForDeletion(`/sites/${siteKey}/home/${page}/area-main/wip-for-deletion`);
             cy.loginAndStoreSession();
-            jContentPageBuilder = JContent
-                .visit(siteKey, 'en', `pages/home/${page}`)
-                .switchToPageBuilder();
         });
 
         it('should display WIP status', () => {
+            jContentPageBuilder = JContent
+                .visit(siteKey, 'en', `pages/home/${page}`)
+                .switchToPageBuilder();
+
             getContent(page, 'wip-all').getBoxStatus('workInProgress').should('be.visible');
             getContent(page, 'wip-en').getBoxStatus('workInProgress').should('be.visible');
 
@@ -61,14 +62,12 @@ describe('Page builder - content status', () => {
             getContent(page, 'wip-for-deletion').getForDeletionStatus().should('be.visible');
             // No content statuses to display means no box is rendered
             getContent(page, 'wip-for-deletion').assertNoBox();
+        });
 
-            cy.log('Should display status when undeleted');
-            getContent(page, 'wip-for-deletion').select();
-            getComponentByRole(Button, 'undelete').click();
-            getComponent(UndeleteDialog).undelete();
-            jContentPageBuilder.clearSelection();
-            getContent(page, 'wip-for-deletion').getBoxStatus('workInProgress').should('be.visible');
-
+        it('should not display WIP status for specific languages', () => {
+            jContentPageBuilder = JContent
+                .visit(siteKey, 'fr', `pages/home/${page}`)
+                .switchToPageBuilder();
             cy.log('wip-en should have no WIP status for FR language');
             jContentPageBuilder.getLanguageSwitcher().select('fr');
             getContent(page, 'wip-en').getBoxStatus('noTranslation').should('be.visible').and('contain', 'FR');
@@ -76,6 +75,10 @@ describe('Page builder - content status', () => {
         });
 
         it('should display no visibility (language), untranslated badges', () => {
+            jContentPageBuilder = JContent
+                .visit(siteKey, 'fr', `pages/home/${page}`)
+                .switchToPageBuilder();
+
             cy.log('should display untranslated badge');
             getContent(page, 'wip-all').getBoxStatus('workInProgress').should('be.visible');
             getContent(page, 'wip-all').getBoxStatus('noTranslation').should('be.visible').and('contain', 'FR');

--- a/tests/cypress/fixtures/pageBuilder/contentStatus.graphql
+++ b/tests/cypress/fixtures/pageBuilder/contentStatus.graphql
@@ -1,0 +1,151 @@
+mutation createStatusContent($homePath: String! = "/sites/contentStatusSite/home") {
+    jcr {
+        mutateNode(pathOrId: $homePath) {
+            addChildrenBatch(
+                nodes: [
+                    {
+                        name: "alwaysPage",
+                        primaryNodeType: "jnt:page",
+                        properties: [
+                            { name: "jcr:title", language: "en", value: "Always-on statuses" },
+                            { name: "j:templateName", value: "home" }
+                        ]
+                        children: [
+                            {
+                                name: "area-main"
+                                primaryNodeType: "jnt:contentList"
+                                children: [
+                                    {
+                                        name: "wip-all"
+                                        primaryNodeType: "jnt:bigText"
+                                        properties: [
+                                            { name: "text", language: "en", value: "Work In Progress - ALL" }
+                                            { name: "j:workInProgressStatus", value: "ALL_CONTENT"}
+                                        ]
+                                    }
+                                    {
+                                        name: "wip-en"
+                                        primaryNodeType: "jnt:bigText"
+                                        properties: [
+                                            { name: "text", language: "en", value: "Work in Progress - EN" }
+                                            { name: "j:workInProgressStatus", value: "LANGUAGES"}
+                                            { name: "j:workInProgressLanguages", values: ["en"]}
+                                        ]
+                                    }
+                                    {
+                                        name: "wip-for-deletion"
+                                        primaryNodeType: "jnt:bigText"
+                                        properties: [
+                                            { name: "text", language: "en", value: "Work In Progress - Marked for deletion" }
+                                            { name: "j:workInProgressStatus", value: "ALL_CONTENT"}
+                                        ]
+                                    }
+                                    {
+                                        name: "visibility-lang"
+                                        primaryNodeType: "jnt:bigText"
+                                        properties: [
+                                            { name: "text", language: "en", value: "Visibility Language - EN only" }
+                                            { name: "j:invalidLanguages", values: ["fr", "de"]}
+                                        ]
+                                    }
+                                    {
+                                        name: "visibility-lang-with-display-content"
+                                        primaryNodeType: "qant:allFields",
+                                        properties:[
+                                            { name: "textarea", language: "en", value: "Visibility Language - EN only (with display content)" }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                    {
+                        name: "publicationPage",
+                        primaryNodeType: "jnt:page",
+                        properties: [
+                            { name: "jcr:title", language: "en", value: "publication statuses" },
+                            { name: "j:templateName", value: "home" }
+                        ]
+                        children: [
+                            {
+                                name: "area-main"
+                                primaryNodeType: "jnt:contentList"
+                                children: [
+                                    {
+                                        name: "wip-all"
+                                        primaryNodeType: "jnt:bigText"
+                                        properties: [
+                                            { name: "text", language: "en", value: "Work In Progress - ALL" }
+                                            { name: "j:workInProgressStatus", value: "ALL_CONTENT"}
+                                        ]
+                                    }
+                                    {
+                                        name: "wip-en"
+                                        primaryNodeType: "jnt:bigText"
+                                        properties: [
+                                            { name: "text", language: "en", value: "Work in Progress - EN" }
+                                            { name: "j:workInProgressStatus", value: "LANGUAGES"}
+                                            { name: "j:workInProgressLanguages", values: ["en"]}
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                    {
+                        name: "visibilityPermissionPage",
+                        primaryNodeType: "jnt:page",
+                        properties: [
+                            { name: "jcr:title", language: "en", value: "visibility statuses" },
+                            { name: "j:templateName", value: "home" }
+                        ]
+                        children: [
+                            {
+                                name: "area-main"
+                                primaryNodeType: "jnt:contentList"
+                                children: [
+                                    {
+                                        name: "visibility-lang"
+                                        primaryNodeType: "jnt:bigText"
+                                        properties: [
+                                            { name: "text", language: "en", value: "Visibility content - lang" }
+                                            { name: "j:invalidLanguages", values: ["de"]}
+                                        ]
+                                    }
+                                    {
+                                        name: "visibility-datetime"
+                                        primaryNodeType: "jnt:bigText"
+                                        properties: [
+                                            { name: "text", language: "en", value: "Visibility content - datetime" }
+                                        ]
+                                        children: [{
+                                            name: "j:conditionalVisibility",
+                                            primaryNodeType: "jnt:conditionalVisibility"
+                                            children: [{
+                                                name: "jnt:dayOfWeekCondition1742500424469",
+                                                primaryNodeType: "jnt:dayOfWeekCondition",
+                                                properties: {name: "dayOfWeek", values: ["wednesday"]}
+                                            }]
+                                        }]
+                                    }
+                                    {
+                                        name: "permission"
+                                        primaryNodeType: "jnt:bigText"
+                                        properties: [
+                                            { name: "text", language: "en", value: "Permission content" }
+                                            { name: "j:workInProgressStatus", value: "LANGUAGES"}
+                                            { name: "j:workInProgressLanguages", values: ["en"]}
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            ) {
+                uuid
+            }
+        }
+    }
+}
+

--- a/tests/cypress/page-object/contentStatusSelector.ts
+++ b/tests/cypress/page-object/contentStatusSelector.ts
@@ -1,0 +1,37 @@
+import {Dropdown, getComponent, Menu} from '@jahia/cypress';
+
+export class ContentStatusSelector extends Dropdown {
+    static defaultSelector = '.moonstone-dropdown_container[data-sel-role="status-view-mode-dropdown"]';
+
+    selectByRole(item: string) {
+        this.get().click();
+        this.get().find('menu.moonstone-menu').should('be.visible');
+        getComponent(Menu, this).selectByRole(item);
+    }
+
+    getStatus(status: string) {
+        return this.get().find(`.moonstone-menuItem[data-sel-role="status-view-mode-${status}"]`);
+    }
+
+    assertCount(status: string, count: number) {
+        this.get().click();
+        this.getStatus(status).should('contain', count);
+        this.get().click();
+    }
+
+    showNoStatus() {
+        this.selectByRole('status-view-mode-noStatus');
+    }
+
+    showPublication() {
+        this.selectByRole('status-view-mode-published');
+    }
+
+    showVisibility() {
+        this.selectByRole('status-view-mode-visibility');
+    }
+
+    showPermission() {
+        this.selectByRole('status-view-mode-permissions');
+    }
+}

--- a/tests/cypress/page-object/deleteDialog.ts
+++ b/tests/cypress/page-object/deleteDialog.ts
@@ -1,4 +1,4 @@
-import {BaseComponent, Button, getComponent, getComponentByRole} from '@jahia/cypress';
+import {BaseComponent, Button, getComponentByRole} from '@jahia/cypress';
 
 export class DeleteDialog extends BaseComponent {
     static defaultSelector = 'div[data-sel-role="delete-mark-dialog"]';

--- a/tests/cypress/page-object/deleteDialog.ts
+++ b/tests/cypress/page-object/deleteDialog.ts
@@ -1,9 +1,67 @@
-import {BaseComponent} from '@jahia/cypress';
+import {BaseComponent, Button, getComponent, getComponentByRole} from '@jahia/cypress';
 
 export class DeleteDialog extends BaseComponent {
     static defaultSelector = 'div[data-sel-role="delete-mark-dialog"]';
 
-    markForDeletion() {
-        this.get().find('[data-sel-role="delete-mark-button"]').click();
+    markForDeletion(verifyMsg?: string) {
+        if (verifyMsg) {
+            this.assertMessage(verifyMsg);
+        }
+
+        getComponentByRole(Button, 'delete-mark-button').click();
+        cy.get(DeleteDialog.defaultSelector).should('not.exist');
+    }
+
+    assertMessage(verifyMsg: string) {
+        this.get().should('contain', verifyMsg);
+        return this;
+    }
+
+    close() {
+        getComponentByRole(Button, 'close-button').click();
+        cy.get(DeleteDialog.defaultSelector).should('not.exist');
+    }
+}
+
+export class DeletePermanentlyDialog extends BaseComponent {
+    static defaultSelector = 'div[data-sel-role="delete-permanently-dialog"]';
+
+    delete() {
+        this.assertMessage('You are about to permanently delete');
+        getComponentByRole(Button, 'delete-permanently-button').click();
+        cy.get(DeletePermanentlyDialog.defaultSelector).should('not.exist');
+    }
+
+    assertMessage(verifyMsg: string) {
+        this.get().should('contain', verifyMsg);
+        return this;
+    }
+
+    close() {
+        getComponentByRole(Button, 'close-button').click();
+        cy.get(DeletePermanentlyDialog.defaultSelector).should('not.exist');
+    }
+}
+
+export class UndeleteDialog extends BaseComponent {
+    static defaultSelector = 'div[data-sel-role="delete-undelete-dialog"]';
+
+    undelete(verifyMsg?: string) {
+        if (verifyMsg) {
+            this.assertMessage(verifyMsg);
+        }
+
+        getComponentByRole(Button, 'delete-undelete-button').click();
+        cy.get(UndeleteDialog.defaultSelector).should('not.exist');
+    }
+
+    assertMessage(verifyMsg: string) {
+        this.get().should('contain', verifyMsg);
+        return this;
+    }
+
+    close() {
+        getComponentByRole(Button, 'close-button').click();
+        cy.get(UndeleteDialog.defaultSelector).should('not.exist');
     }
 }

--- a/tests/cypress/page-object/index.ts
+++ b/tests/cypress/page-object/index.ts
@@ -6,3 +6,9 @@ export * from './pageComposer';
 export * from './accordionItem';
 export * from './categoryManager';
 export {AdvancedOptions} from './advancedOptions';
+export {
+    PageBuilderModule,
+    PageBuilderModuleHeader,
+    PageBuilderModuleFooter,
+    PageBuilderModuleCreateButton
+} from './pageBuilder';

--- a/tests/cypress/page-object/jcontent.ts
+++ b/tests/cypress/page-object/jcontent.ts
@@ -20,8 +20,9 @@ import {ContentTable} from './contentTable';
 import {AccordionItem} from './accordionItem';
 import {ContentGrid} from './contentGrid';
 import {CompareDialog} from './compareDialog';
-import {PageBuilderHeaders, PageBuilderModule} from "./pageBuilder";
+import {PageBuilderHeaders, PageBuilderModule} from './pageBuilder';
 import VisitOptions = Cypress.VisitOptions;
+import {ContentStatusSelector} from './contentStatusSelector';
 
 export class JContent extends BasePage {
     secondaryNav: SecondaryNav;
@@ -117,6 +118,10 @@ export class JContent extends BasePage {
         }
 
         return this.languageSwitcher;
+    }
+
+    getStatusSelector(): ContentStatusSelector {
+        return getComponent(ContentStatusSelector);
     }
 
     getTable(): ContentTable {
@@ -218,9 +223,17 @@ export class JContent extends BasePage {
         return getComponentBySelector(Button, `.moonstone-header button[data-sel-role="${role}"]`);
     }
 
-    publishAll() {
+    publish() {
         cy.get('[data-sel-role="publish"]').click();
         this.clickPublishNow();
+    }
+
+    publishAll() {
+        cy.get('[data-sel-role="publishAll"]').click();
+        this.clickPublishNow();
+        cy.get('div[id="notistack-snackbar"]', {timeout: 5000})
+            .contains('Publication completed', {timeout: 5000})
+            .should('be.visible');
     }
 
     clickPublishNow() {

--- a/tests/cypress/page-object/pageBuilder/index.ts
+++ b/tests/cypress/page-object/pageBuilder/index.ts
@@ -1,0 +1,5 @@
+export {PageBuilderModule} from './pageBuilderModule';
+export {PageBuilderModuleHeader} from './pageBuilderModuleHeader';
+export {PageBuilderModuleFooter} from './pageBuilderModuleFooter';
+export {PageBuilderModuleCreateButton} from './pageBuilderModuleCreateButton';
+export {PageBuilderHeaders} from './pageBuilderHeaders';

--- a/tests/cypress/page-object/pageBuilder/pageBuilderHeaders.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderHeaders.ts
@@ -1,0 +1,7 @@
+import {BaseComponent} from '@jahia/cypress';
+
+export class PageBuilderHeaders extends BaseComponent {
+    items() {
+        return this.get().find('div');
+    }
+}

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
@@ -7,10 +7,44 @@ import {PageBuilderModuleCreateButton} from './pageBuilderModuleCreateButton';
 export class PageBuilderModule extends BaseComponent {
     static defaultSelector = '[jahiatype="module"]';
     parentFrame: BaseComponent;
+    path: string;
 
     hover() {
         this.get().realHover();
         return this.get();
+    }
+
+    getBox() {
+        return cy.get(`@component${this.parentFrame.id}`)
+            .find(`[data-sel-role="page-builder-box"][data-jahia-path="${this.path}"]`);
+    }
+
+    assertNoBox() {
+        return cy.get(`@component${this.parentFrame.id}`)
+            .find(`[data-sel-role="page-builder-box"][data-jahia-path="${this.path}"]`).should('not.exist');
+    }
+
+    getBoxStatus(status: string) {
+        this.getBox().find(`[data-sel-role="content-status"][data-status-type="${status}"]`).scrollIntoView();
+        return this.getBox().find(`[data-sel-role="content-status"][data-status-type="${status}"]`);
+    }
+
+    /*
+     * Use specifically to check when expected for content to have other statuses displayed (i.e. box element exists)
+     * Otherwise use `assertBoxNotExist` when there are no badges displayed
+     */
+    assertNoBoxStatus(status: string) {
+        this.getBox().scrollIntoView();
+        return this.getBox().find(`[data-sel-role="content-status"][data-status-type="${status}"]`).should('not.exist');
+    }
+
+    getForDeletionStatus() {
+        cy.get(`@component${this.parentFrame.id}`)
+            .find(`[data-sel-role="infos-deleted"][data-jahia-path="${this.path}"]`)
+            .scrollIntoView();
+        return cy.get(`@component${this.parentFrame.id}`)
+            .find(`[data-sel-role="infos-deleted"][data-jahia-path="${this.path}"]`)
+            .find('[data-sel-role="content-status"][data-status-type="markedForDeletion"]');
     }
 
     hasNoHeaderAndFooter() {
@@ -68,5 +102,10 @@ export class PageBuilderModule extends BaseComponent {
 
     doubleClick(clickOptions?: Partial<ClickOptions>) {
         this.get().scrollIntoView().dblclick(clickOptions);
+    }
+
+    select() {
+        this.get().click({metaKey: true, force: true});
+        cy.get('[data-sel-role="selection-infos"]').should('be.visible').and('contain', 'selected');
     }
 }

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
@@ -1,0 +1,72 @@
+import {BaseComponent, getComponentBySelector, Menu} from '@jahia/cypress';
+import ClickOptions = Cypress.ClickOptions;
+import {PageBuilderModuleHeader} from './pageBuilderModuleHeader';
+import {PageBuilderModuleFooter} from './pageBuilderModuleFooter';
+import {PageBuilderModuleCreateButton} from './pageBuilderModuleCreateButton';
+
+export class PageBuilderModule extends BaseComponent {
+    static defaultSelector = '[jahiatype="module"]';
+    parentFrame: BaseComponent;
+
+    hover() {
+        this.get().realHover();
+        return this.get();
+    }
+
+    hasNoHeaderAndFooter() {
+        this.hover();
+        this.get().invoke('attr', 'id').then(id => {
+            this.parentFrame.get().find(`[jahiatype="header"][data-jahia-id="${id}"]`).should('not.exist');
+            this.parentFrame.get().find(`[jahiatype="footer"][data-jahia-id="${id}"]`).should('not.exist');
+        });
+    }
+
+    getHeader(selectFirst = false) {
+        this.hover();
+        if (selectFirst) {
+            this.click(); // Header shows up only when selected
+        }
+
+        return new PageBuilderModuleHeader(this.get().invoke('attr', 'id').then(id => {
+            return this.parentFrame.get().find(`[jahiatype="header"][data-jahia-id="${id}"]`);
+        }));
+    }
+
+    getFooter() {
+        this.hover();
+        return new PageBuilderModuleFooter(this.get().invoke('attr', 'id').then(id => {
+            return this.parentFrame.get().find(`[jahiatype="footer"][data-jahia-id="${id}"]`);
+        }));
+    }
+
+    getCreateButtons() {
+        return new PageBuilderModuleCreateButton(this.get().find('[jahiatype="module"][type="placeholder"]').invoke('attr', 'id').then(id => {
+            return this.parentFrame.get().find(`[jahiatype="createbuttons"][data-jahia-id="${id}"]`);
+        }));
+    }
+
+    assertHasNoCreateButtons() {
+        this.get().find('[jahiatype="module"][type="placeholder"]').invoke('attr', 'id').then(id => {
+            return cy.get('iframe[data-sel-role="page-builder-frame-active"]').find(`[jahiatype="createbuttons"][data-jahia-id="${id}"]`).should('not.exist');
+        });
+    }
+
+    contextMenu(selectFirst = false, force = true): Menu {
+        if (selectFirst) {
+            this.getHeader(selectFirst);
+        } else {
+            this.hover();
+        }
+
+        this.get().rightclick({force, waitForAnimations: true});
+        return getComponentBySelector(Menu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)');
+    }
+
+    click(clickOptions?: Partial<ClickOptions>) {
+        this.get().scrollIntoView().click(clickOptions);
+    }
+
+    doubleClick(clickOptions?: Partial<ClickOptions>) {
+        this.get().scrollIntoView().dblclick(clickOptions);
+    }
+}

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModuleCreateButton.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModuleCreateButton.ts
@@ -1,0 +1,21 @@
+import {BaseComponent, Button} from '@jahia/cypress';
+
+export class PageBuilderModuleCreateButton extends BaseComponent {
+    static defaultSelector = '[jahiatype="createbuttons"]';
+
+    getButton(type: string): Button {
+        return new Button(this.get().find('.moonstone-button').contains(type));
+    }
+
+    getFirstInsertionButton(): Button {
+        return new Button(this.get().find('button[data-sel-role="createContent"]').first());
+    }
+
+    assertHasNoButton(): void {
+        this.get().find('.moonstone-button').should('not.exist');
+    }
+
+    assertHasNoButtonForType(type: string): void {
+        this.get().find('.moonstone-button').contains(type).should('not.exist');
+    }
+}

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModuleFooter.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModuleFooter.ts
@@ -1,0 +1,26 @@
+import {BaseComponent, getComponentByRole} from '@jahia/cypress';
+
+export class PageBuilderModuleFooter extends BaseComponent {
+    static defaultSelector = '[jahiatype="footer"]';
+
+    getItemPathDropdown(): ItemPathDropdown {
+        return getComponentByRole(ItemPathDropdown, 'pagebuilder-itempath-dropdown', this);
+    }
+}
+
+export class ItemPathDropdown extends BaseComponent {
+    static defaultSelector = '[data-sel-role="pagebuilder-itempath-dropdown"]';
+
+    open(): ItemPathDropdown {
+        this.element.click({waitForAnimations: true});
+        return this;
+    }
+
+    shouldHaveCount(length: number) {
+        this.get().find('[role="option"]').should('have.length', length);
+    }
+
+    select(item: string) {
+        this.get().find('[role="option"]').contains(item).click({force: true});
+    }
+}

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModuleHeader.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModuleHeader.ts
@@ -1,0 +1,21 @@
+import {BaseComponent, Button, getComponentByRole} from '@jahia/cypress';
+
+export class PageBuilderModuleHeader extends BaseComponent {
+    static defaultSelector = '[jahiatype="header"]';
+
+    assertStatus(value: string) {
+        this.get().find('[data-sel-role="content-status"]').contains(value);
+    }
+
+    getButton(role: string): Button {
+        return getComponentByRole(Button, role, this);
+    }
+
+    assertHeaderText(text: string) {
+        this.get().find('p').contains(text);
+    }
+
+    select() {
+        this.get().click({metaKey: true, force: true});
+    }
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "devDependencies": {
     "@4tw/cypress-drag-drop": "^2.2.1",
-    "@jahia/cypress": "^4.0.0",
+    "@jahia/cypress": "^4.2.0",
     "@jahia/jahia-reporter": "^1.0.30",
     "@types/node": "^18.11.18",
     "@typescript-eslint/eslint-plugin": "^5.48.1",

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -123,10 +123,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
-"@jahia/cypress@^4.0.0":
-  version "4.0.0"
-  resolved "https://npm.jahia.com/@jahia%2fcypress/-/cypress-4.0.0.tgz#d47b4b013c5f26bf969caf652c426a9a780b225d"
-  integrity sha512-rvG0NpB6RddUOcEr2JS9S3s3E0wdzUv1BtaTekLBsT8sW1wv/CfDiIQQxG3dwaS/JpTon4eGK6VyrPEUuT4xGQ==
+"@jahia/cypress@^4.2.0":
+  version "4.2.0"
+  resolved "https://npm.jahia.com/@jahia%2fcypress/-/cypress-4.2.0.tgz#e2ad6f7710565ea7d2e2bfc95cbf1ec0bd768e43"
+  integrity sha512-mhhm60DYku6Q0bM12p8RgOFHNeQ5T/SxszZUkGI7qrZfVXkr4wLCp3YzOj4uFrkkQkk4fZaWShsIlYQc5w8cag==
   dependencies:
     "@apollo/client" "^3.4.9"
     cypress-real-events "^1.11.0"


### PR DESCRIPTION
### Description

Follow-up to add cypress tests for https://github.com/Jahia/jcontent/pull/1640

- Added css selectors to page builder components
- Implement test scenarios for page builder content status feature
- Update to latest @jahia/cypress
- Refactor page builder components in jcontent.ts to separate files
- Added Delete dialog page objects

### Checklist
#### Source code
- [ ] I've considered the implications on security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] I've considered the implications on performances
- [x] I've considered the implications on migration
- [x] I've considered the implications on code maintainability

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

#### Documentation
- [ ] I've provided inline documentation (Source code)
- [ ] I've provided internal documentation (README, Confluence)
- [ ] I've provided user-facing documentation (Academy)

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
