### PR TITLE
feat: change 'go back' button UI in CE

### DIFF
--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelCompact.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelCompact.jsx
@@ -74,7 +74,6 @@ export const EditPanelCompact = ({title, createAnother}) => {
                 )}
                 <div className="flexFluid"/>
                 <DisplayAction
-                    buttonLabel={t('label.contentEditor.cancel')}
                     actionKey="backButton"
                     render={ButtonRenderer}
                 />

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/EditPanelHeader.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/EditPanelHeader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {DisplayAction, DisplayActions} from '@jahia/ui-extender';
-import {ButtonRendererNoLabel, ButtonRendererShortLabel, getButtonRenderer, getNodeTypeIcon, truncate} from '~/ContentEditor/utils';
-import {ArrowLeft, ButtonGroup, Chip, Header, Separator, Tab, TabItem} from '@jahia/moonstone';
+import {ButtonRendererShortLabel, getButtonRenderer, getNodeTypeIcon, truncate} from '~/ContentEditor/utils';
+import {ButtonGroup, Chip, Header, Separator, Tab, TabItem} from '@jahia/moonstone';
 import styles from './EditPanelHeader.scss';
 import {PublishMenu} from './PublishMenu';
 import {useTranslation} from 'react-i18next';
@@ -29,21 +29,20 @@ const TabItemRenderer = renderProps => {
 };
 
 const ButtonRenderer = getButtonRenderer({
-    defaultButtonProps: {
-        size: 'big',
-        color: 'accent'
-    }
+    defaultButtonProps: {size: 'big', color: 'accent'}
+});
+
+const BackButtonRenderer = getButtonRenderer({
+    defaultButtonProps: {size: 'big', variant: 'ghost'},
+    noIcon: true
 });
 
 export const EditPanelHeader = ({title, isShowPublish, activeTab, setActiveTab}) => {
     const {nodeData, nodeTypeName, nodeTypeDisplayName, mode} = useContentEditorContext();
-
-    const backButton = (
-        <DisplayAction actionKey="backButton" render={ButtonRendererNoLabel} buttonProps={{variant: 'outlined', icon: <ArrowLeft/>}}/>
-    );
+    const {t} = useTranslation('jcontent');
 
     return (
-        <Header backButton={backButton}
+        <Header
                 title={truncate(title, 60)}
                 breadcrumb={(
                     nodeData?.path?.startsWith('/sites') && <ContentPath path={nodeData.path}/>
@@ -53,6 +52,11 @@ export const EditPanelHeader = ({title, isShowPublish, activeTab, setActiveTab})
                 )}
                 mainActions={(
                     <div className="flexRow_center alignCenter">
+                        <DisplayAction
+                            actionKey="backButton"
+                            render={BackButtonRenderer}
+                            buttonLabel={t('label.contentEditor.close')}
+                        />
                         <div className={styles.saveActions}>
                             <DisplayActions
                                 target="content-editor/header/main-save-actions"

--- a/src/javascript/ContentEditor/registerActions.jsx
+++ b/src/javascript/ContentEditor/registerActions.jsx
@@ -12,7 +12,7 @@ export const registerActions = registry => {
 
     registry.add('action', 'backButton', goBackAction, {
         buttonIcon: <ArrowLeft/>,
-        buttonLabel: 'jcontent:label.contentEditor.edit.action.goBack.name',
+        buttonLabel: 'jcontent:label.contentEditor.edit.action.goBack.btnContinue',
         targets: ['editHeaderPathActions:1'],
         showIcons: true
     });

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -614,7 +614,6 @@
             }
           },
           "goBack": {
-            "name": "Zurück zu {{parentNodeDisplayName}}",
             "edit": {
               "title": "Nicht gespeicherte Änderungen",
               "message": "Änderungen wurden noch nicht gespeichert. Was möchten Sie vor dem Schließen tun?",

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -621,7 +621,6 @@
             }
           },
           "goBack": {
-            "name": "Back to {{parentNodeDisplayName}}",
             "edit": {
               "title": "Unsaved changes",
               "message": "There are unsaved changes. What do you want to do with them before closing?"

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -615,7 +615,6 @@
             }
           },
           "goBack": {
-            "name": "Retour à {{parentNodeDisplayName}}",
             "edit": {
               "title": "Modifications non enregistrées",
               "message": "Vous avez des modifications non enregistrées. Que souhaitez-vous faire avant de fermer?",


### PR DESCRIPTION
### Description

- Changed default goBack button to default to `Cancel` label and remove unused `goBack.name` labels
- Remove back button in CE header and render as part of main actions instead
