### PR TITLE
test: Fix selector in ChoiceListField.addNewValue()

### DIFF
--- a/tests/cypress/page-object/fields/choiceListField.ts
+++ b/tests/cypress/page-object/fields/choiceListField.ts
@@ -1,4 +1,4 @@
-import {Dropdown, getComponent, getComponentByRole, Menu} from '@jahia/cypress';
+import {Dropdown, getComponent, getComponentBySelector, Menu} from '@jahia/cypress';
 import {Field} from './field';
 
 export class ChoiceListField extends Field {
@@ -8,7 +8,7 @@ export class ChoiceListField extends Field {
      */
     addNewValue(value: string): void {
         this.get().click();
-        getComponentByRole(Menu, 'list').selectByValue(value);
+        getComponentBySelector(Menu, '[role="list"]').selectByValue(value);
     }
 
     /**


### PR DESCRIPTION
### Description
Fix the selector used in `ChoiceListField.addNewValue()` that is currently breaking the test `Extend Mixins tests with CE Does not apply extend mixin on create`. See https://github.com/Jahia/jcontent/actions/runs/16782132722/job/47523843006.

In https://github.com/Jahia/jcontent/pull/1941, the following code:
```
getComponentBySelector(Menu, '[role="list"]').selectByValue(value);
```
got replaced by mistake with:
```
getComponentByRole(Menu, 'list').selectByValue(value);
```

Which is a different way to retrieve the component.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
