### PR TITLE
fix: URL parsing for filenames with dot 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahia/jcontent",
-  "version": "3.4.0-SNAPSHOT",
+  "version": "3.3.1-SNAPSHOT",
   "scripts": {
     "build": "yarn webpack",
     "webpack": "node --max_old_space_size=2048 ./node_modules/webpack/bin/webpack.js",

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </parent>
     <artifactId>jcontent</artifactId>
     <name>jContent</name>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>3.3.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (jContent) for running on a Jahia server.</description>
 
@@ -47,7 +47,7 @@
     <properties>
         <jahia-module-type>system</jahia-module-type>
         <yarn.arguments>build:production</yarn.arguments>
-        <jahia-module-signature>MCwCFFWwfatMPSRb1bLVA/c9m9rQcuPQAhRAZUKwzqV1kAVBsqY9UodI2LFtwA==</jahia-module-signature>
+        <jahia-module-signature>MC0CFBvkGXHIlxkcDSJsCt6vCgDNWhvoAhUAh3FFtznehVYNF2G1mbRU7TzBrgI=</jahia-module-signature>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
         <jahia-depends>jahia-ui-root=1.10.0,app-shell=2.7,graphql-dxm-provider=3.2.0</jahia-depends>
         <import-package>

--- a/src/javascript/JContent/redux/JContent.redux.js
+++ b/src/javascript/JContent/redux/JContent.redux.js
@@ -26,7 +26,7 @@ const apps = {
             const accordion = registry.get('accordionItem', mode);
             const viewMode = localStorage.getItem('jcontent-previous-tableView-viewMode-' + site + '-' + mode) || accordion?.tableConfig?.defaultViewMode || 'flatList';
             let template = '';
-            if (path.lastIndexOf('.') > 0) {
+            if (viewMode === JContentConstants.tableView.viewMode.PAGE_BUILDER && path.lastIndexOf('.') > 0) {
                 template = path.substring(path.lastIndexOf('.') + 1);
                 path = path.substring(0, path.lastIndexOf('.'));
             }

--- a/tests/cypress/e2e/jcontent/navigation.cy.ts
+++ b/tests/cypress/e2e/jcontent/navigation.cy.ts
@@ -14,9 +14,7 @@ describe('Content navigation', () => {
         });
         enableModule('jcontent-test-module', 'mySite1');
         enableModule('events', 'mySite1');
-        enableModule('events', 'mySite3');
         addNode({parentPathOrId: '/sites/mySite1/contents', primaryNodeType: 'jnt:event', name: 'test-event'});
-        addNode({parentPathOrId: '/sites/mySite3/contents', primaryNodeType: 'jnt:event', name: 'test-event'});
         addNode({
             name: specialCharsName,
             parentPathOrId: '/sites/mySite1/home',
@@ -26,6 +24,11 @@ describe('Content navigation', () => {
                 {name: 'j:templateName', value: '2-column'}
             ]
         });
+        addNode({parentPathOrId: '/sites/mySite1/files', name: 'll.js', primaryNodeType: 'jnt:folder'});
+        addNode({parentPathOrId: '/sites/mySite1/contents', name: 'll.js', primaryNodeType: 'jnt:contentFolder'});
+
+        enableModule('events', 'mySite3');
+        addNode({parentPathOrId: '/sites/mySite3/contents', primaryNodeType: 'jnt:event', name: 'test-event'});
     });
 
     after(() => {
@@ -56,6 +59,20 @@ describe('Content navigation', () => {
         jcontent.getAccordionItem('pages').getTreeItem(specialCharsName).click();
         jcontent.shouldBeInMode('Page Builder');
         cy.get('h1').contains('special chars page');
+    });
+
+    it('can open media folders with dots', () => {
+        JContent.visit('mySite1', 'en', 'media/files/ll.js');
+        cy.get('h1').contains('ll.js');
+        cy.get('[data-type="upload"]').should('be.visible');
+        cy.url().should('contain', 'll.js');
+    });
+
+    it('can open content folders with dots', () => {
+        JContent.visit('mySite1', 'en', 'content-folders/contents/ll.js');
+        cy.get('h1').contains('ll.js');
+        cy.get('[data-type="import"]').should('be.visible');
+        cy.url().should('contain', 'll.js');
     });
 
     it('can open page with the correct view mode selection', () => {

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -48,7 +48,7 @@
     <groupId>org.jahia.test</groupId>
     <artifactId>jcontent-test-module-root</artifactId>
     <name>jContent Test Module Root</name>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>3.3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>This is the custom module (text-field-initializer) for content-editor cypress tests.</description>
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jahia/jcontent-cypress",
   "private": false,
-  "version": "3.4.0-SNAPSHOT",
+  "version": "3.3.1-SNAPSHOT",
   "scripts": {
     "instrument": "nyc instrument --compact=false cypress instrumented",
     "e2e:ci": "cypress run --browser chrome",


### PR DESCRIPTION
### Description

Currently URLs parsed for `.` extensions to check for any template. This should only apply to viewable contents e.g. when displaying viewable contents. Check that we're applying this only when view is in page builder mode, otherwise redirects when not applicable. 


### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
