### PR TITLE
revert: "fix: Remove context menu in page builder completely. (#1879)"

### DIFF
--- a/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
@@ -15,6 +15,7 @@ import {refetchTypes, setRefetcher, unsetRefetcher} from '~/JContent/JContent.re
 import {TableViewModeChangeTracker} from '~/JContent/ContentRoute/ToolBar/ViewModeSelector/tableViewChangeTracker';
 import {getBoundingBox} from '../EditFrame.utils';
 import InsertionPoints from '../InsertionPoints';
+import BoxesContextMenu from './BoxesContextMenu';
 import useClearSelection from './useClearSelection';
 import {resetContentStatusPaths} from '~/JContent/redux/contentStatus.redux';
 
@@ -320,6 +321,7 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
         });
     }, [nodes, site, language, uilang, currentDocument]);
 
+    const currentPath = currentElement?.path || path;
     const entries = useMemo(() => modules.map(m => ({
         name: m.dataset.jahiaPath.substr(m.dataset.jahiaPath.lastIndexOf('/') + 1),
         path: m.dataset.jahiaPath,
@@ -372,9 +374,15 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
 
     const el = currentElement?.element;
 
-    // Note that context menu was removed but that component is still available here ./BoxesContextMenu
     return (
         <div>
+            <BoxesContextMenu
+                currentFrameRef={currentFrameRef}
+                currentDocument={currentDocument}
+                currentPath={currentPath}
+                selection={selection}
+            />
+
             {modules.map(element => ({element, node: nodes?.[element.dataset.jahiaPath]}))
                 .filter(({node}) => node && (!isMarkedForDeletion(node) || hasMixin(node, 'jmix:markedForDeletionRoot')))
                 .map(({node, element}) => (

--- a/tests/cypress/e2e/menuActions/areaActions.cy.ts
+++ b/tests/cypress/e2e/menuActions/areaActions.cy.ts
@@ -41,7 +41,7 @@ describe('Area actions', () => {
     it('Checks that content can be pasted into the area', () => {
         const jcontentPageBuilder = jcontent.switchToPageBuilder();
         jcontentPageBuilder.getModule('/sites/jcontentSite/home/landing/test-content-path2', false)
-            .contextMenu()
+            .contextMenu(false, false)
             .selectByRole('copy');
 
         // Clicking on area header is very tricky due to overlapping contents. Select area header using footer instead.

--- a/tests/cypress/e2e/pageBuilder/clipboard.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/clipboard.cy.ts
@@ -26,7 +26,7 @@ describe('Page builder - clipboard tests', () => {
     it('should show paste button when we copy', function () {
         // We don't force right-click otherwise it might bring up page context menu
         const contentPath = `/sites/${siteKey}/home/area-main/test-content1`;
-        const contextMenu = jcontent.getModule(contentPath).contextMenu();
+        const contextMenu = jcontent.getModule(contentPath).contextMenu(true, false);
 
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(1000); // Wait for the context menu to appear
@@ -43,7 +43,7 @@ describe('Page builder - clipboard tests', () => {
 
     it('should remove paste button when we clear clipboard', function () {
         // We don't force right-click otherwise it might bring up page context menu
-        const contextMenu = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content1`, false).contextMenu();
+        const contextMenu = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content1`, false).contextMenu(true, false);
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(1000); // Wait for the context menu to appear
         contextMenu.selectByRole('copy');

--- a/tests/cypress/e2e/pageBuilder/listLimit.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/listLimit.cy.ts
@@ -66,7 +66,7 @@ describe('Page builder - list limit restrictions tests', () => {
 
         it('should not show paste button when limit is reached', () => {
             jcontent.getModule(`/sites/${contentSiteKey}/home/area-main/test-content1`, false)
-                .contextMenu()
+                .contextMenu(true)
                 .select('Copy');
 
             cy.log('Assert no paste buttons after copy');
@@ -113,7 +113,7 @@ describe('Page builder - list limit restrictions tests', () => {
 
             cy.log('it should not show paste buttons');
             pageBuilder.getModule(`/sites/${limitSiteKey}/home/${limitPage}/my-area/abc1`, false)
-                .contextMenu(false)
+                .contextMenu(false, false)
                 .selectByRole('copy');
             cy.get('#message-id').contains('in the clipboard');
             const restrictedArea = pageBuilder.getModule(`/sites/${limitSiteKey}/home/${limitPage}/my-area`, false);

--- a/tests/cypress/e2e/pageBuilder/restrictions.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/restrictions.cy.ts
@@ -153,7 +153,7 @@ describe('Page builder', () => {
 
             cy.log('disable button when not allowed');
             pageBuilder.getModule(`/sites/${siteKey}/home/${pageName}/any-area/notAllowedText`, false)
-                .contextMenu()
+                .contextMenu(false, false)
                 .selectByRole('copy');
             cy.get('#message-id').contains('in the clipboard');
 
@@ -165,7 +165,7 @@ describe('Page builder', () => {
 
             cy.log('enable button when allowed');
             pageBuilder.getModule(`/sites/${siteKey}/home/${pageName}/any-area/allowedText`, false)
-                .contextMenu()
+                .contextMenu(false, false)
                 .selectByRole('copy');
             cy.get('#message-id').contains('in the clipboard');
 
@@ -191,7 +191,7 @@ describe('Page builder', () => {
             cy.log('restricted-area should restrict context menu create buttons for pbnt:contentRestriction only');
             const contextMenu = pageBuilder
                 .getModule(`/sites/${siteKey}/home/${pageName}/restricted-area`, false)
-                .contextMenu();
+                .emptyAreaContextMenu();
             contextMenu.shouldNotHaveRoleItem('createContent');
             contextMenu.shouldHaveRoleItem('pbnt:contentRestriction');
         });

--- a/tests/cypress/e2e/pageBuilder/selections.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/selections.cy.ts
@@ -76,8 +76,7 @@ describe('Page builder - selections test', () => {
         // Doesn't work: module.parentFrame.get().find('div[data-current="true"]').should('not.exist');
     });
 
-    // We need to discuss if we still want this
-    it.skip('Allows to select with right click', () => {
+    it('Allows to select with right click', () => {
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
         let module = jcontent.getModule(item1);
         module.click();
@@ -85,7 +84,7 @@ describe('Page builder - selections test', () => {
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
 
         module = jcontent.getModule(item3);
-        module.contextMenu(false).selectByRole('selectionAction');
+        module.contextMenu(false, false).selectByRole('selectionAction');
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '2 items selected');
 
         jcontent.clearSelection();

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
@@ -83,9 +83,14 @@ export class PageBuilderModule extends BaseComponent {
         });
     }
 
-    contextMenu(force = true, menuName = 'contentItemActionsMenu'): Menu {
-        this.click({force});
-        this.getHeader().get().should('be.visible').find(`button[data-sel-role="${menuName}"]`).should('be.visible').click({force, waitForAnimations: true});
+    contextMenu(selectFirst = false, force = true): Menu {
+        if (selectFirst) {
+            this.click();
+            this.getHeader().get().should('be.visible').rightclick({force, waitForAnimations: true});
+        } else {
+            this.hover();
+            this.get().rightclick({force, waitForAnimations: true});
+        }
 
         return getComponentBySelector(Menu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)');
     }


### PR DESCRIPTION
This reverts commit d9199d302717139d9fd2125cc76bf2a6d253ca20.

### Description
Remove context menu in page builder completely. (#1879)

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
