### PR TITLE
fix: Use fallback MIME type when uploading files via dialog

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.utils.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.utils.js
@@ -1,12 +1,13 @@
 import imageExtensions from 'image-extensions';
 import JContentConstants from '~/JContent/JContent.constants';
 import mime from 'mime';
+import {DEFAULT_MIME_TYPE} from '~/JContent/ContentRoute/ContentLayout/Upload/Upload.utils';
 const imageExtensionSet = new Set(imageExtensions);
 
 export const isBrowserImage = node => {
     if (node.isFile) {
         const mimetype = node.content === undefined ? node.resourceChildren.nodes[0].mimeType.value : node.content.mimeType.value;
-        if (mimetype === 'application/binary' || mimetype === 'application/octet-stream') {
+        if (mimetype === 'application/binary' || mimetype === DEFAULT_MIME_TYPE) {
             switch (node.path.split('.').pop().toLowerCase()) {
                 case 'avif':
                 case 'png':
@@ -36,7 +37,7 @@ export const isImageFile = filename => {
 export const isPDF = node => {
     if (node.isFile) {
         const mimetype = node.content === undefined ? node.resourceChildren.nodes[0].mimeType.value : node.content.mimeType.value;
-        if (mimetype === 'application/binary' || mimetype === 'application/octet-stream') {
+        if (mimetype === 'application/binary' || mimetype === DEFAULT_MIME_TYPE) {
             if (node.path.split('.').pop().toLowerCase() === 'pdf') {
                 return true;
             }
@@ -53,7 +54,7 @@ export const isPDF = node => {
 export const getFileExtension = node => {
     if (node.isFile) {
         const mimetype = node.content === undefined ? node.resourceChildren.nodes[0].mimeType.value : node.content.mimeType.value;
-        if (mimetype === 'application/binary' || mimetype === 'application/octet-stream') {
+        if (mimetype === 'application/binary' || mimetype === DEFAULT_MIME_TYPE) {
             return node.path.split('.').pop().toLowerCase();
         }
 
@@ -98,5 +99,13 @@ export const isInSearchMode = mode => JContentConstants.mode.SQL2SEARCH === mode
 // Note that as with the browsers spoofing is a possibility.
 export const getUploadedFileMimeType = file => {
     const type = file.name.includes('.') ? mime.getType(file.name) : null;
-    return type || file.type;
+    if (type) {
+        return type;
+    }
+
+    if (file.type && file.type !== 'null') {
+        return file.type;
+    }
+
+    return DEFAULT_MIME_TYPE;
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/Upload/Upload.utils.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/Upload/Upload.utils.js
@@ -10,6 +10,7 @@ import {
 import JContentConstants from '~/JContent/JContent.constants';
 
 const IGNORED_FILES = ['.DS_Store', '.localized'];
+export const DEFAULT_MIME_TYPE = 'application/octet-stream';
 
 export const onFilesSelected = ({acceptedFiles, dispatchBatch, type, additionalActions = []}) => {
     if (acceptedFiles.length > 0) {

--- a/src/javascript/JContent/dnd/useFileDrop.jsx
+++ b/src/javascript/JContent/dnd/useFileDrop.jsx
@@ -9,6 +9,7 @@ import {NativeTypes} from 'react-dnd-html5-backend';
 import JContentConstants from '~/JContent/JContent.constants';
 import {
     createMissingFolders,
+    DEFAULT_MIME_TYPE,
     fileIgnored,
     fileMatchSize,
     onFilesSelected
@@ -20,8 +21,6 @@ import {batchActions} from 'redux-batched-actions';
 import mime from 'mime';
 
 const ACCEPTING_NODE_TYPES = ['jnt:folder', 'jnt:contentFolder'];
-
-const DEFAULT_MIME_TYPE = 'application/octet-stream';
 
 async function scan({fileList, uploadMaxSize, uploadMinSize, uploadFilter, uploadPath}) {
     const files = [];

--- a/tests/cypress/page-object/file.ts
+++ b/tests/cypress/page-object/file.ts
@@ -5,29 +5,21 @@ import {JContent} from './jcontent';
 
 export class File extends BasePage {
     media: Media;
-    fileName : string;
+    fileName: string;
 
-    constructor(media: Media, fileName : string) {
+    constructor(media: Media, fileName: string) {
         super();
         this.media = media;
         this.fileName = fileName;
     }
 
-    dndUpload(selector : string) : File {
+    dndUpload(selector: string): File {
         cy.get(selector).parent().selectFile({
             contents: Cypress.Buffer.from('file contents'),
             fileName: this.fileName,
             mimeType: 'text/plain',
             lastModified: Date.now()
         }, {action: 'drag-drop'});
-        // The wait is very important otherwise the upload will never complete
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(1000);
-        return this;
-    }
-
-    dndUploadFromFixtures(selector: string, subFolder: string = '.'): File {
-        cy.get(selector).parent().selectFile(`cypress/fixtures/${subFolder}/${this.fileName}`, {action: 'drag-drop'});
         // The wait is very important otherwise the upload will never complete
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(1000);
@@ -42,7 +34,7 @@ export class File extends BasePage {
         return this.getUploadStatus().find('[data-sel-role="upload-error-msg"]').contains(msg);
     }
 
-    download() : File {
+    download(): File {
         this.getGridCard().contextMenu().selectByRole('downloadFile');
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(500);
@@ -74,7 +66,7 @@ export class File extends BasePage {
         return this;
     }
 
-    rename(newFileName : string) : File {
+    rename(newFileName: string): File {
         this.getGridCard().threeDotsMenu().selectByRole('rename');
         cy.get('input#folder-name').clear();
         cy.get('input#folder-name').type(newFileName);
@@ -83,7 +75,7 @@ export class File extends BasePage {
         return this;
     }
 
-    renameAfterUpload(newFileName : string) : File {
+    renameAfterUpload(newFileName: string): File {
         getComponentByAttr(Button, 'data-cm-role', 'upload-rename').get().click();
         getComponentByAttr(Button, 'data-cm-role', 'rename-dialog').get().should('be.disabled');
         cy.get('input#rename-dialog-text').clear();
@@ -93,7 +85,7 @@ export class File extends BasePage {
         return this;
     }
 
-    markForDeletion() : File {
+    markForDeletion(): File {
         this.getGridCard().contextMenu().selectByRole('delete');
         cy.get('[data-sel-role="delete-mark-button"]').click();
         // Verify dialog has been dismissed before proceeding
@@ -101,7 +93,7 @@ export class File extends BasePage {
         return this;
     }
 
-    deletePermanently() : File {
+    deletePermanently(): File {
         // Delete the folder we just created permanently
         this.getGridCard().contextMenu().selectByRole('deletePermanently');
         cy.get('[data-sel-role="delete-permanently-button"]').click();

--- a/tests/cypress/page-object/media.ts
+++ b/tests/cypress/page-object/media.ts
@@ -22,14 +22,14 @@ export class Media extends BasePage {
         return this;
     }
 
-    createFolder(parentPath : string, folderName : string) : Folder {
+    createFolder(parentPath: string, folderName: string): Folder {
         getComponentByRole(Button, 'createFolder').click();
         getElement('input#folder-name').type(folderName);
         getComponentByAttr(Button, 'data-cm-role', 'create-folder-as-confirm').click();
         return new Folder(this, parentPath, folderName);
     }
 
-    createInvalidFolder(parentPath : string, folderName : string) : Media {
+    createInvalidFolder(parentPath: string, folderName: string): Media {
         getComponentByRole(Button, 'createFolder').click();
         getElement('input#folder-name').type(folderName);
         cy.get('#folder-name-helper-text').should('contain', 'Invalid characters');
@@ -37,8 +37,27 @@ export class Media extends BasePage {
         return this;
     }
 
-    createFile(fileName : string) : File {
+    createFile(fileName: string): File {
         return new File(this, fileName);
+    }
+
+    uploadFileViaDragAndDrop(fileName: string, fixtureSubFolder: string): File {
+        cy.get('div[data-sel-role-card=bootstrap]').parent().selectFile(`cypress/fixtures/${fixtureSubFolder}/${fileName}`, {action: 'drag-drop'});
+        this.waitForUploadToComplete();
+        return new File(this, fileName);
+    }
+
+    uploadFileViaDialog(fileName: string, fixtureSubFolder: string = '.'): File {
+        cy.get('button[data-sel-role="fileUpload"]').should('be.visible').click();
+        cy.get('input#file-upload-input[type="file"]').selectFile(`cypress/fixtures/${fixtureSubFolder}/${fileName}`, {force: true});
+        this.waitForUploadToComplete();
+        return new File(this, fileName);
+    }
+
+    private waitForUploadToComplete(): void {
+        cy.get('[data-cm-role="upload-status-success"]').should('be.visible');
+        cy.get('[data-cm-role="upload-close-button"]').click();
+        cy.get('[data-cm-role="upload-status-success"]').should('not.be.visible');
     }
 
     switchView(displayMode: 'list' | 'grid') {


### PR DESCRIPTION
Closes https://github.com/Jahia/jahia-private/issues/3768.
### Description
Follows https://github.com/Jahia/jcontent/pull/1911 that only covers the "drag & drop" upload workflow, but not the one with the "Upload file(s)" button (and its dialog).
Refactor the code to use the new `DEFAULT_MIME_TYPE` constant.
Moving `File.dndUploadFromFixtures()` to `Media.uploadFileViaDragAndDrop()` so there is no longer a need to create a (dummy) `File` before being able to drag and drop.

### Checklist

#### Tests
- [x] I've provided Unit and/or Integration Tests

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
