### PR TITLE
fix: Apply template restrictions for context menu actions

### DIFF
--- a/src/javascript/ContentEditor/actions/jcontent/createContent/createContent.utils.js
+++ b/src/javascript/ContentEditor/actions/jcontent/createContent/createContent.utils.js
@@ -111,6 +111,6 @@ export function childrenLimitReachedOrExceeded(node, templateLimit) {
         }
     }
 
-    return typeof (templateLimit) === 'number' && childrenCount >= templateLimit;
+    return typeof (templateLimit) === 'number' && !isNaN(templateLimit) && childrenCount >= templateLimit;
 }
 

--- a/src/javascript/ContentEditor/actions/jcontent/createContent/createContentAction.jsx
+++ b/src/javascript/ContentEditor/actions/jcontent/createContent/createContentAction.jsx
@@ -10,6 +10,7 @@ import {useNodeChecks, useNodeInfo} from '@jahia/data-helper';
 import * as PropTypes from 'prop-types';
 import {useTranslation} from 'react-i18next';
 import {useContentEditorApiContext} from '~/ContentEditor/contexts/ContentEditorApi/ContentEditorApi.context';
+import {JahiaAreasUtil} from '~/JContent/JContent.utils';
 
 export const CreateContent = ({
     contextNodePath,
@@ -20,7 +21,6 @@ export const CreateContent = ({
     isIncludeSubTypes,
     isFullscreen,
     hasBypassChildrenLimit,
-    templateLimit,
     onCreate,
     onClosed,
     isDisabled,
@@ -47,8 +47,9 @@ export const CreateContent = ({
         }
     );
     const excludedNodeTypes = ['jmix:studioOnly', 'jmix:hiddenType'];
+    let areaNodeTypes = (nodeTypes?.length > 0) ? nodeTypes : JahiaAreasUtil.getArea(path)?.nodeTypes;
     const {loadingTypes, error, nodetypes: nodeTypesTree} = useCreatableNodetypesTree({
-        nodeTypes,
+        nodeTypes: areaNodeTypes,
         childNodeName: name,
         includeSubTypes: isIncludeSubTypes || false,
         path: contextNodePath || path,
@@ -69,6 +70,7 @@ export const CreateContent = ({
             return defaultProps;
         }
 
+        const templateLimit = JahiaAreasUtil.getArea(path)?.limit;
         if (!res || !res.node || (nodeTypesTree && nodeTypesTree.length === 0) || childrenLimitReachedOrExceeded(nodeInfo?.node, templateLimit)) {
             return {...defaultProps, loading: false};
         }
@@ -83,7 +85,7 @@ export const CreateContent = ({
             actions,
             missingNodes: false
         };
-    }, [Loading, hasBypassChildrenLimit, loadingTypes, res, nodeInfo, nodeTypesTree, templateLimit]);
+    }, [path, Loading, hasBypassChildrenLimit, loadingTypes, res, nodeInfo, nodeTypesTree]);
 
     useEffect(() => {
         onVisibilityChanged?.(isVisible);

--- a/src/javascript/ContentEditor/actions/jcontent/createContent/createContentAction.spec.jsx
+++ b/src/javascript/ContentEditor/actions/jcontent/createContent/createContentAction.spec.jsx
@@ -16,8 +16,10 @@ jest.mock('react-redux', () => {
     return {useSelector: jest.fn()};
 });
 jest.mock('@jahia/data-helper', () => {
-    return {useNodeChecks: jest.fn(),
-        useNodeInfo: jest.fn()};
+    return {
+        useNodeChecks: jest.fn(),
+        useNodeInfo: jest.fn()
+    };
 });
 jest.mock('~/ContentEditor/ContentTypeSelectorModal', () => jest.fn());
 jest.mock('./createContent.utils', () => {
@@ -26,6 +28,13 @@ jest.mock('./createContent.utils', () => {
         flattenNodeTypes: jest.fn(),
         transformNodeTypesToActions: jest.fn(),
         childrenLimitReachedOrExceeded: jest.fn()
+    };
+});
+jest.mock('~/JContent/JContent.utils', () => {
+    return {
+        JahiaAreasUtil: {
+            getArea: () => {}
+        }
     };
 });
 

--- a/src/javascript/JContent/ContentRoute/ContentRoute.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentRoute.jsx
@@ -82,10 +82,11 @@ export const ContentRoute = () => {
                 const jahiatype = element.getAttribute('jahiatype');
                 const modulePath = element.getAttribute('path');
                 const elemType = element.getAttribute('type');
-                const nodeTypes = element.getAttribute('nodetypes');
+                const nodeTypes = element.getAttribute('nodetypes')?.split(' ');
+                const limit = element.getAttribute('listlimit') ?? undefined;
 
                 if (jahiatype === 'module' && modulePath !== '*' && modulePath !== path && (elemType === 'area' || elemType === 'absoluteArea')) {
-                    JahiaAreasUtil.addArea(modulePath, {elemType, nodeTypes});
+                    JahiaAreasUtil.addArea(modulePath, {elemType, nodeTypes, limit: Number(limit)});
                 }
             }));
         }).catch(e => {

--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -59,14 +59,7 @@ const useElemAttributes = ({element, parent}) => {
         nodeTypes = element.getAttribute('nodetypes').split(' ');
     }
 
-    // Extract limit defined on template set
-    let templateLimit = null;
-    if (parent.getAttribute('listLimit') &&
-        (parent.getAttribute('type') === 'area' || parent.getAttribute('type') === 'absoluteArea')) {
-        templateLimit = Number(parent.getAttribute('listLimit'));
-    }
-
-    return {nodeName, nodePath, nodeTypes, templateLimit};
+    return {nodeName, nodePath, nodeTypes};
 };
 
 const useReorderNodes = ({parentPath}) => {
@@ -114,7 +107,7 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
     const parent = element.dataset.jahiaParent && element.ownerDocument.getElementById(element.dataset.jahiaParent);
     const parentPath = parent.getAttribute('path');
     const [currentOffset, setCurrentOffset] = useState(getBoundingBox(element));
-    const {nodeName, nodePath, nodeTypes, templateLimit} = useElemAttributes({element, parent, isInsertionPoint});
+    const {nodeName, nodePath, nodeTypes} = useElemAttributes({element, parent, isInsertionPoint});
     const [actionVisibility, setActionVisibility] = useState({
         createContent: false,
         paste: false,
@@ -222,7 +215,6 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
                                name={nodePath}
                                isDisabled={isDisabled}
                                nodeTypes={nodeTypes}
-                               templateLimit={templateLimit}
                                loading={() => false}
                                render={btnRenderer}
                                onVisibilityChanged={onCreateVisibilityChanged}

--- a/src/javascript/JContent/hooks/useNodeTypeCheck.jsx
+++ b/src/javascript/JContent/hooks/useNodeTypeCheck.jsx
@@ -24,8 +24,7 @@ export function useNodeTypeCheck() {
     return useCallback((target, sources, referenceTypes) => {
         const primaryNodeTypesToPaste = [...new Set(sources.map(n => n.primaryNodeType.name))];
 
-        const areaElem = JahiaAreasUtil.getArea(target.path) || {};
-        const areaNodeTypes = areaElem.nodeTypes?.split(' ');
+        const areaNodeTypes = JahiaAreasUtil.getArea(target.path)?.nodeTypes;
         const childNodeTypes = target.allowedChildNodeTypes.map(t => t.name);
 
         // Merge restrictions from content and template definitions

--- a/tests/cypress/e2e/menuActions/copyCutPaste.cy.ts
+++ b/tests/cypress/e2e/menuActions/copyCutPaste.cy.ts
@@ -130,8 +130,8 @@ describe('Copy Cut and Paste tests with jcontent', () => {
         });
     });
 
-    // Template 'simple' from 'jcontent-test-template' has an area content restriction of pbnt:contentRestriction
-    // We have the same test in pageBuilder/restrictions as well
+    // Template 'contentType' from 'jcontent-test-template' has an area content restriction of pbnt:contentRestriction
+    // We have the same test in pageBuilder/restrictions as well for page builder
     describe('Template content type restriction', () => {
         const siteKey = 'restrictedStructuredSite';
         const pageName = 'myPage';

--- a/tests/cypress/e2e/pageBuilder/listLimit.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/listLimit.cy.ts
@@ -103,11 +103,24 @@ describe('Page builder - list limit restrictions tests', () => {
                 .getButton('New content');
         });
 
-        it('should not show create button when template limit is reached', () => {
+        it('should not show create button or paste buttons when template limit is reached', () => {
             cy.apollo({mutation: addContentGql(limitSiteKey, limitPage)});
             const jcontent = JContent.visit(limitSiteKey, 'en', `pages/home/${limitPage}`);
             const pageBuilder = new JContentPageBuilder(jcontent);
+
+            cy.log('it should not show create buttons');
             pageBuilder.getModule(`/sites/${limitSiteKey}/home/${limitPage}/my-area`).assertHasNoCreateButtons();
+
+            cy.log('it should not show paste buttons');
+            pageBuilder.getModule(`/sites/${limitSiteKey}/home/${limitPage}/my-area/abc1`, false)
+                .contextMenu(false, false)
+                .selectByRole('copy');
+            cy.get('#message-id').contains('in the clipboard');
+            const restrictedArea = pageBuilder.getModule(`/sites/${limitSiteKey}/home/${limitPage}/my-area`, false);
+            const buttons = restrictedArea.getCreateButtons();
+            buttons.get().scrollIntoView();
+            buttons.assertHasNoButtonForRole('paste');
+            buttons.assertHasNoButtonForRole('pasteReference');
         });
     });
 });

--- a/tests/cypress/e2e/pageBuilder/restrictions.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/restrictions.cy.ts
@@ -1,5 +1,5 @@
 import {JContent, JContentPageBuilder} from '../../page-object';
-import {addNode, createSite, deleteNode, deleteSite} from '@jahia/cypress';
+import {addNode, createSite, deleteNode, deleteSite, getComponentBySelector, Menu} from '@jahia/cypress';
 import {addRestrictedPage} from '../../fixtures/jcontent/restrictions.gql.js';
 
 describe('Page builder', () => {
@@ -127,7 +127,7 @@ describe('Page builder', () => {
         });
     });
 
-    // Template 'simple' from 'jcontent-test-template' has an area content restriction of pbnt:contentRestriction
+    // Template 'contentType' from 'jcontent-test-template' has an area content restriction of pbnt:contentRestriction
     describe('Template content type restriction', () => {
         const siteKey = 'restrictedSite';
         const pageName = 'myPage';
@@ -174,6 +174,26 @@ describe('Page builder', () => {
             buttons.get().scrollIntoView();
             buttons.getButtonByRole('paste').should('be.visible').and('not.have.attr', 'disabled');
             buttons.getButtonByRole('pasteReference').should('be.visible').and('not.have.attr', 'disabled');
+        });
+
+        it('should restrict create content with page builder create buttons and context menu', () => {
+            const pageBuilder = JContent
+                .visit(siteKey, 'en', `pages/home/${pageName}`)
+                .switchToPageBuilder();
+
+            cy.log('restricted-area should restrict create buttons for pbnt:contentRestriction only');
+            const restrictedArea = pageBuilder.getModule(`/sites/${siteKey}/home/${pageName}/restricted-area`, false);
+            const buttons = restrictedArea.getCreateButtons();
+            buttons.get().scrollIntoView();
+            buttons.assertHasNoButtonForRole('createContent');
+            buttons.getButtonByRole('pbnt:contentRestriction').should('be.visible');
+
+            cy.log('restricted-area should restrict context menu create buttons for pbnt:contentRestriction only');
+            const contextMenu = pageBuilder
+                .getModule(`/sites/${siteKey}/home/${pageName}/restricted-area`, false)
+                .emptyAreaContextMenu();
+            contextMenu.shouldNotHaveRoleItem('createContent');
+            contextMenu.shouldHaveRoleItem('pbnt:contentRestriction');
         });
     });
 });

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
@@ -96,6 +96,12 @@ export class PageBuilderModule extends BaseComponent {
         return getComponentBySelector(Menu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)');
     }
 
+    /* Use specifically for areas with empty content as empty create button takes over content and cannot right-click the regular way */
+    emptyAreaContextMenu() {
+        this.getHeader().get().rightclick();
+        return getComponentBySelector(Menu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)');
+    }
+
     click(clickOptions?: Partial<ClickOptions>) {
         this.get().scrollIntoView().click(clickOptions);
     }

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModuleCreateButton.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModuleCreateButton.ts
@@ -22,4 +22,8 @@ export class PageBuilderModuleCreateButton extends BaseComponent {
     assertHasNoButtonForType(type: string): void {
         this.get().find('.moonstone-button').contains(type).should('not.exist');
     }
+
+    assertHasNoButtonForRole(role: string): void {
+        this.get().find(`.moonstone-button[data-sel-role="${role}"]`).should('not.exist');
+    }
 }


### PR DESCRIPTION
### Description

- Apply template limit to paste actions
- Apply create content type limitations for all create actions

Refactored to use JahiaAreasUtil for getting area template restriction information 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
