### PR TITLE
fix: Prevent links from being selectable in picker context

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/editorialPicker/editorialPicker.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/editorialPicker/editorialPicker.js
@@ -64,6 +64,12 @@ export const registerEditorialPicker = registry => {
             },
             treeConfig: {
                 ...pagesItem.treeConfig,
+                selectableTypes: [
+                    'jnt:page',
+                    'jnt:virtualsite',
+                    'jnt:navMenuText',
+                    'jmix:visibleInPagesTree'
+                ],
                 hideRoot: false,
                 dnd: {}
             }


### PR DESCRIPTION
### Description
Prevent links from being selectable in picker context. We don't want to this click to lead to opening content editor on top of the picker.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
