### PR TITLE
chore: Bump parent version to 8.1.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.3.0</version>
+        <version>8.1.7.0</version>
         <relativePath />
     </parent>
     <artifactId>jcontent</artifactId>


### PR DESCRIPTION
### Description

Bump jcontent 2.19 to minimum supported version 8.1.7.0
