### PR TITLE
fix: add terms limit and debounce for picker search

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/Picker/JahiaPicker/RightPanel/Search.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/JahiaPicker/RightPanel/Search.jsx
@@ -48,7 +48,7 @@ export const Search = ({accordionItemProps}) => {
 
         if (v === '') {
             handleClearTerms();
-        } else if (v.length >= 3) {
+        } else if (v.length >= Constants.search.SEARCH_OFFSET) {
             clearTimeout(timeout.current);
             timeout.current = setTimeout(() => {
                 clearTimeout(timeout.current);
@@ -56,7 +56,7 @@ export const Search = ({accordionItemProps}) => {
                     cePickerSetSearchPath(searchPath === '' ? currentPath : searchPath),
                     cePickerSetSearchTerm(v)
                 ]));
-            }, 300);
+            }, Constants.search.DEBOUNCE_TIME);
         }
     };
 

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/JahiaPicker/RightPanel/Search.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/JahiaPicker/RightPanel/Search.jsx
@@ -61,6 +61,7 @@ export const Search = ({accordionItemProps}) => {
     };
 
     const handleClearTerms = () => {
+        setSearchValue('');
         dispatch(batchActions([
             cePickerSetSearchTerm(''),
             cePickerSetSearchPath(currentPath)

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/JahiaPicker/RightPanel/Search.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/JahiaPicker/RightPanel/Search.jsx
@@ -43,17 +43,18 @@ export const Search = ({accordionItemProps}) => {
     const previousMode = mode === Constants.mode.SEARCH ? preSearchModeMemo : mode;
 
     const handleChangeTerms = e => {
-        setSearchValue(e.target.value);
+        const v = e.target.value;
+        setSearchValue(v);
 
-        if (e.target.value === '') {
+        if (v === '') {
             handleClearTerms();
-        } else if (e.target.value.length >= 3) {
+        } else if (v.length >= 3) {
             clearTimeout(timeout.current);
             timeout.current = setTimeout(() => {
                 clearTimeout(timeout.current);
                 dispatch(batchActions([
                     cePickerSetSearchPath(searchPath === '' ? currentPath : searchPath),
-                    cePickerSetSearchTerm(e.target.value)
+                    cePickerSetSearchTerm(v)
                 ]));
             }, 300);
         }

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/JahiaPicker/RightPanel/Search.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/JahiaPicker/RightPanel/Search.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useRef, useState} from 'react';
 import {Dropdown, SearchContextInput} from '@jahia/moonstone';
 import styles from './Search.scss';
 import {cePickerSetSearchPath, cePickerSetSearchTerm} from '~/ContentEditor/SelectorTypes/Picker/Picker.redux';
@@ -16,9 +16,10 @@ import * as jcontentUtils from '~/JContent/JContent.utils';
 export const Search = ({accordionItemProps}) => {
     const {t} = useTranslation('jcontent');
     const dispatch = useDispatch();
-    const {searchTerms, searchPath, preSearchModeMemo, currentPath, currentSite, language, uilang, mode} = useSelector(state => ({
+    const [searchValue, setSearchValue] = useState('');
+    const timeout = useRef(null);
+    const {searchPath, preSearchModeMemo, currentPath, currentSite, language, uilang, mode} = useSelector(state => ({
         mode: state.contenteditor.picker.mode,
-        searchTerms: state.contenteditor.picker.searchTerms,
         searchPath: state.contenteditor.picker.searchPath,
         preSearchModeMemo: state.contenteditor.picker.preSearchModeMemo,
         currentPath: state.contenteditor.picker.path,
@@ -42,13 +43,19 @@ export const Search = ({accordionItemProps}) => {
     const previousMode = mode === Constants.mode.SEARCH ? preSearchModeMemo : mode;
 
     const handleChangeTerms = e => {
+        setSearchValue(e.target.value);
+
         if (e.target.value === '') {
             handleClearTerms();
-        } else {
-            dispatch(batchActions([
-                cePickerSetSearchPath(searchPath === '' ? currentPath : searchPath),
-                cePickerSetSearchTerm(e.target.value)
-            ]));
+        } else if (e.target.value.length >= 3) {
+            clearTimeout(timeout.current);
+            timeout.current = setTimeout(() => {
+                clearTimeout(timeout.current);
+                dispatch(batchActions([
+                    cePickerSetSearchPath(searchPath === '' ? currentPath : searchPath),
+                    cePickerSetSearchTerm(e.target.value)
+                ]));
+            }, 300);
         }
     };
 
@@ -73,7 +80,7 @@ export const Search = ({accordionItemProps}) => {
                                      icon={currentSearchContext.iconStart}
                                      onChange={handleChangeContext}/>}
             size="big"
-            value={searchTerms}
+            value={searchValue}
             className={styles.searchInput}
             onChange={e => handleChangeTerms(e)}
             onClear={e => handleClearTerms(e)}

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/Picker.constants.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/Picker.constants.js
@@ -1,4 +1,8 @@
 export const Constants = {
+    search: {
+        SEARCH_OFFSET: 3,
+        DEBOUNCE_TIME: 300
+    },
     pickerConfig: 'pickerConfiguration',
     ACCORDION_ITEM_NAME: 'accordionItem',
     ACCORDION_ITEM_TYPES: {

--- a/tests/cypress/e2e/pickers/search.cy.ts
+++ b/tests/cypress/e2e/pickers/search.cy.ts
@@ -21,6 +21,7 @@ describe('Picker tests - Search', () => {
     it('Media Picker - Search for tab - letter by letter', () => {
         const picker = contentEditor.getPickerField('jdmix:imgView_image').open();
         picker.getViewMode().select('List');
+        // No search until 3 chars
         picker.search('t');
         picker.verifyResultsLength(43);
         picker.search('a');
@@ -59,6 +60,7 @@ describe('Picker tests - Search', () => {
     it('Editorial Picker- Search for tab - letter by letter', () => {
         const picker = contentEditor.getPickerField('jdmix:hasLink_internalLink').open();
         picker.switchSearchContext('Digitall');
+        // No search until 3 chars
         picker.search('t');
         picker.getResults().should('not.exist');
         picker.search('a');

--- a/tests/cypress/e2e/pickers/search.cy.ts
+++ b/tests/cypress/e2e/pickers/search.cy.ts
@@ -22,9 +22,9 @@ describe('Picker tests - Search', () => {
         const picker = contentEditor.getPickerField('jdmix:imgView_image').open();
         picker.getViewMode().select('List');
         picker.search('t');
-        picker.verifyResultsLength(24);
+        picker.verifyResultsLength(43);
         picker.search('a');
-        picker.verifyResultsLength(6);
+        picker.verifyResultsLength(43);
         picker.search('b');
         picker.verifyResultsLength(1);
         picker.getTableRow('person-smartphone-office-table.jpg').should('be.visible');
@@ -62,7 +62,7 @@ describe('Picker tests - Search', () => {
         picker.search('t');
         picker.verifyResultsAtLeast(82);
         picker.search('a');
-        picker.verifyResultsLength(19);
+        picker.verifyResultsAtLeast(82);
         picker.search('b');
         picker.verifyResultsLength(7);
     });

--- a/tests/cypress/e2e/pickers/search.cy.ts
+++ b/tests/cypress/e2e/pickers/search.cy.ts
@@ -60,9 +60,9 @@ describe('Picker tests - Search', () => {
         const picker = contentEditor.getPickerField('jdmix:hasLink_internalLink').open();
         picker.switchSearchContext('Digitall');
         picker.search('t');
-        picker.verifyResultsAtLeast(82);
+        picker.getResults().should('not.exist');
         picker.search('a');
-        picker.verifyResultsAtLeast(82);
+        picker.getResults().should('not.exist');
         picker.search('b');
         picker.verifyResultsLength(7);
     });

--- a/tests/cypress/page-object/picker.ts
+++ b/tests/cypress/page-object/picker.ts
@@ -171,8 +171,12 @@ export class Picker extends BaseComponent {
         return this.get().find('input[role="searchbox"]').should('be.visible');
     }
 
+    getResults() {
+        return this.get().find('[data-sel-role="table-pagination-total-rows"]');
+    }
+
     verifyResultsLength(length: number) {
-        this.get().find('[data-sel-role="table-pagination-total-rows"]').should('be.visible').and('contain', `of ${length}`);
+        this.getResults().should('be.visible').and('contain', `of ${length}`);
     }
 
     verifyResultsAtLeast(length: number) {


### PR DESCRIPTION
### Description
Add terms limit and debounce for picker search this prevents searching on one or two letters which can result in a very large result and limits the number of queries submitted.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
