### PR TITLE
fix: remove delete & drag buttons on read only

### DIFF
--- a/src/javascript/ContentEditor/DesignSystem/OrderableValue/OrderableValue.jsx
+++ b/src/javascript/ContentEditor/DesignSystem/OrderableValue/OrderableValue.jsx
@@ -10,6 +10,7 @@ export const OrderableValue = ({id, field, onFieldRemove, onValueReorder, onValu
     const {t} = useTranslation('jcontent');
     const ref = useRef(null);
     const name = `${field.name}[${index}]`;
+    const readOnly = field.readOnly;
     const [{handlerId}, drop] = useReorderDrop(
         {ref, index, onReorder: onValueReorder},
         {
@@ -39,19 +40,20 @@ export const OrderableValue = ({id, field, onFieldRemove, onValueReorder, onValu
             data-sel-content-editor-field-readonly={field.readOnly}
             data-handler-id={handlerId}
         >
-            {!isReferenceCard &&
+            {!isReferenceCard && !readOnly &&
             <div ref={isDraggable ? drag : null} className={clsx(isDraggable ? styles.draggableIcon : styles.notDraggableIcon)}>
                 <HandleDrag size="big"/>
             </div>}
             {component}
-            <Tooltip label={t('jcontent:label.contentEditor.edit.fields.actions.clear')}>
-                <Button variant="ghost"
-                        data-sel-action={`removeField_${index}`}
-                        aria-label={t('jcontent:label.contentEditor.edit.fields.actions.clear')}
-                        icon={<Close/>}
-                        onClick={() => onFieldRemove(index)}
-                    />
-            </Tooltip>
+            {!readOnly &&
+                <Tooltip label={t('jcontent:label.contentEditor.edit.fields.actions.clear')}>
+                    <Button variant="ghost"
+                            data-sel-action={`removeField_${index}`}
+                            aria-label={t('jcontent:label.contentEditor.edit.fields.actions.clear')}
+                            icon={<Close/>}
+                            onClick={() => onFieldRemove(index)}
+                        />
+                </Tooltip>}
         </div>
     );
 };


### PR DESCRIPTION
### Description
This PR removed the delete & drag icons from multiple field if it is read only

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
