### PR TITLE
chore: Remove provenance flag from npm publish

### DIFF
--- a/.github/workflows/release-tests-module.yml
+++ b/.github/workflows/release-tests-module.yml
@@ -50,9 +50,9 @@ jobs:
               echo "Dry run should be executed in non-master branch"
             else
               echo "Executing npm publish in dry-run mode"
-              npm publish --provenance --access public --dry-run
+              npm publish --access public --dry-run
             fi
           else 
             echo "Publishing jContent tests in npm..."
-            npm publish --provenance --access public
+            npm publish --access public
           fi


### PR DESCRIPTION
### Description

From last test release run ([link](https://github.com/Jahia/jcontent/actions/runs/14044331268/job/39321531269#step:5:216)), we had issue when publishing to npm:

```
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
npm error code EUSAGE
npm error Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-03-24T19_36_39_057Z-debug-0.log
```

Remove provenance flag for now so we can release, and create separate ticket to grant required access.

Also we still have issue of pushing changes to master from last run ([link](https://github.com/Jahia/jcontent/actions/runs/14042059663/job/39314326510#step:5:106)): 

```
Incrementing version for release..
yarn version v1.22.22
info Current version: 3.3.0-SNAPSHOT
info New version: 3.3.0-tests.0
Done in 0.11s.
remote: error: GH006: Protected branch update failed for refs/heads/master.        
remote: 
remote: - Commits must have verified signatures.        
remote:   Found 1 violation:        
remote: 
remote:   b05103fd21d0f97e2d2e87b489e63584af8cefcb        
remote: 
remote: - Changes must be made through a pull request.        
To https://github.com/Jahia/jcontent
 * [new tag]         v3.3.0-tests.0 -> v3.3.0-tests.0
 ! [remote rejected] master -> master (protected branch hook declined)
```

Modified branch protections on master to allow jahia-ci account to bypass restrictions (to be tested after merge):

![image](https://github.com/user-attachments/assets/212ca453-fa70-4003-814e-492e36aa5e2d)


