### PR TITLE
feat: show tooltips for icon buttons if label is supplied

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellLastModified.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellLastModified.jsx
@@ -3,7 +3,7 @@ import {shallowEqual, useSelector} from 'react-redux';
 import {TableBodyCell, Typography} from '@jahia/moonstone';
 import css from '../../../ContentTable.scss';
 import dayjs from 'dayjs';
-import {ButtonRendererNoLabel} from '~/utils/getButtonRenderer';
+import {ButtonRendererIconButton} from '~/utils/getButtonRenderer';
 import {getDefaultLocale} from '~/JContent/JContent.utils';
 import {DisplayActions} from '@jahia/ui-extender';
 import PropTypes from 'prop-types';
@@ -27,7 +27,7 @@ export const CellLastModified = ({row, value, cell, column}) => {
                         <DisplayActions
                             target="visibleContentItemActions"
                             path={row.original.path}
-                            render={ButtonRendererNoLabel}
+                            render={ButtonRendererIconButton}
                             buttonProps={{variant: 'ghost', size: 'big'}}
                         />
                     </div>}

--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -15,15 +15,13 @@ import {SavePropertiesMutation} from '~/ContentEditor/ContentEditor/updateNode/u
 import {triggerRefetchAll} from '~/JContent/JContent.refetches';
 
 const ButtonRenderer = getButtonRenderer({
-    showTooltip: true,
-    defaultButtonProps: {color: 'default'},
-    defaultTooltipProps: {placement: 'top', classes: {popper: styles.tooltipPopper}}}
-);
+    showTooltip: false,
+    defaultButtonProps: {color: 'default'}
+});
 
 const ButtonRendererNoLabel = getButtonRenderer({
     labelStyle: 'none',
-    showTooltip: true,
-    defaultTooltipProps: {placement: 'top', classes: {popper: styles.tooltipPopper}}
+    showTooltip: true
 });
 
 function getBoundingBox(element) {
@@ -161,7 +159,6 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
 
     const {reorderNodes} = useReorderNodes({parentPath});
 
-    const tooltipProps = {enterDelay: 800, PopperProps: {container: element.ownerDocument.getElementById('jahia-portal-root')}};
     const sizers = [...Array(10).keys()].filter(i => currentOffset.width < i * 150).map(i => `sizer${i}`);
     const isDisabled = clickedElement && clickedElement.path !== parentPath;
     const btnRenderer = (isInsertionPoint && !isEmpty) ? ButtonRendererNoLabel : ButtonRenderer;
@@ -200,7 +197,8 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
                  editStyles.enablePointerEvents,
                  sizers,
                  (isInsertionPoint) && styles.insertionPoint,
-                 isEmpty ? styles.isEmpty : styles.isNotEmpty
+                 isEmpty ? styles.isEmpty : styles.isNotEmpty,
+                 isInsertionPoint && !isEmpty && styles.iconButtonGap
              )}
              style={{...currentOffset, ...insertionStyle}}
              data-jahia-parent={parent.getAttribute('id')}
@@ -210,7 +208,6 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
         >
             {copyPasteNodes.length === 0 &&
                 <DisplayAction actionKey="createContent"
-                               tooltipProps={tooltipProps}
                                path={parentPath}
                                name={nodePath}
                                isDisabled={isDisabled}
@@ -220,7 +217,6 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
                                onVisibilityChanged={onCreateVisibilityChanged}
                                onCreate={onAction(({name}) => reorderNodes([name], nodeName))}/>}
             <DisplayAction actionKey="paste"
-                           tooltipProps={tooltipProps}
                            isDisabled={isDisabled}
                            path={parentPath}
                            loading={() => false}
@@ -228,7 +224,6 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
                            onVisibilityChanged={onPasteVisibilityChanged}
                            onAction={onAction(data => reorderNodes(data?.map(d => d?.data?.jcr?.pasteNode?.node?.name), nodeName))}/>
             <DisplayAction actionKey="pasteReference"
-                           tooltipProps={tooltipProps}
                            isDisabled={isDisabled}
                            path={parentPath}
                            loading={() => false}

--- a/src/javascript/JContent/EditFrame/Create.scss
+++ b/src/javascript/JContent/EditFrame/Create.scss
@@ -65,6 +65,10 @@
     }
 }
 
+.iconButtonGap {
+    gap: var(--spacing-small);
+}
+
 :global(.noprefix) .dropTarget {
     &::after {
         display: inline-block;
@@ -74,8 +78,4 @@
         border: 2px dashed gray;
         content: "";
     }
-}
-
-div[role="tooltip"].tooltipPopper {
-    z-index: 1100000;
 }

--- a/src/javascript/utils/getButtonRenderer.jsx
+++ b/src/javascript/utils/getButtonRenderer.jsx
@@ -1,9 +1,8 @@
 import {useTranslation} from 'react-i18next';
-import {Button} from '@jahia/moonstone';
+import {Button, Tooltip} from '@jahia/moonstone';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {ellipsizeText} from '~/JContent/JContent.utils';
-import {Tooltip} from '@material-ui/core';
 
 const useLabel = labelProps => {
     const {
@@ -90,7 +89,7 @@ export const getButtonRenderer = ({labelStyle, showTooltip, ellipsis, defaultBut
         );
 
         return (showTooltip) ? (
-            <Tooltip title={tooltip} {...defaultTooltipProps} {...tooltipProps}>
+            <Tooltip label={tooltip} {...defaultTooltipProps} {...tooltipProps}>
                 {button}
             </Tooltip>
         ) : button;
@@ -121,4 +120,5 @@ export const getButtonRenderer = ({labelStyle, showTooltip, ellipsis, defaultBut
 
 export const ButtonRenderer = getButtonRenderer();
 export const ButtonRendererNoLabel = getButtonRenderer({labelStyle: 'none'});
+export const ButtonRendererIconButton = getButtonRenderer({labelStyle: 'none', showTooltip: true});
 export const ButtonRendererShortLabel = getButtonRenderer({labelStyle: 'short'});


### PR DESCRIPTION
### Description
This PR will show tooltips icon buttons in jcontent table view, as well as use moonstone tooltips instead.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
