### PR TITLE
fix: show content list types in user language

### DIFF
--- a/src/javascript/ContentEditor/ContentEditor/edit.gql-queries.js
+++ b/src/javascript/ContentEditor/ContentEditor/edit.gql-queries.js
@@ -54,7 +54,7 @@ const NodeDataFragment = {
                         displayName(language: $language)
                         primaryNodeType {
                             name
-                            displayName(language: $language)
+                            displayName(language: $uilang)
                             icon
                             supertypes {
                                 name


### PR DESCRIPTION
### Description
This PR changes the content type language to the user's language in content/link lists.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
