### PR TITLE
fix: Show site as root for page accordion in pickers

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/editorialPicker/editorialPicker.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/editorialPicker/editorialPicker.js
@@ -64,6 +64,7 @@ export const registerEditorialPicker = registry => {
             },
             treeConfig: {
                 ...pagesItem.treeConfig,
+                hideRoot: false,
                 dnd: {}
             }
         }, renderer);

--- a/tests/cypress/e2e/contentEditor/boundComponent.cy.ts
+++ b/tests/cypress/e2e/contentEditor/boundComponent.cy.ts
@@ -27,7 +27,8 @@ describe('Bound component tests', () => {
         jcontent.switchToListMode();
         const contentEditor = jcontent.createContent('cent:boundComponent');
         const picker = contentEditor.getPickerField('jmix:bindedComponent_j:bindedComponent').open();
-        picker.getTableRow('Search Results').click();
+        picker.getAccordionItem('picker-pages').getTreeItem('home').click();
+        picker.getTable().getRowByName('search-results').should('be.visible').click();
         picker.select();
         contentEditor.create();
 
@@ -36,6 +37,5 @@ describe('Bound component tests', () => {
 
         const pickerField = contentEditor.getPickerField('jmix:bindedComponent_j:bindedComponent');
         pickerField.assertValue('Search Results');
-        pickerField.open();
     });
 });

--- a/tests/cypress/e2e/pickers/picker.cy.ts
+++ b/tests/cypress/e2e/pickers/picker.cy.ts
@@ -37,6 +37,7 @@ describe('Picker tests', () => {
         cy.log('assert pages accordion is visible');
         const pagesAccordion: AccordionItem = picker.getAccordionItem('picker-pages');
         pagesAccordion.getHeader().should('be.visible').and('have.attr', 'aria-expanded').and('equal', 'true');
+        pagesAccordion.getTreeItem(siteKey).should('be.visible'); // Show site as root tree item in pages
 
         cy.log('assert content folder accordion is expanded and populated');
         const contentAccordion: AccordionItem = picker.getAccordionItem('picker-content-folders');


### PR DESCRIPTION
### Description

Show site root for page accordions so that we can select home page and other first level pages in picker.

![image](https://github.com/user-attachments/assets/0926a888-91dc-4992-b342-4fc8db395fa9)


### Checklist
#### Source code
- ~[ ] I've shared and documented any breaking change~
- ~[ ] I've reviewed and updated the jahia-depends~

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [x] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
