### PR TITLE
fix: Scrolling in picker navigation tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,5 +145,6 @@
     "webpack": "^5.10.0",
     "webpack-bundle-analyzer": "^4.2.0",
     "webpack-cli": "^4.2.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <jahia-module-type>system</jahia-module-type>
         <yarn.arguments>build:production</yarn.arguments>
         <jahia-module-signature>MCwCFFMjeVEJROijOE0/yBSRCDAMPH/GAhQzxjzBBmW4K3E+ZzBgtxoVuxXmYw==</jahia-module-signature>
-        <jahia-depends>jahia-ui-root</jahia-depends>
+        <jahia-depends>jahia-ui-root,graphql-dxm-provider=2.19</jahia-depends>
         <jahia-plugin-version>6.9</jahia-plugin-version>
     </properties>
 
@@ -194,7 +194,11 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Import-Package>org.jahia.modules.graphql.provider.dxm;version="2.19.0",${jahia.plugin.projectPackageImport},*</Import-Package>
+                        <Import-Package>
+                            org.jahia.modules.graphql.provider.dxm;version="2.19.0",
+                            ${jahia.plugin.projectPackageImport},
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/src/javascript/JContent/ContentTree/ContentTree.jsx
+++ b/src/javascript/JContent/ContentTree/ContentTree.jsx
@@ -116,6 +116,14 @@ export const ContentTree = ({setPathAction, openPathAction, closePathAction, ite
         }
     }, []);
 
+    // Scroll to selected item in picker dialog
+    useEffect(() => {
+        const el = ulRef.current?.querySelector('[aria-selected="true"]');
+        if (el?.closest('[data-sel-role="picker-dialog"]')) { // Only for pickers
+            el?.scrollIntoView({behavior: 'auto', block: 'center'});
+        }
+    }, [path]);
+
     const useTreeEntriesOptionsJson = {
         fragments: [PickerItemsFragment.mixinTypes, PickerItemsFragment.primaryNodeType, PickerItemsFragment.isPublished, PickerItemsFragment.isTreeSelectable, lockInfo, PickerItemsFragment.parentNode, displayName],
         rootPaths: [rootPath],


### PR DESCRIPTION
### Description

We have a related issue that was fixed here https://jira.jahia.org/browse/QA-14993. I tried to use the same approach but the issue is that the whole component is recreated on selection, so ref is reset.

Force a workaround by querying selector and scrolling it into view whenever selection changes instead. Also limit the change to pickers only.

Misc 
- adding jahia-depends since we have version requirement in import-package
- locking yarn version in package.json


