### PR TITLE
fix: Prevent proto pollution in json overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "connected-react-router": "^6.9.3",
     "dayjs": "^1.10.6",
     "ellipsize": "^0.5.0",
+    "es-toolkit": "^1.39.4",
     "formik": "^2.4.6",
     "graphql": "^16.10.0",
     "graphql-tag": "^2.12.6",

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/Picker.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/Picker.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import {useTranslation} from 'react-i18next';
 import {FieldPropTypes} from '~/ContentEditor/ContentEditor.proptypes';
 import {ReferenceCard} from '~/ContentEditor/DesignSystem/ReferenceCard';
-import {mergeDeep, set, toArray} from './Picker.utils';
+import {mergeDeep, toArray} from './Picker.utils';
+import {set} from 'es-toolkit/compat';
 import {PickerDialog} from './PickerDialog/PickerDialog';
 import {DisplayAction} from '@jahia/ui-extender';
 import {

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/Picker.utils.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/Picker.utils.js
@@ -47,63 +47,6 @@ export const getDetailedPathArray = fullPath => {
         [];
 };
 
-export const set = (target, path, value) => {
-    const splitRes = path.split('.');
-    const regex = /(\[\d+])$/;
-
-    let key;
-    let position;
-    let match;
-    let current = target;
-    while ((splitRes.length > 1) && (key = splitRes.shift())) {
-        // Case items[0].key = 'something'
-        match = regex.exec(key);
-
-        if (match) {
-            key = key.replace(match[0], '');
-            position = parseInt(match[0].replace(/[[\]]/g, ''), 10);
-        }
-
-        if (!current[key]) {
-            if (match) {
-                current[key] = [];
-            } else {
-                current[key] = {};
-            }
-        }
-
-        if (Array.isArray(current[key])) {
-            if (!current[key][position]) {
-                current[key][position] = {};
-            }
-
-            current = current[key][position];
-            match = null;
-            position = null;
-        } else {
-            current = current[key];
-        }
-    }
-
-    key = splitRes.shift();
-
-    // Case items[0] = 'something'
-    match = regex.exec(key);
-
-    if (match) {
-        key = key.replace(match[0], '');
-        position = parseInt(match[0].replace(/[[\]]/g, ''), 10);
-
-        if (!current[key]) {
-            current[key] = [];
-        }
-
-        current[key][position] = value;
-    } else {
-        current[key] = value;
-    }
-};
-
 export const getBaseSearchContextData = ({t, currentSite, accordion, node, currentPath}) => (
     [
         {

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/Picker.utils.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/Picker.utils.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import {SiteWeb} from '@jahia/moonstone';
 import {NodeIcon} from '~/utils/NodeIcon';
-import {mergeDeep} from '~/JContent/JContent.utils';
-export {mergeDeep};
+export {mergeDeep} from '~/JContent/JContent.utils';
 
 export const getPathWithoutFile = fullPath => {
     return fullPath && fullPath.split('/').slice(0, -1).join('/');

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/Picker.utils.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/Picker.utils.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import {SiteWeb} from '@jahia/moonstone';
 import {NodeIcon} from '~/utils/NodeIcon';
+import {mergeDeep} from '~/JContent/JContent.utils';
+export {mergeDeep};
 
 export const getPathWithoutFile = fullPath => {
     return fullPath && fullPath.split('/').slice(0, -1).join('/');
@@ -100,34 +102,6 @@ export const set = (target, path, value) => {
     } else {
         current[key] = value;
     }
-};
-
-export const isObject = item => {
-    return (item && typeof item === 'object' && !Array.isArray(item));
-};
-
-export const mergeDeep = (target, ...sources) => {
-    if (!sources.length) {
-        return target;
-    }
-
-    const source = sources.shift();
-
-    if (isObject(target) && isObject(source)) {
-        for (const key in source) {
-            if (isObject(source[key])) {
-                if (!target[key]) {
-                    Object.assign(target, {[key]: {}});
-                }
-
-                mergeDeep(target[key], source[key]);
-            } else {
-                Object.assign(target, {[key]: source[key]});
-            }
-        }
-    }
-
-    return mergeDeep(target, ...sources);
 };
 
 export const getBaseSearchContextData = ({t, currentSite, accordion, node, currentPath}) => (

--- a/tests/cypress/e2e/pickers/search.cy.ts
+++ b/tests/cypress/e2e/pickers/search.cy.ts
@@ -33,6 +33,8 @@ describe('Picker tests - Search', () => {
 
     it('Media Picker - Search for tab - in different context', () => {
         const picker = contentEditor.getPickerField('jdmix:imgView_image').open();
+        // Verify existing image is selected i.e. files/images/slides folder is selected
+        picker.getAccordionItem('picker-media').getTreeItem('slides').shouldBeSelected();
         picker.getViewMode().select('List');
         picker.search('tab');
         picker.verifyResultsLength(1);
@@ -45,6 +47,7 @@ describe('Picker tests - Search', () => {
 
     it('Media Picker - Search for tab - cancel and reopen - search should be empty', () => {
         let picker = contentEditor.getPickerField('jdmix:imgView_image').open();
+        picker.getAccordionItem('picker-media').getTreeItem('slides').shouldBeSelected();
         picker.getViewMode().select('List');
         picker.search('tab');
         picker.verifyResultsLength(1);

--- a/tests/cypress/page-object/contentEditor.ts
+++ b/tests/cypress/page-object/contentEditor.ts
@@ -57,6 +57,10 @@ export class ContentEditor extends BasePage {
         return getComponentByAttr(ContentStatus, 'data-status-type', statusType).should('be.visible');
     }
 
+    getTitle() {
+        return cy.get('#contenteditor-dialog-title');
+    }
+
     getSection(sectionName: string) {
         // Works with both display name and system name
         const section = getComponentBySelector(Section, `[data-sel-content-editor-fields-group="${sectionName}"], [data-sel-content-editor-fields-group-display-name="${sectionName}"]`);

--- a/tests/cypress/page-object/fields/pickerField.ts
+++ b/tests/cypress/page-object/fields/pickerField.ts
@@ -9,6 +9,7 @@ export class PickerField extends Field {
         const buttonSelector = this.multiple ? PickerField.ADD_FIELD_SEL : '[data-sel-field-picker-action]';
         this.get().find(buttonSelector).scrollIntoView({offset: {left: 0, top: -150}}).click({force: true});
         getComponentByAttr(Button, 'data-sel-picker-dialog-action', 'cancel').get().should('be.visible');
+        cy.get('.moonstone-loader', {timeout: 5000}).should('not.exist');
         return getComponentByRole(Picker, 'picker-dialog');
     }
 

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -152,6 +152,9 @@
  - defaultValueField (string)
  - valueConstraintField (string)
 
+[cent:testProtoMerge] > jnt:content, mix:title, jmix:basicContent, jmix:editorialContent
+ - pickerOverrideField (weakreference)
+
  [cent:testChoiceTreeContent] > jnt:content, mix:title, jmix:basicContent, jmix:editorialContent
   + * (cent:testChoiceTreeContent) = cent:testChoiceTreeContent
 

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/jahia-content-editor-forms/forms/cent_testProtoMerge.json
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/jahia-content-editor-forms/forms/cent_testProtoMerge.json
@@ -1,0 +1,25 @@
+{
+  "nodeType": "cent:testProtoMerge",
+  "priority": 1.0,
+  "hasPreview": false,
+  "sections": [
+    {
+      "name": "myCustomSection",
+      "fieldSets": [
+        {
+          "name": "cent:testProtoMerge",
+          "fields": [
+            {
+              "name": "pickerOverrideField",
+              "selectorType": "Picker",
+              "selectorOptionsMap": {
+                "type": "default",
+                "__proto__": {"polluted": "Yes, I am polluted!"}
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7441,6 +7441,11 @@ es-to-primitive@^1.3.0:
     is-date-object "^1.0.5"
     is-symbol "^1.0.4"
 
+es-toolkit@^1.39.4:
+  version "1.39.4"
+  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.39.4.tgz#73d1128933d46bf463666bc05b8f3c5ad876f3d0"
+  integrity sha512-hHqQ0yJERMNrJUyYHnf02qDuIxjRnnJlx1CFdR9Ia6tw6jPA7kXmb+tWzc7trJDHwMsc393hZ/m2XMxYXGAfqQ==
+
 es5-shim@^4.5.13:
   version "4.6.7"
   resolved "https://registry.yarnpkg.com/es5-shim/-/es5-shim-4.6.7.tgz#bc67ae0fc3dd520636e0a1601cc73b450ad3e955"


### PR DESCRIPTION
### Description

https://support.jahia.com/browse/SECURITY-529

Prevent proto pollution by checking for reserved keywords before copy when merging json override objects.

In the case of set function, I've replaced it with utility package es-toolkit (more up-to-date lodash) that takes care of the corner cases around proto pollution.

