### PR TITLE
fix: Include uilang in content editor's url

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/Picker/actions/openInTabAction.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/actions/openInTabAction.js
@@ -10,7 +10,7 @@ import {useSelector} from 'react-redux';
 
 export const OpenInTabActionComponent = ({render: Render, loading: Loading, path, field, inputContext, ...others}) => {
     const {lang} = useContentEditorContext();
-    const fallbackLanguage = useSelector(state => state.language);
+    const {fallbackLanguage, currentUILang} = useSelector(state => ({fallbackLanguage: state.language, currentUILang: state.uilang}));
     const client = useApolloClient();
 
     let uuid;
@@ -38,7 +38,7 @@ export const OpenInTabActionComponent = ({render: Render, loading: Loading, path
             {...others}
             onClick={() => {
                 jcontentUtils.expandTree({uuid}, client).then(({mode, parentPath, site}) => {
-                    const hash = rison.encode_uri({contentEditor: [{uuid, lang: lang || fallbackLanguage, mode: Constants.routes.baseEditRoute, isFullscreen: true}]});
+                    const hash = rison.encode_uri({contentEditor: [{uuid, uilang: currentUILang, lang: lang || fallbackLanguage, mode: Constants.routes.baseEditRoute, isFullscreen: true}]});
                     const url = jcontentUtils.buildUrl({site, language: lang || fallbackLanguage, mode, path: parentPath});
                     window.open(`${window.contextJsParameters.urlbase}${url}#${hash}`, '_blank');
                 });

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/actions/openInTabAction.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/actions/openInTabAction.js
@@ -6,11 +6,11 @@ import {useApolloClient, useQuery} from '@apollo/client';
 import rison from 'rison-node';
 import {OpenInTabActionQuery} from '~/ContentEditor/SelectorTypes/Picker/actions/openInTabAction.gql-queries';
 import * as jcontentUtils from '~/JContent/JContent.utils';
-import {useSelector} from 'react-redux';
+import {shallowEqual, useSelector} from 'react-redux';
 
 export const OpenInTabActionComponent = ({render: Render, loading: Loading, path, field, inputContext, ...others}) => {
     const {lang} = useContentEditorContext();
-    const {fallbackLanguage, currentUILang} = useSelector(state => ({fallbackLanguage: state.language, currentUILang: state.uilang}));
+    const {fallbackLanguage, currentUILang} = useSelector(state => ({fallbackLanguage: state.language, currentUILang: state.uilang}), shallowEqual);
     const client = useApolloClient();
 
     let uuid;

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/actions/openInTabAction.spec.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/actions/openInTabAction.spec.js
@@ -16,7 +16,10 @@ jest.mock('@apollo/client', () => {
 });
 
 jest.mock('react-redux', () => ({
-    useSelector: jest.fn()
+    useSelector: () => ({
+        fallbackLanguage: 'en',
+        currentUILang: 'en'
+    })
 }));
 
 jest.mock('~/ContentEditor/contexts/ContentEditor/ContentEditor.context');
@@ -59,6 +62,6 @@ describe('openInTab action', () => {
         const cmp = shallow(<OpenInTabActionComponent {...context} render={button}/>);
         cmp.simulate('click');
 
-        expect(window.open).toHaveBeenCalledWith('/jahia/jahia/jcontent/url#(contentEditor:!((isFullscreen:!t,lang:fr,mode:edit,uuid:this-is-an-id)))', '_blank');
+        expect(window.open).toHaveBeenCalledWith('/jahia/jahia/jcontent/url#(contentEditor:!((isFullscreen:!t,lang:fr,mode:edit,uilang:en,uuid:this-is-an-id)))', '_blank');
     });
 });

--- a/src/javascript/JContent/EditFrame/Boxes/BoxesContextMenu.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/BoxesContextMenu.jsx
@@ -2,6 +2,16 @@ import React, {useEffect, useRef} from 'react';
 import {ContextualMenu} from '@jahia/ui-extender';
 import PropTypes from 'prop-types';
 
+/**
+ * @deprecated since version 3.4.0 https://github.com/Jahia/jcontent/pull/1879
+ * This component will be removed in version 4.0.0.
+ * @component
+ * @param {Object} props Component props
+ * @param {Object} props.currentFrameRef Reference to the current frame
+ * @param {Object} props.currentDocument Current document object
+ * @param {string} props.currentPath Current content path
+ * @param {string[]} props.selection Array of selected paths
+ */
 const BoxesContextMenu = ({currentFrameRef, currentDocument, currentPath, selection}) => {
     const contextualMenu = useRef();
 


### PR DESCRIPTION
### Description
Include uilang in content editor's url so it can properly restore its context.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
