### PR TITLE
fix: display the right placeholder when I drag back an item

### DIFF
--- a/src/javascript/ContentEditor/DesignSystem/OrderableValue/OrderableValue.jsx
+++ b/src/javascript/ContentEditor/DesignSystem/OrderableValue/OrderableValue.jsx
@@ -29,31 +29,29 @@ export const OrderableValue = ({id, field, onFieldRemove, onValueReorder, onValu
     }
 
     return (
-        <div className={styles.fieldComponentContainer}>
-            <div
-                ref={field.readOnly ? undefined : ref}
-                className={clsx(
-                    styles.draggableCard,
-                    isDragging && styles.draggingCard
-                )}
-                data-sel-content-editor-multiple-generic-field={name}
-                data-sel-content-editor-field-readonly={field.readOnly}
-                data-handler-id={handlerId}
-            >
-                {!isReferenceCard &&
-                    <div ref={isDraggable ? drag : null} className={clsx(isDraggable ? styles.draggableIcon : styles.notDraggableIcon)}>
-                        <HandleDrag size="big"/>
-                    </div>}
-                {component}
-                <Tooltip label={t('jcontent:label.contentEditor.edit.fields.actions.clear')}>
-                    <Button variant="ghost"
-                            data-sel-action={`removeField_${index}`}
-                            aria-label={t('jcontent:label.contentEditor.edit.fields.actions.clear')}
-                            icon={<Close/>}
-                            onClick={() => onFieldRemove(index)}
+        <div
+            ref={isDraggable ? ref : undefined}
+            className={clsx(
+                styles.draggableCard,
+                isDragging && styles.draggingCard
+            )}
+            data-sel-content-editor-multiple-generic-field={name}
+            data-sel-content-editor-field-readonly={field.readOnly}
+            data-handler-id={handlerId}
+        >
+            {!isReferenceCard &&
+            <div ref={isDraggable ? drag : null} className={clsx(isDraggable ? styles.draggableIcon : styles.notDraggableIcon)}>
+                <HandleDrag size="big"/>
+            </div>}
+            {component}
+            <Tooltip label={t('jcontent:label.contentEditor.edit.fields.actions.clear')}>
+                <Button variant="ghost"
+                        data-sel-action={`removeField_${index}`}
+                        aria-label={t('jcontent:label.contentEditor.edit.fields.actions.clear')}
+                        icon={<Close/>}
+                        onClick={() => onFieldRemove(index)}
                     />
-                </Tooltip>
-            </div>
+            </Tooltip>
         </div>
     );
 };

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ManualOrdering/DragDrop/DraggableReference.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ManualOrdering/DragDrop/DraggableReference.jsx
@@ -40,7 +40,7 @@ export const DraggableReference = ({
 
     return (
         <div
-            ref={ref}
+            ref={isDraggable ? ref : null}
             className={clsx(
                 styles.draggableCard,
                 isDragging && styles.draggingCard

--- a/src/javascript/ContentEditor/utils/dragAndDrop.scss
+++ b/src/javascript/ContentEditor/utils/dragAndDrop.scss
@@ -1,9 +1,3 @@
-.fieldComponentContainer {
-    display: flex;
-
-    flex-direction: column;
-}
-
 .addButton {
     margin: var(--spacing-small) 0;
 }
@@ -18,10 +12,10 @@
 
 .draggableCard.draggingCard {
     background-color: var(--color-accent_light_plain20);
-}
 
-.draggableCard.draggingCard * {
-    visibility: hidden;
+    * {
+        opacity: 0;
+    }
 }
 
 .draggableCard {


### PR DESCRIPTION
### Description
- To avoid to display the content of the item when I drag back the item to its orginal place I set `opacity: 0` instead of `visibility`
- I removed the `div.fieldComponentContainer` to ensure the same spacing between list items. As we have nested items, the margins were not collapsing.
- I only add the `ref` when the component is draggable, because [react-dnd](https://github.com/react-dnd/react-dnd/issues/2690) always sets the `draggable` attribute to true even if `canDrag = false`. As we use this attribute to set the right cursor `grab`, `pointer`, `default`, we have to only set the ref when the component is draggable.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
