### PR TITLE
test: Add reference card tests

### DIFF
--- a/src/javascript/ContentEditor/DesignSystem/ReferenceCard/ReferenceCard.jsx
+++ b/src/javascript/ContentEditor/DesignSystem/ReferenceCard/ReferenceCard.jsx
@@ -72,7 +72,7 @@ ReferenceCardCmp.defaultProps = {
     fieldData: null,
     emptyLabel: '',
     emptyIcon: null,
-    onClick: undefined
+    onClick: () => {}
 };
 
 ReferenceCardCmp.propTypes = {

--- a/tests/cypress/e2e/contentEditor/referenceCard.cy.ts
+++ b/tests/cypress/e2e/contentEditor/referenceCard.cy.ts
@@ -1,0 +1,110 @@
+import {createSite, deleteSite, enableModule} from '@jahia/cypress';
+import {createSubpages} from '../../fixtures/contentEditor/referenceCard/referenceCard.utils';
+import {JContent} from '../../page-object';
+
+describe('Content Editor - Reference Card', () => {
+    const siteKey = 'referenceCardTestSite';
+
+    before(() => {
+        createSite(siteKey);
+        enableModule('jcontent-test-module', siteKey);
+        createSubpages(siteKey);
+    });
+
+    beforeEach(() => {
+        cy.login();
+    });
+
+    after(() => {
+        cy.logout();
+        deleteSite(siteKey);
+    });
+
+    it('should display reference card with correct content', () => {
+        const ce = JContent.visit(siteKey, 'en', 'pages/home').editPage();
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(1000); // Delay for focusing on the first field before scrolling to view
+        const listOrdering = ce.getSection('listOrdering').get();
+        listOrdering.scrollIntoView();
+        // Get original order of IDs as @orderIds
+        listOrdering.find('[draggable]').then($els => {
+            const orderIds = [...$els].map(el => el.dataset.handlerId);
+            cy.wrap(orderIds).as('orderIds');
+        });
+
+        cy.log('Verify move up/first buttons are disabled');
+        cy.get('@orderIds').then(orderIds => {
+            ce.getSection('listOrdering').get()
+                .find(`[draggable][data-handler-id="${orderIds[0]}"]`)
+                .should('be.visible')
+                .realHover();
+            ce.getSection('listOrdering').get()
+                .find(`[draggable][data-handler-id="${orderIds[0]}"]`)
+                .find('[data-sel-action^="moveUp"]')
+                .should('have.attr', 'disabled');
+            ce.getSection('listOrdering').get()
+                .find(`[draggable][data-handler-id="${orderIds[0]}"]`)
+                .find('[data-sel-action^="moveToFirst"]')
+                .should('have.attr', 'disabled');
+        });
+
+        cy.log('Verify move down/last buttons are disabled');
+        cy.get('@orderIds').then(orderIds => {
+            ce.getSection('listOrdering').get()
+                .find(`[draggable][data-handler-id="${orderIds[4]}"]`)
+                .should('be.visible')
+                .realHover();
+            ce.getSection('listOrdering').get()
+                .find(`[draggable][data-handler-id="${orderIds[4]}"]`)
+                .find('[data-sel-action^="moveDown"]')
+                .should('have.attr', 'disabled');
+            ce.getSection('listOrdering').get()
+                .find(`[draggable][data-handler-id="${orderIds[4]}"]`)
+                .find('[data-sel-action^="moveToLast"]')
+                .should('have.attr', 'disabled');
+        });
+
+        cy.log('Test move down functionality');
+        cy.get('@orderIds').then(orderIds => {
+            cy.log(`Move down: ${orderIds.join(',')}`);
+            const orderItem = ce.getSection('listOrdering').get().find(`[draggable][data-handler-id="${orderIds[1]}"]`);
+            orderItem.should('be.visible').realHover();
+            orderItem.find('[data-sel-action^="moveDown"]').should('be.visible').click();
+            cy.get(`[data-handler-id="${orderIds[2]}"] + [data-handler-id="${orderIds[1]}"]`).scrollIntoView();
+            cy.get(`[data-handler-id="${orderIds[2]}"] + [data-handler-id="${orderIds[1]}"]`).should('be.visible'); // 0, 2, 1, 3, 4
+        });
+
+        cy.log('Test move up functionality');
+        cy.get('@orderIds').then(orderIds => {
+            cy.log(`Move up: ${orderIds.join(',')}`);
+            const orderItem = ce.getSection('listOrdering').get().find(`[draggable][data-handler-id="${orderIds[4]}"]`);
+            orderItem.should('be.visible').realHover();
+            orderItem.find('[data-sel-action^="moveUp"]').should('be.visible').click();
+            cy.get(`[data-handler-id="${orderIds[1]}"] + [data-handler-id="${orderIds[4]}"]`).scrollIntoView();
+            cy.get(`[data-handler-id="${orderIds[1]}"] + [data-handler-id="${orderIds[4]}"]`).should('be.visible'); // 0, 2, 1, 4, 3
+        });
+
+        cy.log('Test move last functionality');
+        cy.get('@orderIds').then(orderIds => {
+            cy.log(`Move last: ${orderIds.join(',')}`);
+            const section = ce.getSection('listOrdering').get();
+            const orderItem = section.find(`[draggable][data-handler-id="${orderIds[2]}"]`);
+            orderItem.should('be.visible').realHover();
+            orderItem.find('[data-sel-action^="moveToLast"]').should('be.visible').click();
+            cy.get('[draggable][data-handler-id]').last().should('contain', 'test-page2'); // 0, 1, 4, 3, 2
+        });
+
+        cy.log('Test move first functionality');
+        cy.get('@orderIds').then(orderIds => {
+            cy.log(`Move first: ${orderIds.join(',')}`);
+            const section = ce.getSection('listOrdering').get();
+            const orderItem = section.find(`[draggable][data-handler-id="${orderIds[2]}"]`);
+            orderItem.should('be.visible').realHover();
+            orderItem.find('[data-sel-action^="moveToFirst"]').should('be.visible').click();
+            cy.get('[draggable][data-handler-id]').first().should('contain', 'test-page2'); // 2, 0, 1, 4, 3
+        });
+
+        ce.save();
+    });
+});

--- a/tests/cypress/e2e/pageBuilder/boxesHeader.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/boxesHeader.cy.ts
@@ -30,19 +30,15 @@ describe('Page builder - boxes and header tests', () => {
     });
 
     it('should show box with name, status and edit buttons', () => {
-        const module = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content4`);
-        module.hover().should('have.attr', 'data-hovered', 'true').click();
-        const header = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content4`).getHeader();
-        header.get().find('p').contains('test-content4');
+        const header = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content4`).getHeader(true);
+        header.get().should('be.visible').find('p').contains('test-content4');
         header.assertStatus('Not published');
         header.getButton('edit');
         header.getButton('contentItemActionsMenu');
     });
 
     it('should trim long titles', () => {
-        const module = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content8-long-text`);
-        module.hover().should('have.attr', 'data-hovered', 'true').click();
-        const header = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content8-long-text`).getHeader();
-        header.get().find('p').contains('Lorem ipsum dolor sit am...');
+        const header = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content8-long-text`).getHeader(true);
+        header.get().should('be.visible').find('p').contains('Lorem ipsum dolor sit am...');
     });
 });

