### PR TITLE
fix: increase the size of Content Editor modal

### DIFF
--- a/src/javascript/ContentEditor/ContentEditorApi/ContentEditorModal.jsx
+++ b/src/javascript/ContentEditor/ContentEditorApi/ContentEditorModal.jsx
@@ -115,7 +115,7 @@ export const ContentEditorModal = ({editorConfig, updateEditorConfig, onExited})
             needRefresh.current = false;
             updateEditorConfig({
                 uuid: newNode.uuid,
-                lang: language ? language : mergedConfig.lang,
+                lang: language || mergedConfig.lang,
                 mode: Constants.routes.baseEditRoute
             });
         } else if (!mergedConfig.isFullscreen) {

--- a/src/javascript/ContentEditor/ContentEditorApi/ContentEditorModal.scss
+++ b/src/javascript/ContentEditor/ContentEditorApi/ContentEditorModal.scss
@@ -10,6 +10,10 @@
 
 .ceDialogContent.ceDialogContent {
     width: 1080px;
-    max-width: calc(100vw - 80px);
-    height: calc(100vh - 80px);
+    max-width: calc(100vw - 56px);
+    height: calc(100vh - 56px);
+
+    // override css from material-ui
+    max-height: calc(100vh - 56px);
+    margin: 0;
 }

--- a/src/javascript/ContentEditor/ContentEditorApi/ContentEditorModal.scss
+++ b/src/javascript/ContentEditor/ContentEditorApi/ContentEditorModal.scss
@@ -9,6 +9,7 @@
 }
 
 .ceDialogContent.ceDialogContent {
-    width: 960px;
-    height: calc(100vh - 96px);
+    width: 1080px;
+    max-width: calc(100vw - 80px);
+    height: calc(100vh - 80px);
 }


### PR DESCRIPTION
### Description
- I increased the modal size to `1080px`
- I changed the `max-width` to have the same space horizontally and vertically on smaller screen

### Checklist
#### Source code
- [x] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [x] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
