### PR TITLE
fix: Do now show publication manager on selection of multiple nodes

### DIFF
--- a/src/javascript/JContent/actions/showPublicationManagerAction.jsx
+++ b/src/javascript/JContent/actions/showPublicationManagerAction.jsx
@@ -5,7 +5,7 @@ import {useSelector} from 'react-redux';
 import {useTranslation} from 'react-i18next';
 
 export const PublishManagerActionComponent = props => {
-    const {id, path, publicationNodeTypes, buttonIcon, buttonLabel, render: Render, loading: Loading} = props;
+    const {id, path, paths, publicationNodeTypes, buttonIcon, buttonLabel, render: Render, loading: Loading} = props;
     const {language, siteKey} = useSelector(state => ({
         language: state.language,
         siteKey: state.site
@@ -25,7 +25,7 @@ export const PublishManagerActionComponent = props => {
         return (Loading && <Loading {...props}/>) || false;
     }
 
-    const isVisible = res.checksResult && typeof window?.authoringApi?.showPublicationManager === 'function';
+    const isVisible = !paths && res.checksResult && typeof window?.authoringApi?.showPublicationManager === 'function';
     const mixinTypes = res.node?.mixinTypes ? res.node.mixinTypes.map(mixinType => mixinType.name) : [];
 
     return (


### PR DESCRIPTION
### Description
Do now show publication manager on selection of multiple nodes
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
