### PR TITLE
fix: Do not show publication manager on categories

### DIFF
--- a/src/javascript/JContent/actions/showPublicationManagerAction.jsx
+++ b/src/javascript/JContent/actions/showPublicationManagerAction.jsx
@@ -17,7 +17,8 @@ export const PublishManagerActionComponent = props => {
         getDisplayName: true,
         getProperties: ['jcr:mixinTypes'],
         getSiteLanguages: true,
-        getPermissions: ['publish', 'publication-start']
+        getPermissions: ['publish', 'publication-start'],
+        hideOnNodeTypes: ['jnt:category']
     });
 
     if (res.loading) {


### PR DESCRIPTION
### Description
Do not show publication manager on categories.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
