### PR TITLE
fix: Count locale nodes when calculating visibility

### DIFF
--- a/src/javascript/ContentEditor/editorTabs/AdvancedOptions/AdvancedOptionsNavigation/AdvancedOptionsNavigation.jsx
+++ b/src/javascript/ContentEditor/editorTabs/AdvancedOptions/AdvancedOptionsNavigation/AdvancedOptionsNavigation.jsx
@@ -53,7 +53,7 @@ const Renderer = ({activeOption, setActiveOption, buttonLabel, onClick, tabs}) =
                 className={styles.menuItemWithChip}
                 isSelected={activeOption === tab}
                 label={buttonLabel}
-                iconEnd={<Chip color={activeOption === tab ? 'light' : 'default'} label={getNodesCount(data)}/>}
+                iconEnd={<Chip className={styles.menuItemChipNoWidth} color={activeOption === tab ? 'light' : 'default'} label={getNodesCount(data)}/>}
                 onClick={e => {
                     if (DEPRECATED_GWT_ACTIONS.includes(tab)) {
                         setActiveOption(tab);

--- a/src/javascript/ContentEditor/editorTabs/AdvancedOptions/AdvancedOptionsNavigation/AdvancedOptionsNavigation.scss
+++ b/src/javascript/ContentEditor/editorTabs/AdvancedOptions/AdvancedOptionsNavigation/AdvancedOptionsNavigation.scss
@@ -19,3 +19,7 @@
 
     padding-right: 28px;
 }
+
+.menuItemChipNoWidth {
+  width: unset;
+}

--- a/src/javascript/ContentEditor/editorTabs/AdvancedOptions/AdvancedOptionsNavigation/AdvancedOptionsNavigation.scss
+++ b/src/javascript/ContentEditor/editorTabs/AdvancedOptions/AdvancedOptionsNavigation/AdvancedOptionsNavigation.scss
@@ -21,5 +21,5 @@
 }
 
 .menuItemChipNoWidth {
-  width: unset;
+    width: unset;
 }

--- a/src/javascript/UsagesTable/UsagesTable.jsx
+++ b/src/javascript/UsagesTable/UsagesTable.jsx
@@ -70,7 +70,7 @@ export const UsagesTable = ({path, language}) => {
     }
 
     let externalUsagesWarning = null;
-    const visibleUsages = data?.jcr?.nodeByPath?.usages?.pageInfo?.totalCount;
+    const visibleUsages = usages.reduce((prev, current) => prev + current.locales.length, 0);
 
     if (Number.isInteger(usagesCount) && Number.isInteger(visibleUsages) && usagesCount !== visibleUsages) {
         externalUsagesWarning = (

--- a/tests/cypress/e2e/contentEditor/usagesScreen.cy.ts
+++ b/tests/cypress/e2e/contentEditor/usagesScreen.cy.ts
@@ -26,12 +26,12 @@ describe('Create content tests', () => {
         deleteSite(usagesSite);
     });
 
-    it('display 16 usages', () => {
+    it('display 18 usages', () => {
         jcontent = JContent.visit('digitall', 'en', 'media/files/images/backgrounds');
         jcontent.switchToListMode().getTable().getRowByLabel('boy-father.jpg').contextMenu().select('Edit');
         const contentEditor = new ContentEditor();
         const advancedOptions = contentEditor.switchToAdvancedOptions();
-        advancedOptions.checkOption('Usages', '16');
+        advancedOptions.checkOption('Usages', '18');
         advancedOptions.switchToOption('Usages');
         cy.get('table[data-cm-role="table-usages-list"]').as('usagesTable').should('be.visible');
         cy.get('@usagesTable').find('tbody > tr').should('have.length', 10);
@@ -44,7 +44,7 @@ describe('Create content tests', () => {
         // ContentEditor.cancel();
     });
 
-    it('displays 31 usages and restriction message', () => {
+    it('displays 35 usages and restriction message', () => {
         createSite(usagesSite);
         cy.apollo({
             mutationFile: 'contentEditor/usages/createUsages.graphql',
@@ -58,7 +58,7 @@ describe('Create content tests', () => {
         jcontent.switchToListMode().getTable().getRowByLabel('boy-father.jpg').contextMenu().select('Edit');
         const contentEditor = new ContentEditor();
         const advancedOptions = contentEditor.switchToAdvancedOptions();
-        advancedOptions.checkOption('Usages', '31');
+        advancedOptions.checkOption('Usages', '35');
         advancedOptions.switchToOption('Usages');
         cy.get('table[data-cm-role="table-usages-list"]').as('usagesTable').should('be.visible');
         cy.get('@usagesTable').find('tbody > tr').should('have.length', 10);

--- a/tests/cypress/fixtures/contentEditor/usages/createUsages.graphql
+++ b/tests/cypress/fixtures/contentEditor/usages/createUsages.graphql
@@ -9,6 +9,8 @@ mutation($pathOrId: String!) {
                             primaryNodeType: "jnt:imageReferenceLink"
                             properties: [
                                 { name: "j:node", language: "en", type: REFERENCE, value: "/sites/digitall/files/images/backgrounds/boy-father.jpg" },
+                                { name: "j:node", language: "de", type: REFERENCE, value: "/sites/digitall/files/images/backgrounds/boy-father.jpg" },
+                                { name: "j:node", language: "fr", type: REFERENCE, value: "/sites/digitall/files/images/backgrounds/boy-father.jpg" },
                                 { name: "j:linkType", value: "none"}
                             ]
                         },


### PR DESCRIPTION
### Description
Cound locale nodes when calculating visibility. It is necessary as a node can be referenced in multiple languages.
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
