### PR TITLE
chore: Release JContent test module v3.4.0-tests.3

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jahia/jcontent-cypress",
   "private": false,
-  "version": "3.4.0-tests.2",
+  "version": "3.4.0-tests.3",
   "scripts": {
     "instrument": "nyc instrument --compact=false cypress instrumented",
     "e2e:ci": "cypress run --browser chrome",


### PR DESCRIPTION
Closes https://github.com/Jahia/javascript-modules/issues/405.
Required by https://github.com/Jahia/jahia-ee/pull/874.

### Description
Following the publication of https://www.npmjs.com/package/@jahia/jcontent-cypress/v/3.4.0-tests.3 (done via https://github.com/Jahia/jcontent/actions/runs/16826462538/job/47663985844), merge the bump of version into master  (until https://github.com/Jahia/jcontent/issues/1691 gets addressed).


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
