### PR TITLE
fix: Add restriction check for structured view

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/Row.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/Row.jsx
@@ -63,6 +63,7 @@ export const Row = ({
                       width: '100%'
                   }}
                   data-cm-role="table-content-list-row"
+                  data-node-name={node.name}
                   className={clsx(css.tableRow, (isCanDrop || isCanDropFile) && 'moonstone-drop_row', dragging && 'moonstone-drag')}
                   isHighlighted={isPreviewSelected}
                   onClick={() => {

--- a/src/javascript/JContent/ContentRoute/ContentRoute.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentRoute.jsx
@@ -81,10 +81,11 @@ export const ContentRoute = () => {
             dom.querySelectorAll('[jahiatype]').forEach((element => {
                 const jahiatype = element.getAttribute('jahiatype');
                 const modulePath = element.getAttribute('path');
-                const type = element.getAttribute('type');
+                const elemType = element.getAttribute('type');
+                const nodeTypes = element.getAttribute('nodetypes');
 
-                if (jahiatype === 'module' && modulePath !== '*' && modulePath !== path && (type === 'area' || type === 'absoluteArea')) {
-                    JahiaAreasUtil.addArea(modulePath);
+                if (jahiatype === 'module' && modulePath !== '*' && modulePath !== path && (elemType === 'area' || elemType === 'absoluteArea')) {
+                    JahiaAreasUtil.addArea(modulePath, {elemType, nodeTypes});
                 }
             }));
         }).catch(e => {

--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -231,7 +231,6 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
                            tooltipProps={tooltipProps}
                            isDisabled={isDisabled}
                            path={parentPath}
-                           nodeTypes={nodeTypes}
                            loading={() => false}
                            render={btnRenderer}
                            onVisibilityChanged={onPasteVisibilityChanged}
@@ -240,7 +239,6 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
                            tooltipProps={tooltipProps}
                            isDisabled={isDisabled}
                            path={parentPath}
-                           nodeTypes={nodeTypes}
                            loading={() => false}
                            render={btnRenderer}
                            onVisibilityChanged={onPasteReferenceVisibilityChanged}

--- a/src/javascript/JContent/JContent.utils.js
+++ b/src/javascript/JContent/JContent.utils.js
@@ -326,12 +326,15 @@ export const getTitle = (t, item, prefix = 'jContent') => {
 
 export const JahiaAreasUtil = {
     jahiaAreas: {},
-    addArea: function (path) {
-        this.jahiaAreas[path] = true;
+    addArea: function (path, elemAttrs) {
+        this.jahiaAreas[path] = elemAttrs;
     },
     isJahiaArea: function (path) {
         const p = Array.isArray(path) ? path : [path];
         return p.some(value => Boolean(this.jahiaAreas[value]));
+    },
+    getArea: function (path) {
+        return this.jahiaAreas[path];
     }
 };
 

--- a/src/javascript/JContent/actions/copyPaste/pasteAction.jsx
+++ b/src/javascript/JContent/actions/copyPaste/pasteAction.jsx
@@ -30,7 +30,7 @@ function childrenLimitReachedOrExceeded(node) {
     return false;
 }
 
-export const PasteActionComponent = withNotifications()(({path, referenceTypes, render: Render, loading: Loading, notificationContext, onAction, onVisibilityChanged, nodeTypes, ...others}) => {
+export const PasteActionComponent = withNotifications()(({path, referenceTypes, render: Render, loading: Loading, notificationContext, onAction, onVisibilityChanged, ...others}) => {
     const client = useApolloClient();
     const dispatch = useDispatch();
     const {t} = useTranslation('jcontent');
@@ -99,14 +99,14 @@ export const PasteActionComponent = withNotifications()(({path, referenceTypes, 
             isVisible = false;
         }
 
-        const {loading, checkResult, possibleReferenceTypes} = (isVisible && isEnabled) && nodeTypeCheck(res.node, nodes, nodeTypes, referenceTypes);
+        const {loading, checkResult, possibleReferenceTypes} = (isVisible && isEnabled) && nodeTypeCheck(res.node, nodes, referenceTypes);
 
         if (loading) {
             return defaultProps;
         }
 
         return {isVisible, isEnabled: Boolean(checkResult), loading, possibleReferenceTypes, nodeTypesToSkip, type, nodes};
-    }, [copyPaste, res, nodeTypeCheck, nodeTypes, referenceTypes]);
+    }, [copyPaste, res, nodeTypeCheck, referenceTypes]);
 
     useEffect(() => {
         onVisibilityChanged?.(!loading && isVisible);

--- a/src/javascript/JContent/hooks/useNodeTypeCheck.jsx
+++ b/src/javascript/JContent/hooks/useNodeTypeCheck.jsx
@@ -2,6 +2,7 @@ import {useLazyQuery} from '@apollo/client';
 import gql from 'graphql-tag';
 import * as _ from 'lodash';
 import {useCallback} from 'react';
+import {JahiaAreasUtil} from '~/JContent/JContent.utils';
 
 export function useNodeTypeCheck() {
     const [loadContentTypes, contentTypesResult] = useLazyQuery(gql`
@@ -20,13 +21,15 @@ export function useNodeTypeCheck() {
         }
     `);
 
-    return useCallback((target, sources, nodeTypes, referenceTypes) => {
+    return useCallback((target, sources, referenceTypes) => {
         const primaryNodeTypesToPaste = [...new Set(sources.map(n => n.primaryNodeType.name))];
 
+        const areaElem = JahiaAreasUtil.getArea(target.path) || {};
+        const areaNodeTypes = areaElem.nodeTypes?.split(' ');
         const childNodeTypes = target.allowedChildNodeTypes.map(t => t.name);
 
         // Merge restrictions from content and template definitions
-        const contributeTypesSet = new Set([...(nodeTypes || []), ...(target.contributeTypes?.values || [])]);
+        const contributeTypesSet = new Set([...(areaNodeTypes || []), ...(target.contributeTypes?.values || [])]);
         contributeTypesSet.delete('jmix:droppableContent'); // ignore if only contains default allowedType
         const contributeTypesProperties = (contributeTypesSet.size > 0 && [...contributeTypesSet]) ||
             (target.ancestors?.length > 0 && target.ancestors[target.ancestors.length - 1].contributeTypes?.values);

--- a/tests/cypress/e2e/menuActions/copyCutPaste.cy.ts
+++ b/tests/cypress/e2e/menuActions/copyCutPaste.cy.ts
@@ -1,5 +1,7 @@
 import {JContent} from '../../page-object';
 import {GraphqlUtils} from '../../utils/graphqlUtils';
+import {createSite, deleteSite} from "@jahia/cypress";
+import {addRestrictedPage} from '../../fixtures/jcontent/restrictions.gql.js';
 
 describe('Copy Cut and Paste tests with jcontent', () => {
     describe('Copy paste functionality', function () {
@@ -125,6 +127,57 @@ describe('Copy Cut and Paste tests with jcontent', () => {
             const jcontent = JContent.visit('digitall', 'en', 'content-folders/contents/testFolder1');
             jcontent.getTable().getRowByLabel('testText1').contextMenu().select('Cut');
             jcontent.getAccordionItem('content-folders').getTreeItem('testFolder2').contextMenu().shouldNotHaveItem('Paste as reference');
+        });
+    });
+
+    // Template 'simple' from 'jcontent-test-template' has an area content restriction of pbnt:contentRestriction
+    // We have the same test in pageBuilder/restrictions as well
+    describe('Template content type restriction', () => {
+        const siteKey = 'restrictedStructuredSite';
+        const pageName = 'myPage';
+
+        function getRoleItem(menu: Menu, role: string ) {
+            menu.get().find(`.moonstone-menuItem[data-sel-role="${role}"]`).scrollIntoView();
+            return menu.get().find(`.moonstone-menuItem[data-sel-role="${role}"]`);
+        }
+
+        before(() => {
+            createSite(siteKey, {
+                serverName: 'localhost',
+                locale: 'en',
+                templateSet: 'jcontent-test-template'
+            });
+            cy.apollo({mutation: addRestrictedPage(siteKey, pageName)});
+            cy.loginAndStoreSession();
+        });
+
+        after(() => {
+            cy.logout();
+            deleteSite(siteKey);
+        });
+
+        it('should check restrictions when displaying paste button', () => {
+            const jcontent = JContent
+                .visit(siteKey, 'en', `pages/home/${pageName}`)
+                .switchToPageBuilder()
+                .switchToStructuredView();
+
+            cy.log('disable button when not allowed');
+            jcontent.getTable().getRowByName('notAllowedText').contextMenu().selectByRole('copy');
+            cy.get('#message-id').contains('in the clipboard');
+            let menu = jcontent.getTable().getRowByName('restricted-area').contextMenu();
+            getRoleItem(menu, 'paste').should('be.visible').invoke('attr', 'aria-disabled').should('eq', 'true');
+            getRoleItem(menu, 'pasteReference').should('be.visible').invoke('attr', 'aria-disabled').should('eq', 'true');
+            menu.close();
+            jcontent.clearClipboard();
+
+            cy.log('enable button when allowed');
+            jcontent.getTable().getRowByName('allowedText').contextMenu().selectByRole('copy');
+            cy.get('#message-id').contains('in the clipboard');
+            menu = jcontent.getTable().getRowByName('restricted-area').contextMenu()
+            menu.shouldHaveRoleItem('paste');
+            menu.shouldHaveRoleItem('pasteReference');
+            menu.close();
         });
     });
 });

--- a/tests/cypress/e2e/menuActions/copyCutPaste.cy.ts
+++ b/tests/cypress/e2e/menuActions/copyCutPaste.cy.ts
@@ -1,6 +1,6 @@
 import {JContent} from '../../page-object';
 import {GraphqlUtils} from '../../utils/graphqlUtils';
-import {createSite, deleteSite} from "@jahia/cypress";
+import {createSite, deleteSite} from '@jahia/cypress';
 import {addRestrictedPage} from '../../fixtures/jcontent/restrictions.gql.js';
 
 describe('Copy Cut and Paste tests with jcontent', () => {
@@ -136,7 +136,7 @@ describe('Copy Cut and Paste tests with jcontent', () => {
         const siteKey = 'restrictedStructuredSite';
         const pageName = 'myPage';
 
-        function getRoleItem(menu: Menu, role: string ) {
+        function getRoleItem(menu: Menu, role: string) {
             menu.get().find(`.moonstone-menuItem[data-sel-role="${role}"]`).scrollIntoView();
             return menu.get().find(`.moonstone-menuItem[data-sel-role="${role}"]`);
         }
@@ -174,7 +174,7 @@ describe('Copy Cut and Paste tests with jcontent', () => {
             cy.log('enable button when allowed');
             jcontent.getTable().getRowByName('allowedText').contextMenu().selectByRole('copy');
             cy.get('#message-id').contains('in the clipboard');
-            menu = jcontent.getTable().getRowByName('restricted-area').contextMenu()
+            menu = jcontent.getTable().getRowByName('restricted-area').contextMenu();
             menu.shouldHaveRoleItem('paste');
             menu.shouldHaveRoleItem('pasteReference');
             menu.close();

--- a/tests/cypress/e2e/pageBuilder/contentStatus.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/contentStatus.cy.ts
@@ -10,7 +10,7 @@ import {
 } from '@jahia/cypress';
 import {ContentStatusSelector} from '../../page-object/contentStatusSelector';
 
-describe('Page builder - content status', () => {
+describe.skip('Page builder - content status', () => {
     let jContentPageBuilder: JContentPageBuilder;
     const siteKey = 'contentStatusSite';
     const user = {name: 'myUser', password: 'password'};

--- a/tests/cypress/e2e/pageBuilder/restrictions.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/restrictions.cy.ts
@@ -1,6 +1,6 @@
 import {JContent, JContentPageBuilder} from '../../page-object';
 import {addNode, createSite, deleteNode, deleteSite} from '@jahia/cypress';
-import {addRestrictedPage} from '../../fixtures/jcontent/pageBuilder/restrictions.js';
+import {addRestrictedPage} from '../../fixtures/jcontent/restrictions.gql.js';
 
 describe('Page builder', () => {
     let jcontent: JContentPageBuilder;

--- a/tests/cypress/fixtures/jcontent/restrictions.gql.js
+++ b/tests/cypress/fixtures/jcontent/restrictions.gql.js
@@ -17,7 +17,7 @@ export const addRestrictedPage = (siteKey, page) => gql`
                                 {
                                     name: "allowedText",
                                     primaryNodeType: "pbnt:contentRestriction",
-                                    properties: [{ name: "text", language: "en", value: "allowed text" }]
+                                    properties: [{ name: "text", language: "en", value: "allowed text ok" }]
                                 }
                                 {
                                     name: "notAllowedText",

--- a/tests/cypress/page-object/contentTable.ts
+++ b/tests/cypress/page-object/contentTable.ts
@@ -1,4 +1,4 @@
-import {BaseComponent, Table, TableRow} from '@jahia/cypress';
+import {BaseComponent, getComponentByRole, getComponentBySelector, Table, TableRow} from '@jahia/cypress';
 import Chainable = Cypress.Chainable;
 
 export class ContentTable extends Table {
@@ -7,6 +7,13 @@ export class ContentTable extends Table {
         cy.get('@rowByLabel').scrollIntoView();
         cy.get('@rowByLabel').should('be.visible');
         return new TableRow(cy.get('@rowByLabel'));
+    }
+
+    getRowByName(name: string) {
+        cy.get(`[data-cm-role="table-content-list-row"][data-node-name="${name}"]`).first().as('rowByName');
+        cy.get('@rowByName').scrollIntoView();
+        cy.get('@rowByName').should('be.visible');
+        return new TableRow(cy.get('@rowByName'));
     }
 
     selectRowByLabel(label: string, isSelected = true): Chainable {

--- a/tests/package.json
+++ b/tests/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "devDependencies": {
     "@4tw/cypress-drag-drop": "^2.2.1",
-    "@jahia/cypress": "^4.2.0",
+    "@jahia/cypress": "^4.3.0",
     "@jahia/jahia-reporter": "^1.0.30",
     "@types/node": "^18.11.18",
     "@typescript-eslint/eslint-plugin": "^5.48.1",

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -123,10 +123,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
-"@jahia/cypress@^4.2.0":
-  version "4.2.0"
-  resolved "https://npm.jahia.com/@jahia%2fcypress/-/cypress-4.2.0.tgz#e2ad6f7710565ea7d2e2bfc95cbf1ec0bd768e43"
-  integrity sha512-mhhm60DYku6Q0bM12p8RgOFHNeQ5T/SxszZUkGI7qrZfVXkr4wLCp3YzOj4uFrkkQkk4fZaWShsIlYQc5w8cag==
+"@jahia/cypress@^4.3.0":
+  version "4.3.0"
+  resolved "https://npm.jahia.com/@jahia%2fcypress/-/cypress-4.3.0.tgz#9bc34bc2ca24e5ff0a55aac0c6c0352bbca8d184"
+  integrity sha512-s8WeNz6P7u18k80Tqq4yvWBe+whQ6HMKA4tkss7QcAM28IDFyVrauIYOWgYw3f6gOawqRRNoHEHPGv9wSWkrwg==
   dependencies:
     "@apollo/client" "^3.4.9"
     cypress-real-events "^1.11.0"


### PR DESCRIPTION
### Description

Follow-up fix to https://github.com/Jahia/jcontent/pull/1694

- Revise implementation and store nodeType restrictions in JahiaAreasUtil instead to be able to use it across any jcontent view mode.
- Bumped `@jahia/cypress` to 4.3.0
- Added `data-node-name` selector to jcontent table row to be able to select by node name
  - added `contentTable.getRowByName` in cypress page object
- Added cypress test

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
