### PR TITLE
fix: Add check for multiple keyword on tag selector type

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/Tag/registerTag.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Tag/registerTag.js
@@ -8,6 +8,7 @@ export const registerTag = ceRegistry => {
             {name: 'description', value: 'jcontent:label.contentEditor.selectorTypes.tag.description'},
             {name: 'iconStart', value: 'Label'}
         ],
-        cmp: Tag, supportMultiple: true
+        cmp: Tag,
+        supportMultiple: true
     });
 };

--- a/src/javascript/JContent.assignActionAndMenuTargets.js
+++ b/src/javascript/JContent.assignActionAndMenuTargets.js
@@ -74,6 +74,7 @@ const actionTargetAssignments = {
         'createContentFolder',
         'fileUpload',
         'createFolder',
+        'createContent',
         'paste',
         'import',
         'refresh',

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -739,6 +739,7 @@
           "alreadyExist": "Ein Element mit demselben Systemnamen ist bereits vorhanden. Bitte wählen Sie ein anderes aus",
           "maxLength": "Maximal {{selectorOptions.maxLength}} Zeichen.",
           "invalidLink": "Der Link {{0}} ist defekt",
+          "invalidSelectorType": "Der für diese Eigenschaft definierte Selektor ist nicht mit dem Eigenschaftstyp kompatibel und kann nicht angezeigt werden. Bitte überprüfen Sie Ihre Definitionen.",
           "constraintViolation": "{{0}}"
         },
         "tab": {

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -749,6 +749,7 @@
           "alreadyExist": "An item with the same system name already exists, please choose another one",
           "maxLength": "{{selectorOptions.maxLength}} characters maximum",
           "invalidLink": "The link {{0}} is broken",
+          "invalidSelectorType": "The selector defined for this property is not compatible with the property type and cannot be displayed. Please review your definitions.",
           "constraintViolation": "{{0}}"
         },
         "tab": {

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -740,6 +740,7 @@
           "alreadyExist": "Il y a déjà un objet avec ce nom système, veuillez en choisir un autre",
           "maxLength": "{{selectorOptions.maxLength}} caractères maximum",
           "invalidLink": "Le lien {{0}} est rompu",
+          "invalidSelectorType": "Le sélecteur défini pour cette propriété n'est pas compatible avec le type de propriété et ne peut pas être affiché. Veuillez vérifier vos définitions.",
           "constraintViolation": "{{0}}"
         },
         "tab": {

--- a/tests/cypress/e2e/contentEditor/contentEditorForm.cy.ts
+++ b/tests/cypress/e2e/contentEditor/contentEditorForm.cy.ts
@@ -193,10 +193,9 @@ describe('Content editor form', () => {
         const contentTypeName = 'cent:epSifeRestaurant';
 
         cy.log('verify there is only one title field');
-        const contentEditor = jcontent.createContent(contentTypeName);
+        jcontent.createContent(contentTypeName);
         // Get all the fields and ensure there is only one title field
         cy.get('[data-sel-content-editor-field]').should('have.length.greaterThan', 7).filter('[data-sel-content-editor-field$="_jcr:title"]').should('have.length', 1);
-        contentEditor.cancel();
     });
 
     it('should display default resource key when module is disabled', () => {

--- a/tests/cypress/e2e/contentEditor/selectorTypes.cy.ts
+++ b/tests/cypress/e2e/contentEditor/selectorTypes.cy.ts
@@ -1,0 +1,35 @@
+import {TagField} from '../../page-object/fields/tagField';
+import {JContent} from '../../page-object/jcontent';
+import {addNode, createSite, deleteSite, enableModule} from '@jahia/cypress';
+
+describe('Content Editor - Selector Types', () => {
+    const siteKey = 'selectorTypeTestSite';
+    const nodeName = 'selectorTypeTestNode';
+
+    before(() => {
+        createSite(siteKey);
+        enableModule('jcontent-test-module', siteKey);
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: nodeName,
+            primaryNodeType: 'cent:selectorTypeTest'
+        });
+    });
+
+    after(() => {
+        cy.logout();
+        deleteSite(siteKey);
+    });
+
+    beforeEach(() => {
+        cy.login();
+    });
+
+    it('should display error when tag selector is not marked multiple', () => {
+        const ce = JContent.visit(siteKey, 'en', `content-folders/contents/${nodeName}`).editContent();
+        ce.getField(TagField, 'cent:selectorTypeTest_errorTag')
+            .should('be.visible')
+            .find('[data-sel-error="tag-multiple-error"]')
+            .should('be.visible');
+    });
+});

--- a/tests/cypress/e2e/menuActions/delete.cy.ts
+++ b/tests/cypress/e2e/menuActions/delete.cy.ts
@@ -32,7 +32,7 @@ describe('delete tests', () => {
         jcontent.getAccordionItem('pages').getTreeItem('test-pageDelete1').contextMenu().select('Delete');
 
         cy.log('Verify dialog opens and can be mark for deletion');
-        getComponent(DeleteDialog).markForDeletion('You are about to delete 5 items, including 3 page(s)');
+        getComponent(DeleteDialog).toggleRowExpanded().markForDeletion('You are about to delete 5 items, including 3 page(s)');
 
         cy.log('Verify menu and subpages has been marked for deletion');
         cy.apollo({

--- a/tests/cypress/e2e/pickers/editoriallink.cy.ts
+++ b/tests/cypress/e2e/pickers/editoriallink.cy.ts
@@ -131,8 +131,7 @@ describe('Picker - Editorial link', {testIsolation: false}, () => {
             .should('be.visible') // Expanded
             .and('have.class', 'moonstone-TableRow-highlighted'); // Selected
         picker.cancel();
-        contentEditor.cancel();
-        cy.get('[data-sel-role="close-dialog-discard"]').click();
+        contentEditor.cancelAndDiscard();
     });
 
     it('can select main resource and sub-main resource', () => {
@@ -149,7 +148,6 @@ describe('Picker - Editorial link', {testIsolation: false}, () => {
         picker.getTable().getRowByName('paragraph').should('be.visible').click();
         picker.select();
 
-        contentEditor.cancel();
-        cy.get('[data-sel-role="close-dialog-discard"]').click();
+        contentEditor.cancelAndDiscard();
     });
 });

--- a/tests/cypress/e2e/pickers/search.cy.ts
+++ b/tests/cypress/e2e/pickers/search.cy.ts
@@ -6,11 +6,10 @@ describe('Picker tests - Search', () => {
     let jcontent: JContent;
 
     beforeEach(() => {
-        // I have issues adding these to before()/after() so have to add to beforeEach()/afterEach()
         cy.login(); // Edit in chief
         cy.apollo({mutationFile: 'jcontent/enableLegacyPageComposer.graphql'});
-        contentEditor = ContentEditor.visit('/sites/digitall/home/area-main/highlights/leading-by-example', 'digitall', 'en', 'pages/home');
-        jcontent = new JContent();
+        jcontent = JContent.visit('digitall', 'en', 'pages/home/area-main/highlights/leading-by-example');
+        contentEditor = jcontent.editContent();
     });
 
     afterEach(() => {
@@ -46,7 +45,7 @@ describe('Picker tests - Search', () => {
     });
 
     it('Media Picker - Search for tab - cancel and reopen - search should be empty', () => {
-        let picker = contentEditor.getPickerField('jdmix:imgView_image').open();
+        const picker = contentEditor.getPickerField('jdmix:imgView_image').open();
         picker.getAccordionItem('picker-media').getTreeItem('slides').shouldBeSelected();
         picker.getViewMode().select('List');
         picker.search('tab');
@@ -54,9 +53,8 @@ describe('Picker tests - Search', () => {
         picker.getTableRow('person-smartphone-office-table.jpg').should('be.visible');
         picker.cancel();
         contentEditor.cancel();
-        jcontent.switchToListMode();
-        cy.get('table[data-cm-role="table-content-list"]').parent().scrollTo(0, 500);
-        picker = jcontent.editComponentByText('Leading by Example').getPickerField('jdmix:imgView_image').open();
+
+        jcontent.editContent().getPickerField('jdmix:imgView_image').open();
         picker.getSearchInput().should('be.empty');
     });
 

--- a/tests/cypress/page-object/contentEditor.ts
+++ b/tests/cypress/page-object/contentEditor.ts
@@ -109,7 +109,7 @@ export class ContentEditor extends BasePage {
     }
 
     cancel() {
-        getComponentByRole(Button, 'backButton').click().should('not.be.visible');
+        getComponentByRole(Button, 'backButton').click().get().should('not.exist');
     }
 
     cancelAndDiscard() {

--- a/tests/cypress/page-object/deleteDialog.ts
+++ b/tests/cypress/page-object/deleteDialog.ts
@@ -12,6 +12,11 @@ export class DeleteDialog extends BaseComponent {
         cy.get(DeleteDialog.defaultSelector).should('not.exist');
     }
 
+    toggleRowExpanded() {
+        cy.get('.moonstone-TableCell[title="Toggle Row Expanded"] > svg').click({force: true});
+        return this;
+    }
+
     assertMessage(verifyMsg: string) {
         this.get().should('contain', verifyMsg);
         return this;

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -43,6 +43,9 @@
 [cent:testOverride] > jnt:content, mix:title, jmix:basicContent, jmix:editorialContent
  - jcr:title (string) < '^.{0,10}$'
 
+[cent:selectorTypeTest] > jnt:content, mix:title, jmix:basicContent, jmix:editorialContent
+ - errorTag (string, tag) // multiple keyword is required here
+
 [cent:choiceListSelectorTypeOverride] > jnt:content, mix:title, jmix:basicContent, jmix:editorialContent
  - radioButton (string, choicelist) = 'choice1' < 'choice1', 'choice2', 'choice3'
  - list (string, choicelist) = 'choice4' < 'choice4', 'choice5', 'choice6'


### PR DESCRIPTION
### Description

Add an error message when Tag definition doesn't have multiple keyword as we do not support single tags at the moment.

We do not display message through validation errors as we want to distinguish this from a user-generated error, and validation errors prevents user from saving content.

Added cypress test.

### Checklist
#### Source code
- ~[ ] I've shared and documented any breaking change~
- ~[ ] I've reviewed and updated the jahia-depends~

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [x] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
