### PR TITLE
fix: Use no-cache for publication action

### DIFF
--- a/src/javascript/JContent/actions/deleteActions/deletePermanentlyAction.jsx
+++ b/src/javascript/JContent/actions/deleteActions/deletePermanentlyAction.jsx
@@ -30,6 +30,7 @@ export const DeletePermanentlyActionComponent = ({path, paths, buttonProps, onDe
         {
             getDisplayName: true,
             getPrimaryNodeType: true,
+            getIsNodeTypes: ['jmix:autoPublish'],
             getProperties: ['jcr:mixinTypes'],
             getAggregatedPublicationInfo: true,
             getOperationSupport: true,

--- a/src/javascript/JContent/actions/publishAction.jsx
+++ b/src/javascript/JContent/actions/publishAction.jsx
@@ -121,7 +121,7 @@ export const PublishActionComponent = props => {
     const {t} = useTranslation('jcontent');
 
     // Publication info needs to be refreshed in case subNodes have changed
-    const queryOptions = (publishType === 'publish') ? {fetchPolicy: 'network-only'} : undefined;
+    const queryOptions = {fetchPolicy: 'network-only'};
     const res = useNodeChecks({path, paths, language: languageToUse}, {
         getDisplayName: true,
         getProperties: ['jcr:mixinTypes'],

--- a/src/javascript/JContent/actions/publishAction.jsx
+++ b/src/javascript/JContent/actions/publishAction.jsx
@@ -121,7 +121,7 @@ export const PublishActionComponent = props => {
     const {t} = useTranslation('jcontent');
 
     // Publication info needs to be refreshed in case subNodes have changed
-    const queryOptions = {fetchPolicy: 'network-only'};
+    const queryOptions = {fetchPolicy: 'no-cache'};
     const res = useNodeChecks({path, paths, language: languageToUse}, {
         getDisplayName: true,
         getProperties: ['jcr:mixinTypes'],


### PR DESCRIPTION
### Description
Use no-cache for publication action. We get wrong result for the query most likely due to merging/caching of queries in the same batch. It is somewhat random. Note that including no-cache changes parameters of the original query due to query merging that is done in javascript-components. 

Merging is doing a lot of side effects, for example because publication query includes hideOnNodeTypes these node types show up in the delete query (via `addArrayOptionValues(hideOnNodeTypes, useNodeInfoOptions, 'getIsNodeTypes')`) even though they are never explicitly requested, hence the need to do explicit request for isNodeType check.

Ideally we want to address this merging issue but it will likely produce quite a few side effects, which can include impact on performance. Unless this is deemed to be "desired behaviour", which it has been up until this issue.

As a reminder we have two different publication behaviours for "Publish now" button in content editor and jcontent, with content editor offering "technical" publication of nodes (node, translation and metadata only) https://jira.jahia.org/browse/BACKLOG-16419 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
