### PR TITLE
fix: Translation action fixes

### DIFF
--- a/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/CopyLanguageDialog.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/CopyLanguageDialog.jsx
@@ -60,7 +60,10 @@ export const CopyLanguageDialog = ({
     const handleApply = () => {
         getDataFromSelectedLanguage(currentOption.value).then(data => {
             for (const [key, value] of Object.entries(data)) {
-                formik.setFieldValue(key, value);
+                // Set to empty string if value is null or undefined to ensure field is cleared
+                // This is necessary to avoid issues with formik not updating the field if the value is null
+                // or undefined, as it will not trigger a change event
+                formik.setFieldValue(key, value || '');
             }
         });
 

--- a/src/javascript/ContentEditor/actions/contenteditor/save/saveAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/save/saveAction.jsx
@@ -15,7 +15,7 @@ import {isDirty, useKeydownListener} from '~/ContentEditor/utils';
 const Save = ({render: Render, loading: Loading, ...otherProps}) => {
     const componentRenderer = useContext(ComponentRendererContext);
     const {publicationInfoPolling} = usePublicationInfoContext();
-    const {mode, i18nContext, siteInfo, lang, resetI18nContext, setErrors} = useContentEditorContext();
+    const {mode, i18nContext, siteInfo, lang, resetI18nContext, setErrors, nodeData} = useContentEditorContext();
     const {onSavedCallback} = useContentEditorConfigContext();
     const {sections} = useContentEditorSectionContext();
     const formik = useFormikContext();
@@ -63,7 +63,7 @@ const Save = ({render: Render, loading: Loading, ...otherProps}) => {
             {...otherProps}
             hasWarningBadge={Object.keys(formik.errors).length > 0}
             isVisible={mode === Constants.routes.baseEditRoute}
-            disabled={!dirty || publicationInfoPolling}
+            disabled={!dirty || publicationInfoPolling || !nodeData.hasWritePermission || nodeData.lockedAndCannotBeEdited}
             onClick={() => save(formik)}
         />
     );

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/SourceContentPanel.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/SourceContentPanel.jsx
@@ -25,7 +25,9 @@ export const SourceContentPanel = () => {
             ...ceConfigContext.sideBySideContext,
             enabled: true,
             readOnly: true,
-            translateLang: ceConfigContext.lang
+            translateLang: ceConfigContext.lang,
+            hasWritePermission: ceContext.nodeData?.hasWritePermission,
+            lockedAndCannotBeEdited: ceContext.nodeData?.lockedAndCannotBeEdited
         }
     };
 

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/translateAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/translateAction.jsx
@@ -18,7 +18,7 @@ export const TranslateActionComponent = ({path, render: Render, ...otherProps}) 
     const sourceLang = languages.find(l => l.language !== lang) || languages[0];
     return (res.loading) ? null : (
         <Render {...otherProps}
-                enabled={languages.length > 2}
+                enabled={languages.length > 1}
                 onClick={() => {
                     api.edit({
                         uuid: res.node.uuid,

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/translateFieldAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/translateFieldAction.jsx
@@ -8,7 +8,7 @@ export const TranslateFieldActionComponent = ({field, value, render: Render}) =>
     const {sideBySideContext} = useContentEditorConfigContext();
     const {setI18nContext} = useContentEditorContext();
 
-    const {enabled, translateLang} = sideBySideContext || {};
+    const {enabled, translateLang, hasWritePermission, lockedAndCannotBeEdited} = sideBySideContext || {};
     if (!enabled || !field.i18n || !translateLang) {
         return <div className={styles.spacing}/>;
     }
@@ -22,7 +22,6 @@ export const TranslateFieldActionComponent = ({field, value, render: Render}) =>
                 [translateLang]: {
                     ...prev[translateLang],
                     values: {
-                        ...prev[translateLang]?.values,
                         [field.name]: value
                     },
                     validation: {
@@ -39,7 +38,7 @@ export const TranslateFieldActionComponent = ({field, value, render: Render}) =>
         <div className={styles.translate}>
             <Render
               buttonIcon={<ArrowRight/>}
-              enabled={Boolean(value)}
+              enabled={Boolean(value) && hasWritePermission && !lockedAndCannotBeEdited}
               dataSelRole="translate-field"
               buttonProps={{
                   variant: 'ghost',

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/useTranslateFormDefinition.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/useTranslateFormDefinition.jsx
@@ -9,6 +9,12 @@ export const useTranslateFormDefinition = () => {
         // Display only content and SEO sections in the translation panel
         data.sections = data.sections.filter(s => ['content', 'seo'].includes(s.name));
         data.sections?.forEach(section => {
+            // Expand all sections by default in translation mode
+            section.expanded = true;
+            if (data.expandedSections) {
+                data.expandedSections[section.name] = true;
+            }
+
             section.fieldSets?.forEach(fieldSet => {
                 fieldSet.fields.filter(field => !field.i18n).forEach(f => {
                     f.readOnly = true;

--- a/src/javascript/ContentEditor/actions/registerEditActions.js
+++ b/src/javascript/ContentEditor/actions/registerEditActions.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {saveAction} from './contenteditor/save/saveAction';
 import {publishAction} from './contenteditor/publish/publishAction';
 import {startWorkflowAction} from './contenteditor/startWorkflow/startWorkflowAction';
-import {AdvancedEdit, ArrowRight, CloudUpload, Copy, Edit, Language, MoreVert, Save, WorkInProgress} from '@jahia/moonstone';
+import {AdvancedEdit, ArrowRight, CloudUpload, Copy, Edit, MoreVert, Save, Translate, WorkInProgress} from '@jahia/moonstone';
 import {editContentAction} from './jcontent/editContent/editContentAction';
 import {openWorkInProgressAction} from './contenteditor/openWorkInProgress/openWorkInProgressAction';
 import {copyLanguageAction} from './contenteditor/copyLanguage/copyLanguageAction';
@@ -115,7 +115,7 @@ export const registerEditActions = registry => {
     });
 
     registry.add('action', 'sbsTranslate', translateAction, {
-        buttonIcon: <Language/>,
+        buttonIcon: <Translate/>,
         buttonLabel: 'jcontent:label.contentEditor.edit.action.translate.name',
         dataSelRole: 'sbsTranslate',
         requiredSitePermission: ['editAction']

--- a/src/javascript/JContent.assignActionAndMenuTargets.js
+++ b/src/javascript/JContent.assignActionAndMenuTargets.js
@@ -155,6 +155,7 @@ const actionTargetAssignments = {
         'editAdvanced',
         'editPage',
         'editPageAdvanced',
+        'sbsTranslate',
         'editSource',
         'editImage',
         'replaceFile',


### PR DESCRIPTION
### Description

- Add translate action to 3-dots content menu
- Change translate icon
- Fix language count check for enabling translate action
- Fix permission checks for translate field action
  - I also added checks on the actual save button for write and lock permissions
- Expand all sections
- Fix copy-from bug where copying empty values are not being saved correctly

Note: separate task to be done for adding translation cypress tests

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
