### PR TITLE
fix: Cancel stucked DnD event

### DIFF
--- a/src/javascript/JContent/EditFrame/EditFrame.jsx
+++ b/src/javascript/JContent/EditFrame/EditFrame.jsx
@@ -47,14 +47,22 @@ function addEventListeners(target, manager, iframeRef) {
     target.addEventListener('drop', backend.handleTopDropCapture, true);
     target.addEventListener('mouseup', event => {
         if (monitor.isDragging()) {
-            console.debug('Mouse up event happened while monitor is still dragging, cancelling previous DND operation', event, monitor.isDragging());
+            console.debug('Mouse up event happened while monitor is still dragging, cancelling previous DND operation', event);
             backend.handleTopDragEndCapture(event);
+            if (monitor.isDragging()) {
+                manager.getActions()?.endDrag();
+            }
         }
     });
+
     target.addEventListener('mousemove', event => {
-        if (monitor.isDragging() && event.buttons === 0) {
-            console.debug('Mouse move event happened while monitor is still dragging, cancelling previous DND operation', event, monitor.isDragging());
+        const isMouseUp = event.buttons === 0;
+        if (monitor.isDragging() && isMouseUp) {
+            console.debug('Mouse move event happened while monitor is still dragging, cancelling previous DND operation', event);
             backend.handleTopDragEndCapture(event);
+            if (monitor.isDragging()) {
+                manager.getActions()?.endDrag();
+            }
         }
     });
 }


### PR DESCRIPTION
### Description

After enabling DnD in CK5 https://github.com/Jahia/richtext-ckeditor5/issues/135, I started getting these infinitely in the console logs while moving the mouse and UI is frozen after a user drag and drops in CK5 and save/close the editor: 

```
Mouse move event happened while monitor is still dragging, cancelling previous DND operation 
MouseEvent {isTrusted: true, screenX: 1896, screenY: 1154, clientX: 1893, clientY: 1149, …} true
```

We have an existing handler already that's suppose to cancel this event:

```
backend.handleTopDragEndCapture(event);
```

which calls this code `HTML5BackendImpl` in react-dnd:

```
public handleTopDragEndCapture = (): void => {
	if (this.clearCurrentDragSourceNode() && this.monitor.isDragging()) {
		this.actions.endDrag()
	}
	this.cancelHover()
}
```

but it seems that `endDrag()` is not getting called here. So we keep the call to `handleTopDragEndCapture` first to at least clear some objects, and force `endDrag()` only if monitor is still dragging.
