### PR TITLE
fix: Add max-width limit to field inputs

### DIFF
--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.scss
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.scss
@@ -8,6 +8,8 @@
     border-left: 4px solid transparent;
 
     scroll-margin-top: var(--spacing-big);
+
+    max-width: 100%;
 }
 
 .formControlError.formControlError {

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.scss
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.scss
@@ -1,6 +1,8 @@
 .formControl.formControl {
     position: relative;
 
+    max-width: 100%;
+
     margin-bottom: var(--spacing-small);
     margin-left: -12px;
     padding: 8px 0 8px 8px;
@@ -8,8 +10,6 @@
     border-left: 4px solid transparent;
 
     scroll-margin-top: var(--spacing-big);
-
-    max-width: 100%;
 }
 
 .formControlError.formControlError {

--- a/src/javascript/JContent/ContentTree/ContentTree.jsx
+++ b/src/javascript/JContent/ContentTree/ContentTree.jsx
@@ -113,6 +113,7 @@ ItemComponent.propTypes = {
 
 const TREE_ITEM_SIZE = 32;
 
+// eslint-disable-next-line complexity
 export const ContentTree = ({setPathAction, openPathAction, closePathAction, item, selector, refetcherType, isReversed, contextualMenuAction, pageTitlePrefix}) => { // NOSONAR
     const dispatch = useDispatch();
     const {t} = useTranslation('jcontent');


### PR DESCRIPTION
### Description

With ckeditor 5, editor goes out of bounds when toolbar wrap is disabled. Set a max-width limit to force toolbar grouping

![image](https://github.com/user-attachments/assets/d7a2909e-872f-48f7-8f73-fac100015309)


### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
