### PR TITLE
fix: consistent context menu for pickers

### DIFF
--- a/src/javascript/JContent.assignActionAndMenuTargets.js
+++ b/src/javascript/JContent.assignActionAndMenuTargets.js
@@ -189,6 +189,7 @@ const actionTargetAssignments = {
         'editPageAdvanced',
         'editSource',
         'editImage',
+        'openInNewTab',
         'replaceFile',
         'locate',
         'preview',

--- a/src/javascript/init.js
+++ b/src/javascript/init.js
@@ -34,17 +34,11 @@ export default function () {
             registry.add('action', 'contentPickerMenu', registry.get('action', 'menuAction'), {
                 buttonIcon: <MoreVert/>,
                 buttonLabel: 'jcontent:label.contentManager.contentPreview.moreOptions',
-                menuTarget: 'contentPickerActions',
+                menuTarget: 'contentItemContextActions',
                 menuItemProps: {
                     isShowIcons: true
                 }
             });
-
-            registry.get('action', 'rename')?.targets?.push({id: 'contentPickerActions', priority: 1});
-            registry.get('action', 'replaceFile')?.targets?.push({id: 'contentPickerActions', priority: 2});
-            registry.get('action', 'editImage')?.targets?.push({id: 'contentPickerActions', priority: 3});
-            registry.get('action', 'downloadFile')?.targets?.push({id: 'contentPickerActions', priority: 3.7});
-            registry.get('action', 'openInNewTab')?.targets?.push({id: 'contentPickerActions', priority: 4});
         }
     });
 }


### PR DESCRIPTION
### Description
This PR merges the three dots menu and context menu for content pickers.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
