### PR TITLE
fix: icon size in dropdown path

### DIFF
--- a/src/javascript/JContent/EditFrame/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/javascript/JContent/EditFrame/Breadcrumbs/Breadcrumbs.jsx
@@ -29,7 +29,7 @@ export const Breadcrumbs = ({currentNode, nodes, setClickedElement, onSelect}) =
     const data = nodes.concat(currentNode).map((n, index) => ({
         label: n.path === currentNode.path ? t('label.contentManager.pageBuilder.breadcrumbs.currentItem') : n.name,
         value: n.path,
-        image: <NodeIcon node={n} style={{marginLeft: 8 * index}}/>
+        iconStart: <NodeIcon node={n} style={{marginLeft: 8 * index}}/>
     }));
 
     return (


### PR DESCRIPTION
### Description
Use the props `iconStart` instead of `image` to display the content type icon
 
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
