### PR TITLE
fix: use the correct design when ReferenceCard is in error

### DIFF
--- a/src/javascript/ContentEditor/DesignSystem/ReferenceCard/ReferenceCard.jsx
+++ b/src/javascript/ContentEditor/DesignSystem/ReferenceCard/ReferenceCard.jsx
@@ -28,6 +28,23 @@ const ReferenceCardCmp = ({
     cardAction,
     ...props
 }) => {
+    // If card is in error state
+    if (isError) {
+        return (
+            <CardSelector
+                id={id}
+                className={clsx(styles.referenceCard, className)}
+                isReadOnly={isReadOnly}
+                hasError={isError}
+                errorMessage={emptyLabel}
+                data-sel-field-picker="error"
+                data-sel-field-picker-action="openPicker"
+                onClick={onClick}
+                {...props}
+            />
+        );
+    }
+
     // If card have already data
     if (fieldData) {
         return (


### PR DESCRIPTION
### Description
Display the correct design when the `ReferenceCard` is in error
- Use the correct moonstone component
- Add `data-sel-field-picker="error"` when the component is in error


### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
