### PR TITLE
fix: Translation editor fixes

### DIFF
--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.spec.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.spec.jsx
@@ -32,7 +32,7 @@ jest.mock('~/ContentEditor/contexts/ContentEditorConfig/ContentEditorConfig.cont
     return {
         useContentEditorConfigContext: () => ({
             lang: 'fr',
-            sbsContext: {}
+            sideBySideContext: {}
         })
     };
 });

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderBadges/PublicationInfoBadge.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderBadges/PublicationInfoBadge.jsx
@@ -11,10 +11,10 @@ import {useContentEditorConfigContext} from '../../../contexts';
 export const PublicationInfoBadge = () => {
     const {t} = useTranslation('jcontent');
     const publicationInfoContext = usePublicationInfoContext();
-    const {sbsContext} = useContentEditorConfigContext();
+    const {sideBySideContext} = useContentEditorConfigContext();
     const {publicationStatus, existsInLive, publicationInfoPolling} = publicationInfoContext;
     const uilang = useSelector(state => state.uilang);
-    const translateMode = Boolean(sbsContext.lang);
+    const translateMode = Boolean(sideBySideContext.lang);
 
     const statuses = {
         modified: false,

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderBadges/PublicationInfoBadge.spec.js
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderBadges/PublicationInfoBadge.spec.js
@@ -13,7 +13,7 @@ jest.mock('react-redux', () => {
 jest.mock('~/ContentEditor/contexts/ContentEditorConfig/ContentEditorConfig.context', () => {
     return {
         useContentEditorConfigContext: () => ({
-            sbsContext: {}
+            sideBySideContext: {}
         })
     };
 });

--- a/src/javascript/ContentEditor/ContentEditorApi/ContentEditorModal.jsx
+++ b/src/javascript/ContentEditor/ContentEditorApi/ContentEditorModal.jsx
@@ -55,9 +55,9 @@ export const ContentEditorModal = ({editorConfig, updateEditorConfig, onExited})
 
     // Support for side-by-side editing;
     // Can be initialized from CE api but need to recreate state getter/setters at this level
-    const [sbsContext, setSbsContext] = useState(mergedConfig.sbsContext || {});
-    mergedConfig.sbsContext = sbsContext;
-    mergedConfig.setSbsContext = setSbsContext;
+    const [sideBySideContext, setSideBySideContext] = useState(mergedConfig.sideBySideContext || {});
+    mergedConfig.sideBySideContext = sideBySideContext;
+    mergedConfig.setSideBySideContext = setSideBySideContext;
 
     const {createCallback, editCallback, onClosedCallback} = mergedConfig;
 

--- a/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/CopyLanguageDialog.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/CopyLanguageDialog.jsx
@@ -16,7 +16,7 @@ export const CopyLanguageDialog = ({
     onCloseDialog,
     uuid,
     formik,
-    sbsContext
+    sideBySideContext
 }) => {
     const client = useApolloClient();
 
@@ -43,7 +43,7 @@ export const CopyLanguageDialog = ({
     // Override selected option with sbsOption from translate action if it exists and use that as source language
     const sbsOption = availableLanguages
         .map(e => ({value: e.language, label: e.uiLanguageDisplayName}))
-        .find(e => e.value === sbsContext.lang);
+        .find(e => e.value === sideBySideContext.lang);
 
     const defaultOption = sbsOption || {
         label: t('jcontent:label.contentEditor.edit.action.copyLanguage.defaultValue'),
@@ -138,5 +138,5 @@ CopyLanguageDialog.propTypes = {
     isOpen: PropTypes.bool.isRequired,
     uuid: PropTypes.string.isRequired,
     onCloseDialog: PropTypes.func.isRequired,
-    sbsContext: PropTypes.shape({lang: PropTypes.string})
+    sideBySideContext: PropTypes.shape({lang: PropTypes.string})
 };

--- a/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/CopyLanguageDialog.spec.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/CopyLanguageDialog.spec.jsx
@@ -37,7 +37,7 @@ describe('CopyLanguageDialog', () => {
             t: jest.fn(key => 'translated_' + key),
             onCloseDialog: jest.fn(),
             formik: {},
-            sbsContext: {}
+            sideBySideContext: {}
         };
     });
 

--- a/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/copyLanguageAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/copyLanguageAction.jsx
@@ -9,7 +9,7 @@ import {useFormikContext} from 'formik';
 export const CopyLanguageActionComponent = ({render: Render, ...otherProps}) => {
     const {render, destroy} = useContext(ComponentRendererContext);
     const {nodeData, lang, siteInfo} = useContentEditorContext();
-    const {sbsContext} = useContentEditorConfigContext();
+    const {sideBySideContext} = useContentEditorConfigContext();
     const formik = useFormikContext();
 
     return (
@@ -21,7 +21,7 @@ export const CopyLanguageActionComponent = ({render: Render, ...otherProps}) => 
                         uuid: nodeData.uuid,
                         formik,
                         language: getFullLanguageName(siteInfo.languages, lang),
-                        sbsContext,
+                        sideBySideContext,
                         availableLanguages: siteInfo.languages,
                         onCloseDialog: () => destroy('CopyLanguageDialog')
                     });

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/SourceContentPanel.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/SourceContentPanel.jsx
@@ -11,6 +11,7 @@ import {
     useContentEditorContext
 } from '~/ContentEditor/contexts';
 import styles from './styles.scss';
+import {useTranslation} from 'react-i18next';
 
 /** Override contexts */
 export const SourceContentPanel = () => {
@@ -39,6 +40,7 @@ export const SourceContentPanel = () => {
 
 const SourceContentFormBuilder = () => {
     const {initialValues, mode} = useContentEditorContext();
+    const {t} = useTranslation('jcontent');
     useResizeWatcher({columnSelector: 'left-column'});
     return (
         <Formik initialValues={{...initialValues}}
@@ -47,7 +49,7 @@ const SourceContentFormBuilder = () => {
         >
             <>
                 <div className={styles.languageDropDown}>
-                    <span>Source language</span>
+                    <span>{t('label.contentEditor.edit.action.translate.sourceLanguage')}</span>
                     <EditPanelLanguageSwitcher/>
                 </div>
                 <FormBuilder mode={mode}/>

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/SourceContentPanel.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/SourceContentPanel.jsx
@@ -19,9 +19,9 @@ export const SourceContentPanel = () => {
 
     const contextConfig = {
         ...ceConfigContext,
-        lang: ceConfigContext.sbsContext.lang,
-        sbsContext: {
-            ...ceConfigContext.sbsContext,
+        lang: ceConfigContext.sideBySideContext.lang,
+        sideBySideContext: {
+            ...ceConfigContext.sideBySideContext,
             enabled: true,
             readOnly: true,
             translateLang: ceConfigContext.lang

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/TranslatePanel.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/TranslatePanel.jsx
@@ -10,6 +10,7 @@ import clsx from 'clsx';
 import {useContentEditorConfigContext} from '~/ContentEditor/contexts';
 import {useResizeWatcher} from './useResizeWatcher';
 import {SourceContentPanel} from './SourceContentPanel';
+import {useTranslation} from 'react-i18next';
 
 const TwoPanelsContent = ({leftCol, rightCol}) => {
     const {leftColRef, rightColRef} = useSyncScroll();
@@ -34,6 +35,7 @@ TwoPanelsContent.propTypes = {
 
 export const TranslatePanel = ({title}) => {
     const {mode} = useContentEditorConfigContext();
+    const {t} = useTranslation('jcontent');
 
     return (
         <LayoutContent
@@ -49,7 +51,7 @@ export const TranslatePanel = ({title}) => {
                         <>
 
                             <div className={styles.languageDropDown}>
-                                <span>Translate to</span>
+                                <span>{t('label.contentEditor.edit.action.translate.translateToLanguage')}</span>
                                 <EditPanelLanguageSwitcher/>
                             </div>
                             <FormBuilder mode={mode}/>

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/translateAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/translateAction.jsx
@@ -27,7 +27,7 @@ export const TranslateActionComponent = ({path, render: Render, ...otherProps}) 
                         dialogProps: {
                             classes: {}
                         },
-                        sbsContext: {lang},
+                        sideBySideContext: {lang},
                         layout: TranslatePanel,
                         useFormDefinition: useTranslateFormDefinition
                     });

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/translateFieldAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/translateFieldAction.jsx
@@ -5,10 +5,10 @@ import {ArrowRight} from '@jahia/moonstone';
 import styles from './styles.scss';
 
 export const TranslateFieldActionComponent = ({field, value, render: Render}) => {
-    const {sbsContext} = useContentEditorConfigContext();
+    const {sideBySideContext} = useContentEditorConfigContext();
     const {setI18nContext} = useContentEditorContext();
 
-    const {enabled, translateLang} = sbsContext || {};
+    const {enabled, translateLang} = sideBySideContext || {};
     if (!enabled || !field.i18n || !translateLang) {
         return <div className={styles.spacing}/>;
     }

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/useTranslateFormDefinition.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/useTranslateFormDefinition.jsx
@@ -2,7 +2,7 @@ import {useEditFormDefinition} from '~/ContentEditor/ContentEditor/useEditFormDe
 import {useContentEditorConfigContext} from '../../../contexts';
 
 export const useTranslateFormDefinition = () => {
-    const {sbsContext} = useContentEditorConfigContext();
+    const {sideBySideContext} = useContentEditorConfigContext();
     const {data, refetch, loading, error, errorMessage} = useEditFormDefinition();
 
     if (data) {
@@ -13,7 +13,7 @@ export const useTranslateFormDefinition = () => {
                 fieldSet.fields.filter(field => !field.i18n).forEach(f => {
                     f.readOnly = true;
                 });
-                if (sbsContext.readOnly) {
+                if (sideBySideContext.readOnly) {
                     fieldSet.readOnly = true;
                     fieldSet.fields.forEach(field => {
                         field.readOnly = true;

--- a/src/javascript/ContentEditor/utils/useSwitchLanguage.js
+++ b/src/javascript/ContentEditor/utils/useSwitchLanguage.js
@@ -35,7 +35,7 @@ export const useSwitchLanguage = () => {
     const formik = useFormikContext();
     const {setI18nContext} = useContentEditorContext();
     const {sections} = useContentEditorSectionContext();
-    const {lang: previousLanguage, updateEditorConfig, sbsContext, setSbsContext} = useContentEditorConfigContext();
+    const {lang: previousLanguage, updateEditorConfig, sideBySideContext, setSideBySideContext} = useContentEditorConfigContext();
 
     return useCallback(newLanguage => {
         const fields = sections && getFields(sections).filter(field => !field.readOnly);
@@ -89,12 +89,12 @@ export const useSwitchLanguage = () => {
             };
         });
 
-        if (sbsContext.enabled) {
-            setSbsContext(prev => ({...prev, lang: newLanguage}));
+        if (sideBySideContext.enabled) {
+            setSideBySideContext(prev => ({...prev, lang: newLanguage}));
         } else {
             updateEditorConfig({
                 lang: newLanguage
             });
         }
-    }, [updateEditorConfig, formik, sections, setI18nContext, previousLanguage, sbsContext.enabled, setSbsContext]);
+    }, [updateEditorConfig, formik, sections, setI18nContext, previousLanguage, sideBySideContext.enabled, setSideBySideContext]);
 };

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -614,7 +614,9 @@
             }
           },
           "translate": {
-            "name": "Übersetzen"
+            "name": "Übersetzen",
+            "sourceLanguage": "Ausgangssprache",
+            "translateToLanguage": "Übersetzen nach"
           },
           "goBack": {
             "edit": {

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -621,7 +621,9 @@
             }
           },
           "translate": {
-            "name": "Translate"
+            "name": "Translate",
+            "sourceLanguage": "Source language",
+            "translateToLanguage": "Translate to"
           },
           "goBack": {
             "edit": {

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -615,7 +615,9 @@
             }
           },
           "translate": {
-            "name": "Traduire"
+            "name": "Traduire",
+            "sourceLanguage": "Langue source",
+            "translateToLanguage": "Traduire vers"
           },
           "goBack": {
             "edit": {


### PR DESCRIPTION
### Description

Follow-up fixes from PR review:

- Rename `sbsContext` to `sideBySideContext`
- Add translations for translation editor language dropdowns
