### PR TITLE
fix: Update thumbnail getter to handle webp format

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/DefaultPickerConfig.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/DefaultPickerConfig.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {File, FileBroken} from '@jahia/moonstone';
 import {useQuery} from '@apollo/client';
 import {ContentPickerFilledQuery} from './ContentPicker.gql-queries';
-import {getIconFromNode} from '~/utils';
+import {getIconFromNode, getWebpUrl} from '~/utils';
 import {useContentEditorContext} from '~/ContentEditor/contexts';
 import {shallowEqual, useSelector} from 'react-redux';
 
@@ -30,7 +30,7 @@ const usePickerInputData = uuids => {
     const fieldData = data.jcr.result.map(contentData => ({
         uuid: contentData.uuid,
         path: contentData.path,
-        thumbnail: contentData.thumbnailUrl || getIconFromNode(contentData),
+        thumbnail: contentData.thumbnailUrl || getWebpUrl(contentData) || getIconFromNode(contentData),
         name: contentData.name,
         displayName: contentData.displayName,
         type: contentData.primaryNodeType.displayName

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/mediaPicker/useMediaPickerInputData.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/mediaPicker/useMediaPickerInputData.js
@@ -3,7 +3,7 @@ import bytes from 'bytes';
 import {MediaPickerFilledQuery} from './MediaPicker.gql-queries';
 import {useContentEditorContext} from '~/ContentEditor/contexts';
 import {getMimeType} from '~/JContent/ContentRoute/ContentLayout/ContentLayout.utils';
-import {getIconFromMimeType} from '~/utils';
+import {getIconFromMimeType, getWebpUrl} from '~/utils';
 
 const getThumbnailUrl = node => {
     const url = node.thumbnailUrl;
@@ -34,7 +34,7 @@ export const useMediaPickerInputData = uuids => {
     const fieldData = data.jcr.result.map(imageData => {
         const sizeInfo = (imageData.height && imageData.width) ? `${parseInt(imageData.width.value, 10)} x ${parseInt(imageData.height.value, 10)}` : '';
         const mimeType = getMimeType(imageData) || '';
-        const thumbnail = getThumbnailUrl(imageData) || getIconFromMimeType(mimeType);
+        const thumbnail = getThumbnailUrl(imageData) || getWebpUrl(imageData) || getIconFromMimeType(mimeType);
         const size = imageData.content.data.size && bytes(imageData.content.data.size, {unitSeparator: ' '});
 
         return {

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ManualOrdering/DragDrop/DraggableReference.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ManualOrdering/DragDrop/DraggableReference.jsx
@@ -4,7 +4,7 @@ import {useTranslation} from 'react-i18next';
 import {ReferenceCard} from '~/ContentEditor/DesignSystem/ReferenceCard';
 import {Tooltip, File, Button, ChevronLastList, ChevronFirstList, ChevronUp, ChevronDown} from '@jahia/moonstone';
 import {useReorderDrag, useReorderDrop} from '~/ContentEditor/utils';
-import {getIconFromNode} from '~/utils';
+import {getIconFromNode, getWebpUrl} from '~/utils';
 import styles from '~/ContentEditor/utils/dragAndDrop.scss';
 import clsx from 'clsx';
 
@@ -103,7 +103,7 @@ export const DraggableReference = ({
                     displayName: child.displayName,
                     name: child.name,
                     type: child.primaryNodeType.displayName,
-                    thumbnail: child.thumbnailUrl || getIconFromNode(child)
+                    thumbnail: child.thumbnailUrl || getWebpUrl(child) || getIconFromNode(child)
                 }}
             />
         </div>

--- a/src/javascript/utils/getIcon.jsx
+++ b/src/javascript/utils/getIcon.jsx
@@ -216,3 +216,17 @@ export function getIconFromNode(node, props = {}) {
             );
     }
 }
+
+export const getWebpUrl = node => {
+    if (node.content !== undefined || node.resourceChildren !== undefined) {
+        const mimetype = node.content === undefined ? node.resourceChildren.nodes.slice(-1)[0]?.mimeType.value : node.content.mimeType.value;
+
+        // Special case for webp format as our image service can't handle it and no thumbnail is generated
+        if (mimetype === 'image/webp') {
+            const encodedPath = node.path.replace(/[^/]/g, encodeURIComponent);
+            return `${window.contextJsParameters.contextPath}/files/default${encodedPath}`;
+        }
+    }
+
+    return null;
+};


### PR DESCRIPTION
### Description
Update thumbnail getter to handle webp format. Imagej library does not support webp format so our image service can't generate a thumbnail for it.

After discussing the issue it looks like ImageMagic if installed is able to handle webp format but we still need a solution for thumbnails if it is not installed.

It looks like there is awareness of this problem and steps are being taken to figure out what we will do.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
