### PR TITLE
fix: cursor on Page Builder

### DIFF
--- a/src/javascript/JContent/EditFrame/EditFrame.scss
+++ b/src/javascript/JContent/EditFrame/EditFrame.scss
@@ -123,7 +123,7 @@
         perspective: none;
         perspective-origin: 50% 50%;
         visibility: visible;
-        cursor: auto;
+        cursor: inherit;
         opacity: 1;
 
         transition: none;


### PR DESCRIPTION
### Description
Some elements, such as Button, don't display the correct cursor on hover in Page Builder due to a hard reset.
I set the cursor property to `inherit` instead of `auto` to resolve the issue.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
