### PR TITLE
fix: Add checks on object merge

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/Picker/Picker.utils.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/Picker.utils.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import {SiteWeb} from '@jahia/moonstone';
 import {NodeIcon} from '~/utils/NodeIcon';
+import {mergeDeep} from '~/JContent/JContent.utils';
+export {mergeDeep};
 
 export const getPathWithoutFile = fullPath => {
     return fullPath && fullPath.split('/').slice(0, -1).join('/');
@@ -100,34 +102,6 @@ export const set = (target, path, value) => {
     } else {
         current[key] = value;
     }
-};
-
-export const isObject = item => {
-    return (item && typeof item === 'object' && !Array.isArray(item));
-};
-
-export const mergeDeep = (target, ...sources) => {
-    if (!sources.length) {
-        return target;
-    }
-
-    const source = sources.shift();
-
-    if (isObject(target) && isObject(source)) {
-        for (const key in source) {
-            if (isObject(source[key])) {
-                if (!target[key]) {
-                    Object.assign(target, {[key]: {}});
-                }
-
-                mergeDeep(target[key], source[key]);
-            } else {
-                Object.assign(target, {[key]: source[key]});
-            }
-        }
-    }
-
-    return mergeDeep(target, ...sources);
 };
 
 export const getBaseSearchContextData = ({t, currentSite, accordion, node, currentPath}) => (

--- a/src/javascript/JContent/JContent.utils.js
+++ b/src/javascript/JContent/JContent.utils.js
@@ -150,6 +150,10 @@ export const isObject = item => {
     return (item && typeof item === 'object' && !Array.isArray(item));
 };
 
+export const isSafeKey = (key) => {
+    return !["__proto__", "prototype", "constructor"].includes(key);
+}
+
 export const mergeDeep = (target, ...sources) => {
     if (!sources.length) {
         return target;
@@ -159,6 +163,10 @@ export const mergeDeep = (target, ...sources) => {
 
     if (isObject(target) && isObject(source)) {
         for (const key in source) {
+            if (!isSafeKey(key)) {
+                continue;
+            }
+
             if (isObject(source[key])) {
                 if (!target[key]) {
                     Object.assign(target, {[key]: {}});
@@ -205,7 +213,9 @@ export const getCanDisplayItemParams = node => {
 
 export const getAccordionItem = (accordion, accordionItemProps) => {
     if (accordionItemProps && accordion && accordionItemProps[accordion.key]) {
-        return mergeDeep({}, accordion, accordionItemProps[accordion.key]);
+        // Avoid proto pollution by creating an empty object with no Object.prototype
+        const emptyObj = Object.create(null);
+        return mergeDeep(emptyObj, accordion, accordionItemProps[accordion.key]);
     }
 
     return accordion;


### PR DESCRIPTION
### Description

Prevent __proto__ pollution by checking for reserved keywords before copy.

Alternative also is to maybe use a secure deep merge util like lodash.merge (after vuln fix)

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
