### PR TITLE
fix: Clear clicked element selection when copy action is used

### DIFF
--- a/src/javascript/JContent/EditFrame/EditFrame.jsx
+++ b/src/javascript/JContent/EditFrame/EditFrame.jsx
@@ -218,6 +218,7 @@ export const EditFrame = () => {
         }, 50);
 
         return () => {
+            setClickedElementHook(() => undefined)
             clearInterval(interval);
         };
     }, []);

--- a/src/javascript/JContent/EditFrame/EditFrame.jsx
+++ b/src/javascript/JContent/EditFrame/EditFrame.jsx
@@ -68,7 +68,7 @@ function addEventListeners(target, manager, iframeRef) {
 }
 
 // This hook is used to clear clicked element outside on EditFrame context, specifically in copy/paste actions
-let clickedElementHook = () => {};
+let clickedElementHook = () => undefined;
 
 const setClickedElementHook = fcn => {
     clickedElementHook = fcn;

--- a/src/javascript/JContent/EditFrame/EditFrame.jsx
+++ b/src/javascript/JContent/EditFrame/EditFrame.jsx
@@ -218,7 +218,7 @@ export const EditFrame = () => {
         }, 50);
 
         return () => {
-            setClickedElementHook(() => undefined)
+            setClickedElementHook(() => undefined);
             clearInterval(interval);
         };
     }, []);

--- a/src/javascript/JContent/EditFrame/EditFrame.jsx
+++ b/src/javascript/JContent/EditFrame/EditFrame.jsx
@@ -67,6 +67,17 @@ function addEventListeners(target, manager, iframeRef) {
     });
 }
 
+// This hook is used to clear clicked element outside on EditFrame context, specifically in copy/paste actions
+let clickedElementHook = () => {};
+
+const setClickedElementHook = fcn => {
+    clickedElementHook = fcn;
+};
+
+export const getClickedElementHook = () => {
+    return clickedElementHook;
+};
+
 export const EditFrame = () => {
     const manager = useDragDropManager();
 
@@ -84,6 +95,7 @@ export const EditFrame = () => {
     const [currentUrlParams, setCurrentUrlParams] = useState('');
     const [previousUrlParams, setPreviousUrlParams] = useState('');
     const [clickedElement, setClickedElement] = useState();
+    setClickedElementHook(setClickedElement);
     const [loading, setLoading] = useState(false);
 
     const iframe = useRef();

--- a/src/javascript/JContent/actions/copyPaste/CopyCutActionComponent.jsx
+++ b/src/javascript/JContent/actions/copyPaste/CopyCutActionComponent.jsx
@@ -71,6 +71,8 @@ export const CopyCutActionComponent = withNotifications()(({
                     t('jcontent:label.contentManager.copyPaste.stored.many', {size: nodes.length});
                 notificationContext.notify(message, ['closeButton', 'closeAfter5s']);
                 dispatch(copypaste({type, nodes}));
+                // In case an element was clicked, which give it selected look with header and footer, we want to
+                // unclick it so that paste buttons appear where they can.
                 getClickedElementHook()(undefined);
             }}
         />

--- a/src/javascript/JContent/actions/copyPaste/CopyCutActionComponent.jsx
+++ b/src/javascript/JContent/actions/copyPaste/CopyCutActionComponent.jsx
@@ -11,6 +11,7 @@ import {ACTION_PERMISSIONS} from '../actions.constants';
 import {withNotifications} from '@jahia/react-material';
 import {useTranslation} from 'react-i18next';
 import {JahiaAreasUtil} from '../../JContent.utils';
+import {triggerRefetchAll} from '~/JContent/JContent.refetches';
 
 export const CopyCutActionComponent = withNotifications()(({
     path,
@@ -70,6 +71,9 @@ export const CopyCutActionComponent = withNotifications()(({
                     t('jcontent:label.contentManager.copyPaste.stored.many', {size: nodes.length});
                 notificationContext.notify(message, ['closeButton', 'closeAfter5s']);
                 dispatch(copypaste({type, nodes}));
+                // Note that this is used to clear currently selected element without the need to have complex piping
+                // of exposing setClickedElement of EditFrame
+                triggerRefetchAll();
             }}
         />
     );

--- a/src/javascript/JContent/actions/copyPaste/CopyCutActionComponent.jsx
+++ b/src/javascript/JContent/actions/copyPaste/CopyCutActionComponent.jsx
@@ -11,7 +11,7 @@ import {ACTION_PERMISSIONS} from '../actions.constants';
 import {withNotifications} from '@jahia/react-material';
 import {useTranslation} from 'react-i18next';
 import {JahiaAreasUtil} from '../../JContent.utils';
-import {triggerRefetchAll} from '~/JContent/JContent.refetches';
+import {getClickedElementHook} from '~/JContent/EditFrame';
 
 export const CopyCutActionComponent = withNotifications()(({
     path,
@@ -71,9 +71,7 @@ export const CopyCutActionComponent = withNotifications()(({
                     t('jcontent:label.contentManager.copyPaste.stored.many', {size: nodes.length});
                 notificationContext.notify(message, ['closeButton', 'closeAfter5s']);
                 dispatch(copypaste({type, nodes}));
-                // Note that this is used to clear currently selected element without the need to have complex piping
-                // of exposing setClickedElement of EditFrame
-                triggerRefetchAll();
+                getClickedElementHook()(undefined);
             }}
         />
     );

--- a/tests/cypress/e2e/menuActions/areaActions.cy.ts
+++ b/tests/cypress/e2e/menuActions/areaActions.cy.ts
@@ -46,7 +46,7 @@ describe('Area actions', () => {
 
         // Clicking on area header is very tricky due to overlapping contents. Select area header using footer instead.
         const moduleItem = jcontentPageBuilder.getModule('/sites/jcontentSite/home/area-main/test-content1');
-        moduleItem.click();
+        moduleItem.get().click();
         moduleItem.getFooter().getItemPathDropdown().open().select('area-main');
 
         const header = jcontentPageBuilder.getModule('/sites/jcontentSite/home/area-main', false)

--- a/tests/cypress/e2e/menuActions/areaActions.cy.ts
+++ b/tests/cypress/e2e/menuActions/areaActions.cy.ts
@@ -46,7 +46,7 @@ describe('Area actions', () => {
 
         // Clicking on area header is very tricky due to overlapping contents. Select area header using footer instead.
         const moduleItem = jcontentPageBuilder.getModule('/sites/jcontentSite/home/area-main/test-content1');
-        moduleItem.get().click();
+        moduleItem.click();
         moduleItem.getFooter().getItemPathDropdown().open().select('area-main');
 
         const header = jcontentPageBuilder.getModule('/sites/jcontentSite/home/area-main', false)


### PR DESCRIPTION
### Description
Clear clicked element selection when copy action is used, this allows to see paste buttons right away

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
