### PR TITLE
fix: Remove context menu in page builder completely.

### DIFF
--- a/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
@@ -15,7 +15,6 @@ import {refetchTypes, setRefetcher, unsetRefetcher} from '~/JContent/JContent.re
 import {TableViewModeChangeTracker} from '~/JContent/ContentRoute/ToolBar/ViewModeSelector/tableViewChangeTracker';
 import {getBoundingBox} from '../EditFrame.utils';
 import InsertionPoints from '../InsertionPoints';
-import BoxesContextMenu from './BoxesContextMenu';
 import useClearSelection from './useClearSelection';
 import {resetContentStatusPaths} from '~/JContent/redux/contentStatus.redux';
 
@@ -321,7 +320,6 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
         });
     }, [nodes, site, language, uilang, currentDocument]);
 
-    const currentPath = currentElement?.path || path;
     const entries = useMemo(() => modules.map(m => ({
         name: m.dataset.jahiaPath.substr(m.dataset.jahiaPath.lastIndexOf('/') + 1),
         path: m.dataset.jahiaPath,
@@ -374,15 +372,9 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
 
     const el = currentElement?.element;
 
+    // Note that context menu was removed but that component is still available here ./BoxesContextMenu
     return (
         <div>
-            <BoxesContextMenu
-                currentFrameRef={currentFrameRef}
-                currentDocument={currentDocument}
-                currentPath={currentPath}
-                selection={selection}
-            />
-
             {modules.map(element => ({element, node: nodes?.[element.dataset.jahiaPath]}))
                 .filter(({node}) => node && (!isMarkedForDeletion(node) || hasMixin(node, 'jmix:markedForDeletionRoot')))
                 .map(({node, element}) => (

--- a/tests/cypress/e2e/menuActions/areaActions.cy.ts
+++ b/tests/cypress/e2e/menuActions/areaActions.cy.ts
@@ -41,7 +41,7 @@ describe('Area actions', () => {
     it('Checks that content can be pasted into the area', () => {
         const jcontentPageBuilder = jcontent.switchToPageBuilder();
         jcontentPageBuilder.getModule('/sites/jcontentSite/home/landing/test-content-path2', false)
-            .contextMenu(false)
+            .contextMenu()
             .selectByRole('copy');
 
         // Clicking on area header is very tricky due to overlapping contents. Select area header using footer instead.

--- a/tests/cypress/e2e/menuActions/areaActions.cy.ts
+++ b/tests/cypress/e2e/menuActions/areaActions.cy.ts
@@ -41,7 +41,7 @@ describe('Area actions', () => {
     it('Checks that content can be pasted into the area', () => {
         const jcontentPageBuilder = jcontent.switchToPageBuilder();
         jcontentPageBuilder.getModule('/sites/jcontentSite/home/landing/test-content-path2', false)
-            .contextMenu(false, false)
+            .contextMenu(false)
             .selectByRole('copy');
 
         // Clicking on area header is very tricky due to overlapping contents. Select area header using footer instead.

--- a/tests/cypress/e2e/pageBuilder/clipboard.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/clipboard.cy.ts
@@ -26,7 +26,7 @@ describe('Page builder - clipboard tests', () => {
     it('should show paste button when we copy', function () {
         // We don't force right-click otherwise it might bring up page context menu
         const contentPath = `/sites/${siteKey}/home/area-main/test-content1`;
-        const contextMenu = jcontent.getModule(contentPath).contextMenu(true);
+        const contextMenu = jcontent.getModule(contentPath).contextMenu();
 
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(1000); // Wait for the context menu to appear
@@ -43,7 +43,7 @@ describe('Page builder - clipboard tests', () => {
 
     it('should remove paste button when we clear clipboard', function () {
         // We don't force right-click otherwise it might bring up page context menu
-        const contextMenu = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content1`, false).contextMenu(true);
+        const contextMenu = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content1`, false).contextMenu();
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(1000); // Wait for the context menu to appear
         contextMenu.selectByRole('copy');

--- a/tests/cypress/e2e/pageBuilder/clipboard.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/clipboard.cy.ts
@@ -26,7 +26,7 @@ describe('Page builder - clipboard tests', () => {
     it('should show paste button when we copy', function () {
         // We don't force right-click otherwise it might bring up page context menu
         const contentPath = `/sites/${siteKey}/home/area-main/test-content1`;
-        const contextMenu = jcontent.getModule(contentPath).contextMenu(true, false);
+        const contextMenu = jcontent.getModule(contentPath).contextMenu(true);
 
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(1000); // Wait for the context menu to appear
@@ -43,7 +43,7 @@ describe('Page builder - clipboard tests', () => {
 
     it('should remove paste button when we clear clipboard', function () {
         // We don't force right-click otherwise it might bring up page context menu
-        const contextMenu = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content1`, false).contextMenu(true, false);
+        const contextMenu = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content1`, false).contextMenu(true);
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(1000); // Wait for the context menu to appear
         contextMenu.selectByRole('copy');

--- a/tests/cypress/e2e/pageBuilder/listLimit.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/listLimit.cy.ts
@@ -113,7 +113,7 @@ describe('Page builder - list limit restrictions tests', () => {
 
             cy.log('it should not show paste buttons');
             pageBuilder.getModule(`/sites/${limitSiteKey}/home/${limitPage}/my-area/abc1`, false)
-                .contextMenu(false, false)
+                .contextMenu(false)
                 .selectByRole('copy');
             cy.get('#message-id').contains('in the clipboard');
             const restrictedArea = pageBuilder.getModule(`/sites/${limitSiteKey}/home/${limitPage}/my-area`, false);

--- a/tests/cypress/e2e/pageBuilder/listLimit.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/listLimit.cy.ts
@@ -66,7 +66,7 @@ describe('Page builder - list limit restrictions tests', () => {
 
         it('should not show paste button when limit is reached', () => {
             jcontent.getModule(`/sites/${contentSiteKey}/home/area-main/test-content1`, false)
-                .contextMenu(true)
+                .contextMenu()
                 .select('Copy');
 
             cy.log('Assert no paste buttons after copy');

--- a/tests/cypress/e2e/pageBuilder/restrictions.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/restrictions.cy.ts
@@ -153,7 +153,7 @@ describe('Page builder', () => {
 
             cy.log('disable button when not allowed');
             pageBuilder.getModule(`/sites/${siteKey}/home/${pageName}/any-area/notAllowedText`, false)
-                .contextMenu(false)
+                .contextMenu()
                 .selectByRole('copy');
             cy.get('#message-id').contains('in the clipboard');
 
@@ -165,7 +165,7 @@ describe('Page builder', () => {
 
             cy.log('enable button when allowed');
             pageBuilder.getModule(`/sites/${siteKey}/home/${pageName}/any-area/allowedText`, false)
-                .contextMenu(false)
+                .contextMenu()
                 .selectByRole('copy');
             cy.get('#message-id').contains('in the clipboard');
 
@@ -191,7 +191,7 @@ describe('Page builder', () => {
             cy.log('restricted-area should restrict context menu create buttons for pbnt:contentRestriction only');
             const contextMenu = pageBuilder
                 .getModule(`/sites/${siteKey}/home/${pageName}/restricted-area`, false)
-                .emptyAreaContextMenu();
+                .contextMenu();
             contextMenu.shouldNotHaveRoleItem('createContent');
             contextMenu.shouldHaveRoleItem('pbnt:contentRestriction');
         });

--- a/tests/cypress/e2e/pageBuilder/restrictions.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/restrictions.cy.ts
@@ -153,7 +153,7 @@ describe('Page builder', () => {
 
             cy.log('disable button when not allowed');
             pageBuilder.getModule(`/sites/${siteKey}/home/${pageName}/any-area/notAllowedText`, false)
-                .contextMenu(false, false)
+                .contextMenu(false)
                 .selectByRole('copy');
             cy.get('#message-id').contains('in the clipboard');
 
@@ -165,7 +165,7 @@ describe('Page builder', () => {
 
             cy.log('enable button when allowed');
             pageBuilder.getModule(`/sites/${siteKey}/home/${pageName}/any-area/allowedText`, false)
-                .contextMenu(false, false)
+                .contextMenu(false)
                 .selectByRole('copy');
             cy.get('#message-id').contains('in the clipboard');
 

--- a/tests/cypress/e2e/pageBuilder/selections.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/selections.cy.ts
@@ -76,7 +76,8 @@ describe('Page builder - selections test', () => {
         // Doesn't work: module.parentFrame.get().find('div[data-current="true"]').should('not.exist');
     });
 
-    it('Allows to select with right click', () => {
+    // We need to discuss if we still want this
+    it.skip('Allows to select with right click', () => {
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
         let module = jcontent.getModule(item1);
         module.click();

--- a/tests/cypress/e2e/pageBuilder/selections.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/selections.cy.ts
@@ -84,7 +84,7 @@ describe('Page builder - selections test', () => {
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
 
         module = jcontent.getModule(item3);
-        module.contextMenu(false, false).selectByRole('selectionAction');
+        module.contextMenu(false).selectByRole('selectionAction');
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '2 items selected');
 
         jcontent.clearSelection();

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
@@ -83,14 +83,9 @@ export class PageBuilderModule extends BaseComponent {
         });
     }
 
-    contextMenu(selectFirst = false, force = true): Menu {
-        if (selectFirst) {
-            this.click();
-            this.getHeader().get().should('be.visible').rightclick({force, waitForAnimations: true});
-        } else {
-            this.hover();
-            this.get().rightclick({force, waitForAnimations: true});
-        }
+    contextMenu(force = true, menuName = 'contentItemActionsMenu'): Menu {
+        this.click();
+        this.getHeader().get().should('be.visible').get(`button[data-sel-role="${menuName}"]`).should('be.visible').click({force, waitForAnimations: true});
 
         return getComponentBySelector(Menu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)');
     }

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
@@ -84,7 +84,7 @@ export class PageBuilderModule extends BaseComponent {
     }
 
     contextMenu(force = true, menuName = 'contentItemActionsMenu'): Menu {
-        this.click();
+        this.click({force});
         this.getHeader().get().should('be.visible').find(`button[data-sel-role="${menuName}"]`).should('be.visible').click({force, waitForAnimations: true});
 
         return getComponentBySelector(Menu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)');

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
@@ -85,7 +85,7 @@ export class PageBuilderModule extends BaseComponent {
 
     contextMenu(force = true, menuName = 'contentItemActionsMenu'): Menu {
         this.click();
-        this.getHeader().get().should('be.visible').get(`button[data-sel-role="${menuName}"]`).should('be.visible').click({force, waitForAnimations: true});
+        this.getHeader().get().should('be.visible').find(`button[data-sel-role="${menuName}"]`).should('be.visible').click({force, waitForAnimations: true});
 
         return getComponentBySelector(Menu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)');
     }


### PR DESCRIPTION
### Description
Remove context menu in page builder completely. If I read #1878  correctly we want to remove context menu completely, if that is the case then provided solution should do the trick. 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
