### PR TITLE
fix: Add ui language to editorConfig upon creation

### DIFF
--- a/src/javascript/ContentEditor/ContentEditorApi/ContentEditorApi.jsx
+++ b/src/javascript/ContentEditor/ContentEditorApi/ContentEditorApi.jsx
@@ -65,6 +65,8 @@ export const ContentEditorApi = () => {
             editorConfig.formKey = 'modal_' + editorConfigs.length;
         }
 
+        editorConfig.uilang = window.jahiaGWTParameters.uilang;
+
         setEditorConfigs([...editorConfigs, editorConfig]);
     };
 


### PR DESCRIPTION
### Description
Add ui language to editorConfig upon creation

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
