### PR TITLE
fix: remove properties with empty values when cannot find it in context

### DIFF
--- a/src/javascript/ContentEditor/utils/fields.utils.js
+++ b/src/javascript/ContentEditor/utils/fields.utils.js
@@ -96,19 +96,16 @@ function updateValue({field, value, lang, nodeData, sections, mixinsToMutate, pr
             }
         }
     } else if (nodeData) {
-        // Check if props existed before, to remove it
-        const nodeProperty = nodeData.properties.find(prop => prop.name === field.propertyName);
-        if (nodeProperty && nodeProperty[getValuePropName(field).name]) {
-            const fieldSetName = getDynamicFieldSetNameOfField(sections, field);
-            if (!fieldSetName ||
+        // Remove property
+        const fieldSetName = getDynamicFieldSetNameOfField(sections, field);
+        if (!fieldSetName ||
                 (fieldSetName &&
                     !mixinsToMutate.mixinsToDelete.includes(fieldSetName) &&
                     (hasNodeMixin(nodeData, fieldSetName) || mixinsToMutate.mixinsToAdd.includes(fieldSetName)))) {
-                propsToDelete.push({
-                    name: field.propertyName,
-                    language: lang
-                });
-            }
+            propsToDelete.push({
+                name: field.propertyName,
+                language: lang
+            });
         }
     }
 


### PR DESCRIPTION
### Description
This ticket to to enable CTOL to clear all properties in all languages at once, as those properties do not show up in nodeData.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