--- a/tests/cypress/e2e/pageBuilder/clickSelectionAndNavigation.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/clickSelectionAndNavigation.cy.ts
@@ -33,10 +33,10 @@ describe('Page builder - navigation tests', () => {
     it('Can unselect self', () => {
         const jcontent = JContent.visit('digitall', 'en', 'pages/home');
         const pageBuilder = new JContentPageBuilder(jcontent);
-        const module = pageBuilder.getModule('/sites/digitall/home/area-main/highlights/our-companies');
-        module.get().scrollIntoView();
-        module.hover().should('have.attr', 'data-hovered', 'true').click();
-        module.getHeader().assertHeaderText('Our Companies');
+        const contentPath = '/sites/digitall/home/area-main/highlights/our-companies';
+        pageBuilder.getModule(contentPath).get().scrollIntoView();
+        const module = pageBuilder.getModule(contentPath);
+        module.getHeader(true).assertHeaderText('Our Companies');
         module.click();
         module.hasNoHeaderAndFooter();
     });
@@ -44,10 +44,10 @@ describe('Page builder - navigation tests', () => {
     it('Can use breadcrumbs to navigate up and down hierarchy', () => {
         const jcontent = JContent.visit('digitall', 'en', 'pages/home');
         const pageBuilder = new JContentPageBuilder(jcontent);
-        let module = pageBuilder.getModule('/sites/digitall/home/area-main/highlights/our-companies');
-        module.get().scrollIntoView();
-        module.hover().should('have.attr', 'data-hovered', 'true').click();
-        module.getHeader().assertHeaderText('Our Companies');
+        const contentPath = '/sites/digitall/home/area-main/highlights/our-companies';
+        pageBuilder.getModule(contentPath).get().scrollIntoView();
+        let module = pageBuilder.getModule(contentPath);
+        module.getHeader(true).assertHeaderText('Our Companies');
         const breadcrumbs = module.getFooter().getItemPathDropdown();
         breadcrumbs.open();
         breadcrumbs.select('highlights');
@@ -56,9 +56,8 @@ describe('Page builder - navigation tests', () => {
         module.getHeader().assertHeaderText('highlights');
 
         cy.log('Navigate back to the previous module');
-        module = pageBuilder.getModule('/sites/digitall/home/area-main/highlights/our-companies');
-        module.hover().should('have.attr', 'data-hovered', 'true').click();
-        module.getHeader().assertHeaderText('Our Companies');
+        module = pageBuilder.getModule(contentPath);
+        module.getHeader(true).assertHeaderText('Our Companies');
     });
 
     it('Click on links should open modal', () => {

--- a/tests/cypress/e2e/pageBuilder/clipboard.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/clipboard.cy.ts
@@ -25,7 +25,9 @@ describe('Page builder - clipboard tests', () => {
 
     it('should show paste button when we copy', function () {
         // We don't force right-click otherwise it might bring up page context menu
-        const contextMenu = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content1`).contextMenu(false, false);
+        const contentPath = `/sites/${siteKey}/home/area-main/test-content1`;
+        const contextMenu = jcontent.getModule(contentPath).contextMenu(true, false);
+
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(1000); // Wait for the context menu to appear
         contextMenu.selectByRole('copy');
@@ -41,7 +43,7 @@ describe('Page builder - clipboard tests', () => {
 
     it('should remove paste button when we clear clipboard', function () {
         // We don't force right-click otherwise it might bring up page context menu
-        const contextMenu = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content1`, false).contextMenu(false, false);
+        const contextMenu = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content1`, false).contextMenu(true, false);
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(1000); // Wait for the context menu to appear
         contextMenu.selectByRole('copy');

--- a/tests/cypress/e2e/pageBuilder/selections.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/selections.cy.ts
@@ -27,9 +27,7 @@ describe('Page builder - selections test', () => {
 
     it('Selects and unselects one item when clicking outside the selected module', () => {
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
-        const module = jcontent.getModule(item1);
-        module.click();
-        module.getHeader().select();
+        jcontent.getModule(item1).getHeader(true).select();
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
         jcontent.iframe(true).get().find('.wrapper').parent().parent().click('left', {timeout: 1000, force: true});
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
@@ -65,8 +63,7 @@ describe('Page builder - selections test', () => {
     it('Clears selection when unselected', () => {
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
         const module = jcontent.getModule(item1);
-        module.click();
-        module.getHeader().select();
+        jcontent.getModule(item1).getHeader(true).select();
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
 
         module.parentFrame.get().find('div[data-hovered="true"]').should('exist');
@@ -98,27 +95,21 @@ describe('Page builder - selections test', () => {
         // Note that in some cases it may be possible to just refresh and not be able to select anything,
         // but it appears to be a different issue as we don't get 'language is required' exception from useNodeInfo
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
-        const module = jcontent.getModule(item2);
-        module.click();
-        module.getHeader().select();
+        jcontent.getModule(item2).getHeader(true).select();
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
 
         jcontent.clearSelection();
         // Jcontent.refresh();
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
-        const module3 = jcontent.getModule(item3);
-        module3.click();
-        module3.getHeader().select();
+        jcontent.getModule(item3).getHeader(true).select();
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
     });
 
     it('Opens Content Editor on double click', () => {
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
-        const module = jcontent.getModule(item1);
-        module.click();
-        module.getHeader().select();
+        jcontent.getModule(item1).getHeader(true).select();
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
-        module.doubleClick();
+        jcontent.getModule(item1).doubleClick();
         const contentEditor = new ContentEditor();
         contentEditor.getSmallTextField('jnt:event_jcr:title', false).get().should('exist');
         contentEditor.cancel();

--- a/tests/cypress/fixtures/contentEditor/referenceCard/referenceCard.utils.ts
+++ b/tests/cypress/fixtures/contentEditor/referenceCard/referenceCard.utils.ts
@@ -1,0 +1,67 @@
+import gql from 'graphql-tag';
+
+export function createSubpages(siteKey) {
+    return cy.apollo({
+        mutation: gql`
+            mutation createRefCardSubpages {
+                jcr {
+                    mutateNode(pathOrId: "/sites/${siteKey}/home") {
+                        addChildrenBatch(nodes: [
+                            {
+                                name: "test-page1"
+                                primaryNodeType: "jnt:page"
+                                properties: [
+                                    { name: "jcr:title", language: "en", value: "Page test 1" },
+                                    { name: "j:templateName", value: "home" }
+                                ]
+                            },
+                            {
+                                name: "test-page2"
+                                primaryNodeType: "jnt:page"
+                                properties: [
+                                    { name: "jcr:title", language: "en", value: "Page test 2" },
+                                    { name: "j:templateName", value: "home" }
+                                ]
+                            },
+                            {
+                                name: "test-page3"
+                                primaryNodeType: "jnt:page"
+                                properties: [
+                                    { name: "jcr:title", language: "en", value: "Page test 3" },
+                                    { name: "j:templateName", value: "home" }
+                                ]
+                            },
+                            {
+                                name: "test-page4"
+                                primaryNodeType: "jnt:page"
+                                properties: [
+                                    { name: "jcr:title", language: "en", value: "Page test 4" },
+                                    { name: "j:templateName", value: "home" }
+                                ]
+                            }
+                        ]) { uuid }
+                    }
+                }
+            }
+        `
+    });
+}
+
+/* Needs qa-module to be enabled on the site */
+export function createPickerReferences(siteKey: string, uuids: string[]) {
+    return cy.apollo({
+        variables: {uuids},
+        mutation: gql`
+            mutation createRefCardPickerReferences($uuids: [String!]!) {
+                jcr {
+                    addNode(
+                        parentPathOrId: "/sites/${siteKey}/contents",
+                        name: "pickerRefCard",
+                        primaryNodeType: "cent:testPickerRefCard",
+                        properties: [{name: "pagepicker", type: WEAKREFERENCE, values: $uuids}]
+                    ) { uuid }
+                }
+            }
+        `
+    });
+}

--- a/tests/cypress/page-object/contentEditor.ts
+++ b/tests/cypress/page-object/contentEditor.ts
@@ -216,7 +216,7 @@ export class ContentEditor extends BasePage {
     }
 
     getField<FieldType extends Field>(FieldComponent: ComponentType<FieldType>, fieldName: string,
-        multiple?: boolean): FieldType {
+        multiple?: boolean = false): FieldType {
         const r = getComponentByAttr(FieldComponent, 'data-sel-content-editor-field', fieldName);
         r.fieldName = fieldName;
         r.multiple = multiple;

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
@@ -61,9 +61,7 @@ export class PageBuilderModule extends BaseComponent {
             this.click(); // Header shows up only when selected
         }
 
-        return new PageBuilderModuleHeader(this.get().invoke('attr', 'id').then(id => {
-            return this.parentFrame.get().find(`[jahiatype="header"][data-jahia-id="${id}"]`);
-        }));
+        return new PageBuilderModuleHeader(this.getBox().find('[jahiatype="header"]'));
     }
 
     getFooter() {
@@ -87,12 +85,13 @@ export class PageBuilderModule extends BaseComponent {
 
     contextMenu(selectFirst = false, force = true): Menu {
         if (selectFirst) {
-            this.getHeader(selectFirst);
+            this.click();
+            this.getHeader().get().should('be.visible').rightclick({force, waitForAnimations: true});
         } else {
             this.hover();
+            this.get().rightclick({force, waitForAnimations: true});
         }
 
-        this.get().rightclick({force, waitForAnimations: true});
         return getComponentBySelector(Menu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)');
     }
 

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModuleHeader.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModuleHeader.ts
@@ -4,18 +4,22 @@ export class PageBuilderModuleHeader extends BaseComponent {
     static defaultSelector = '[jahiatype="header"]';
 
     assertStatus(value: string) {
+        this.should('be.visible');
         this.get().find('[data-sel-role="content-status"]').contains(value);
     }
 
     getButton(role: string): Button {
+        this.should('be.visible');
         return getComponentByRole(Button, role, this);
     }
 
     assertHeaderText(text: string) {
+        this.should('be.visible');
         this.get().find('p').contains(text);
     }
 
     select() {
+        this.should('be.visible');
         this.get().click({metaKey: true, force: true});
     }
 }


### PR DESCRIPTION
### Description

Add cypress test for Reference Card functionality.

Also fixed an issue with empty onClick throwing error when rendering CardSelector component from moonstone.

Also tried to stabilize some of the recent failing page builder tests (see https://github.com/Jahia/jcontent/actions/runs/16059778705/job/45379825550, mostly around page builder box headers).

