### PR TITLE
fix: Add restriction check on paste actions

### DIFF
--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -51,7 +51,7 @@ const useElemAttributes = ({element, parent}) => {
     const nodePath = (isInsertionPoint || isContainer) ? null : element.getAttribute('path');
     const nodeName = element.getAttribute('path').split('/').pop();
 
-    let nodeTypes = null;
+    let nodeTypes;
     if (parent.getAttribute('nodetypes') &&
         (parent.getAttribute('type') === 'area' || parent.getAttribute('type') === 'absoluteArea')) {
         nodeTypes = parent.getAttribute('nodetypes').split(' ');
@@ -231,6 +231,7 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
                            tooltipProps={tooltipProps}
                            isDisabled={isDisabled}
                            path={parentPath}
+                           nodeTypes={nodeTypes}
                            loading={() => false}
                            render={btnRenderer}
                            onVisibilityChanged={onPasteVisibilityChanged}
@@ -239,6 +240,7 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
                            tooltipProps={tooltipProps}
                            isDisabled={isDisabled}
                            path={parentPath}
+                           nodeTypes={nodeTypes}
                            loading={() => false}
                            render={btnRenderer}
                            onVisibilityChanged={onPasteReferenceVisibilityChanged}

--- a/src/javascript/JContent/actions/copyPaste/pasteAction.jsx
+++ b/src/javascript/JContent/actions/copyPaste/pasteAction.jsx
@@ -30,7 +30,7 @@ function childrenLimitReachedOrExceeded(node) {
     return false;
 }
 
-export const PasteActionComponent = withNotifications()(({path, referenceTypes, render: Render, loading: Loading, notificationContext, onAction, onVisibilityChanged, ...others}) => {
+export const PasteActionComponent = withNotifications()(({path, referenceTypes, render: Render, loading: Loading, notificationContext, onAction, onVisibilityChanged, nodeTypes, ...others}) => {
     const client = useApolloClient();
     const dispatch = useDispatch();
     const {t} = useTranslation('jcontent');
@@ -99,14 +99,14 @@ export const PasteActionComponent = withNotifications()(({path, referenceTypes, 
             isVisible = false;
         }
 
-        const {loading, checkResult, possibleReferenceTypes} = (isVisible && isEnabled) && nodeTypeCheck(res.node, nodes, referenceTypes);
+        const {loading, checkResult, possibleReferenceTypes} = (isVisible && isEnabled) && nodeTypeCheck(res.node, nodes, nodeTypes, referenceTypes);
 
         if (loading) {
             return defaultProps;
         }
 
         return {isVisible, isEnabled: Boolean(checkResult), loading, possibleReferenceTypes, nodeTypesToSkip, type, nodes};
-    }, [copyPaste, res, nodeTypeCheck, referenceTypes]);
+    }, [copyPaste, res, nodeTypeCheck, nodeTypes, referenceTypes]);
 
     useEffect(() => {
         onVisibilityChanged?.(!loading && isVisible);
@@ -166,12 +166,11 @@ export const PasteActionComponent = withNotifications()(({path, referenceTypes, 
 
 PasteActionComponent.propTypes = {
     path: PropTypes.string,
-
-    render: PropTypes.func.isRequired,
-
-    loading: PropTypes.func,
-
     referenceTypes: PropTypes.arrayOf(PropTypes.string),
-
-    onVisibilityChanged: PropTypes.func
+    render: PropTypes.func.isRequired,
+    loading: PropTypes.func,
+    notificationContext: {notify: PropTypes.func},
+    onAction: PropTypes.func,
+    onVisibilityChanged: PropTypes.func,
+    nodeTypes: [PropTypes.string]
 };

--- a/tests/cypress/fixtures/jcontent/pageBuilder/restrictions.js
+++ b/tests/cypress/fixtures/jcontent/pageBuilder/restrictions.js
@@ -1,0 +1,36 @@
+import gql from 'graphql-tag';
+
+export const addRestrictedPage = (siteKey, page) => gql`
+    mutation {
+        jcr {
+            mutateNode(pathOrId: "/sites/${siteKey}/home") {
+                addChildrenBatch(nodes: [
+                    {
+                        name: "${page}",
+                        primaryNodeType: "jnt:page",
+                        properties: [
+                            { name: "jcr:title", language: "en", value: "${page}" }
+                            { name: "j:templateName", value: "contentType" }
+                        ]
+                        children: [
+                            {name: "any-area", primaryNodeType: "jnt:contentList", children: [
+                                {
+                                    name: "allowedText",
+                                    primaryNodeType: "pbnt:contentRestriction",
+                                    properties: [{ name: "text", language: "en", value: "allowed text" }]
+                                }
+                                {
+                                    name: "notAllowedText",
+                                    primaryNodeType: "jnt:text",
+                                    properties: [{ name: "text", language: "en", value: "not allowed text" }]
+                                }
+                            ]},
+                            {name: "restricted-area", primaryNodeType: "jnt:contentList"},
+                        ]
+                    }
+                ]) {
+                    uuid
+                }
+            }
+        }
+    }`;

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModuleCreateButton.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModuleCreateButton.ts
@@ -1,10 +1,14 @@
-import {BaseComponent, Button} from '@jahia/cypress';
+import {BaseComponent, Button, getComponentByRole} from '@jahia/cypress';
 
 export class PageBuilderModuleCreateButton extends BaseComponent {
     static defaultSelector = '[jahiatype="createbuttons"]';
 
     getButton(type: string): Button {
         return new Button(this.get().find('.moonstone-button').contains(type));
+    }
+
+    getButtonByRole(role: string): Button {
+        return getComponentByRole(Button, role, this);
     }
 
     getFirstInsertionButton(): Button {

--- a/tests/jahia-module/jcontent-test-template/src/main/import/repository.xml
+++ b/tests/jahia-module/jcontent-test-template/src/main/import/repository.xml
@@ -28,6 +28,13 @@
                      <my-area j:allowedTypes="" j:numberOfItems="3" jcr:primaryType="jnt:area"/>
                   </pagecontent>
                </simple>
+                <contentType jcr:primaryType="jnt:pageTemplate">
+                    <pagecontent jcr:mixinTypes="jmix:systemNameReadonly"
+                                 jcr:primaryType="jnt:contentList">
+                        <any-area jcr:primaryType="jnt:area"/>
+                        <restricted-area j:allowedTypes="pbnt:contentRestriction" jcr:primaryType="jnt:area"/>
+                    </pagecontent>
+                </contentType>
             </base>
             <content-template j:applyOn="jnt:content"
                               j:hiddenTemplate="true"

--- a/tests/jahia-module/jcontent-test-template/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-template/src/main/resources/META-INF/definitions.cnd
@@ -1,2 +1,5 @@
 <jnt = 'http://www.jahia.org/jahia/nt/1.0'>
 <jmix = 'http://www.jahia.org/jahia/mix/1.0'>
+<pbnt = 'http://www.jahia.org/pb/nt/1.0'>
+
+[pbnt:contentRestriction] > jnt:bigText


### PR DESCRIPTION
### Description

Add check for restriction defined in template for paste/paste references actions

Merge with contribute types if applicable when restriciton is specified in template (other than default `jmix:droppableContent`)

Cypress tests has been added

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
