### PR TITLE
fix: Remove fragment warning

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentPath/ContentPath.gql-queries.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentPath/ContentPath.gql-queries.jsx
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 import {PredefinedFragments} from '@jahia/data-helper';
 
 const visibleInContentTree = gql`
-    fragment VisibleInContentTree on JCRNode {
+    fragment ContentVisibleInContentTree on JCRNode {
         isVisibleInContentTree: isNodeType(type: {
             multi: ANY,
             types: $types
@@ -20,7 +20,7 @@ export const GetContentPath = gql`
                     name
                 }
                 isNodeType(type: {multi: ANY, types: ["jmix:mainResource", "jnt:page"]})
-                ...VisibleInContentTree
+                ...ContentVisibleInContentTree
                 ancestors(fieldFilter: {
                     filters: [
                         {evaluation: DIFFERENT, fieldName: "primaryNodeType.name", value: "rep:root"},
@@ -33,7 +33,7 @@ export const GetContentPath = gql`
                         name
                     }
                     isNodeType(type: {multi: ANY, types: ["jmix:mainResource", "jnt:page"]})
-                    ...VisibleInContentTree
+                    ...ContentVisibleInContentTree
                     ...NodeCacheRequiredFields
                 }
             }

--- a/src/javascript/JContent/ContentTree/ContentTree.gql-fragments.js
+++ b/src/javascript/JContent/ContentTree/ContentTree.gql-fragments.js
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 const PickerItemsFragment = {
     mixinTypes: {
         applyFor: 'node',
-        gql: gql`fragment MixinTypes on JCRNode {
+        gql: gql`fragment PickerMixinTypes on JCRNode {
             mixinTypes {
                 name
             }

--- a/src/javascript/JContent/ContentTree/ContentTree.jsx
+++ b/src/javascript/JContent/ContentTree/ContentTree.jsx
@@ -50,7 +50,7 @@ const ItemComponent = ({children, node, item, treeEntries, virtualizer, virtualR
         dropTarget: node,
         orderable: item.treeConfig.dnd && booleanValue(item.treeConfig.dnd?.canReorder),
         entries: treeEntries,
-        refetchQueries: ['PickerQuery__DisplayName_LockInfo_MixinTypes_ParentNodeWithName_PickerPrimaryNodeTypeName_PublicationStatus']
+        refetchQueries: ['PickerQuery__DisplayName_LockInfo_PickerMixinTypes_ParentNodeWithName_PickerPrimaryNodeTypeName_PublicationStatus']
     });
     const [{isCanDrop: isCanDropFile}, dropFile] = useFileDrop({
         uploadType: node.primaryNodeType.name === 'jnt:folder' && JContentConstants.mode.UPLOAD,


### PR DESCRIPTION
### Description
Remove gql fragment warnings.

Fragments must be uniquely named.
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
