### PR TITLE
fix: show picker content type in user language

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/ContentPicker.gql-queries.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/ContentPicker.gql-queries.js
@@ -2,14 +2,14 @@ import gql from 'graphql-tag';
 import {PredefinedFragments} from '@jahia/data-helper';
 
 export const ContentPickerFilledQuery = gql`
-    query contentPickerFilledQuery($uuids: [String!]!, $language: String!) {
+    query contentPickerFilledQuery($uuids: [String!]!, $language: String!, $uiLanguage: String!) {
         jcr {
             result: nodesById(uuids: $uuids) {
                 displayName(language: $language)
                 name
                 primaryNodeType {
                     name
-                    displayName(language: $language)
+                    displayName(language: $uiLanguage)
                     icon
                 }
                 ...NodeCacheRequiredFields

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/DefaultPickerConfig.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/DefaultPickerConfig.js
@@ -4,14 +4,19 @@ import {useQuery} from '@apollo/client';
 import {ContentPickerFilledQuery} from './ContentPicker.gql-queries';
 import {getIconFromNode} from '~/utils';
 import {useContentEditorContext} from '~/ContentEditor/contexts';
+import {shallowEqual, useSelector} from 'react-redux';
 
 const usePickerInputData = uuids => {
     const {lang} = useContentEditorContext();
+    const {uiLang} = useSelector(state => ({
+        uiLang: state?.uilang
+    }), shallowEqual);
 
     const {data, error, loading} = useQuery(ContentPickerFilledQuery, {
         variables: {
             uuids: uuids || [],
-            language: lang
+            language: lang,
+            uiLanguage: uiLang || lang
         },
         skip: !uuids,
         errorPolicy: 'ignore',

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/DefaultPickerConfig.spec.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/DefaultPickerConfig.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {DefaultPickerConfig} from './DefaultPickerConfig';
 import {useContentEditorContext} from '~/ContentEditor/contexts';
 import {useQuery} from '@apollo/client';
+import {useSelector} from 'react-redux';
 
 jest.mock('@apollo/client', () => {
     return {useQuery: jest.fn()};
@@ -14,15 +15,24 @@ jest.mock('../Picker', () => {
 });
 
 jest.mock('~/ContentEditor/contexts/ContentEditor/ContentEditor.context');
+jest.mock('react-redux', () => ({
+    useSelector: jest.fn(),
+    shallowEqual: jest.fn()
+}));
 
 describe('ContentPicker config', () => {
     describe('usePickerInputData', () => {
         let contentEditorContext;
+        let state;
         beforeEach(() => {
             contentEditorContext = {
                 lang: 'fr'
             };
+            state = {
+                uilang: 'de'
+            };
             useContentEditorContext.mockReturnValue(contentEditorContext);
+            useSelector.mockImplementation(selector => selector(state));
         });
 
         const usePickerInputData = DefaultPickerConfig.pickerInput.usePickerInputData;


### PR DESCRIPTION
### Description
This PR makes the content type of the reference card in pickers show up in UI language, not CE editor language.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
