### PR TITLE
feat: Add new target for translate UI header actions; Add translate action to edit header

### DIFF
--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/EditPanelHeader.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/EditPanelHeader.jsx
@@ -38,7 +38,7 @@ const BackButtonRenderer = getButtonRenderer({
     noIcon: true
 });
 
-export const EditPanelHeader = ({title, isShowPublish, hideLanguageSwitcher, activeTabState}) => {
+export const EditPanelHeader = ({title, isShowPublish, hideLanguageSwitcher, activeTabState, targetActionKey = 'content-editor/header/3dots'}) => {
     const {nodeData, nodeTypeName, nodeTypeDisplayName, mode} = useContentEditorContext();
     const {t} = useTranslation('jcontent');
     const [activeTab, setActiveTab] = activeTabState || [];
@@ -105,8 +105,8 @@ export const EditPanelHeader = ({title, isShowPublish, hideLanguageSwitcher, act
                             </>
                         )}
 
-                        <HeaderButtonActions/>
-                        <HeaderThreeDotsActions/>
+                        <HeaderButtonActions targetActionKey={targetActionKey}/>
+                        <HeaderThreeDotsActions targetActionKey={targetActionKey}/>
                     </div>
                 )}
                 status={<HeaderBadges mode={mode}/>}
@@ -123,5 +123,6 @@ EditPanelHeader.propTypes = {
             0: PropTypes.string.isRequired,
             1: PropTypes.func.isRequired
         })
-    )
+    ),
+    targetActionKey: PropTypes.string
 };

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderActions/HeaderButtonActions.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderActions/HeaderButtonActions.jsx
@@ -38,6 +38,6 @@ const HeaderButtonActions = ({targetActionKey}) => {
 
 HeaderButtonActions.propTypes = {
     targetActionKey: PropTypes.string.isRequired
-}
+};
 
 export default HeaderButtonActions;

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderActions/HeaderButtonActions.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderActions/HeaderButtonActions.jsx
@@ -3,6 +3,7 @@ import {DisplayAction} from '@jahia/ui-extender';
 import {getButtonRenderer} from '~/utils/getButtonRenderer';
 import styles from './HeaderButtonActions.scss';
 import {getButtonLimitValue, getMenuActions} from './utils.headerActions';
+import PropTypes from 'prop-types';
 
 const ButtonRenderer = getButtonRenderer({
     defaultButtonProps: {
@@ -11,9 +12,9 @@ const ButtonRenderer = getButtonRenderer({
     }
 });
 
-const HeaderButtonActions = () => {
+const HeaderButtonActions = ({targetActionKey}) => {
     const limit = getButtonLimitValue();
-    const actionsToDisplay = getMenuActions(0, limit);
+    const actionsToDisplay = getMenuActions(0, limit, targetActionKey);
 
     if (actionsToDisplay.length === 0) {
         return null;
@@ -34,5 +35,9 @@ const HeaderButtonActions = () => {
         </div>
     );
 };
+
+HeaderButtonActions.propTypes = {
+    targetActionKey: PropTypes.string.isRequired
+}
 
 export default HeaderButtonActions;

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderActions/HeaderThreeDotsActions.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderActions/HeaderThreeDotsActions.jsx
@@ -43,6 +43,6 @@ const HeaderThreeDotsActions = ({targetActionKey}) => {
 
 HeaderThreeDotsActions.propTypes = {
     targetActionKey: PropTypes.string.isRequired
-}
+};
 
 export default HeaderThreeDotsActions;

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderActions/HeaderThreeDotsActions.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderActions/HeaderThreeDotsActions.jsx
@@ -3,12 +3,13 @@ import {DisplayAction} from '@jahia/ui-extender';
 import {Button, Menu, MoreVert} from '@jahia/moonstone';
 import {MenuItemRenderer} from '~/JContent/MenuItemRenderer';
 import {getButtonLimitValue, getMenuActions} from './utils.headerActions';
+import PropTypes from 'prop-types';
 
-const HeaderThreeDotsActions = () => {
+const HeaderThreeDotsActions = ({targetActionKey}) => {
     const menuContainerRef = React.useRef(null);
     const [anchorEl, setAnchorEl] = useState(null);
     const limit = getButtonLimitValue();
-    const actionsToDisplay = getMenuActions(limit, 99);
+    const actionsToDisplay = getMenuActions(limit, 99, targetActionKey);
 
     if (actionsToDisplay.length === 0) {
         return null;
@@ -39,5 +40,9 @@ const HeaderThreeDotsActions = () => {
         </div>
     );
 };
+
+HeaderThreeDotsActions.propTypes = {
+    targetActionKey: PropTypes.string.isRequired
+}
 
 export default HeaderThreeDotsActions;

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderActions/utils.headerActions.js
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderActions/utils.headerActions.js
@@ -7,9 +7,9 @@ export const getButtonLimitValue = () => {
     return isNaN(parsedValue) ? 5 : parsedValue; // Default is 5 quick buttons
 };
 
-export const getMenuActions = (offset, limit) => {
+export const getMenuActions = (offset, limit, actionTarget = 'content-editor/header/3dots') => {
     return registry
-        .find({type: 'action', target: 'content-editor/header/3dots'})
+        .find({type: 'action', target: actionTarget})
         .filter((action, index) =>
             index >= offset && index < (offset + limit))
         .map(action => action.key);

--- a/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/copyLanguageAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/copyLanguageAction.jsx
@@ -14,7 +14,7 @@ export const CopyLanguageActionComponent = ({render: Render, ...otherProps}) => 
 
     return (
         <Render {...otherProps}
-                enabled={siteInfo.languages.length > 1 && nodeData.hasWritePermission && !nodeData.lockedAndCannotBeEdited}
+                isVisible={siteInfo.languages.length > 1 && nodeData.hasWritePermission && !nodeData.lockedAndCannotBeEdited}
                 onClick={() => {
                     render('CopyLanguageDialog', CopyLanguageDialog, {
                         isOpen: true,

--- a/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/copyLanguageAction.spec.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/copyLanguageAction.spec.jsx
@@ -58,17 +58,17 @@ describe('copy language action', () => {
         expect(cmp.props().enabled).toBeFalsy();
     });
 
-    it('should render be enabled when there is more than one language', () => {
+    it('should be visible when there is more than one language', () => {
         const cmp = shallowWithTheme(
             <CopyLanguageActionComponent {...defaultProps}/>,
             {},
             dsGenericTheme
         );
 
-        expect(cmp.props().enabled).toBeTruthy();
+        expect(cmp.props().isVisible).toBeTruthy();
     });
 
-    it('should render not be enabled when there is only one language', () => {
+    it('should not be visible when there is only one language', () => {
         contentEditorContext.language = 'en';
         contentEditorContext.siteInfo.languages = [
             {displayName: 'English', language: 'en', activeInEdit: true}
@@ -78,7 +78,7 @@ describe('copy language action', () => {
             dsGenericTheme
         );
 
-        expect(cmp.props().enabled).toBeFalsy();
+        expect(cmp.props().isVisible).toBeFalsy();
     });
 
     it('should destroy copy language dialog when onCloseDialog has been called', () => {

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/TranslatePanel.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/TranslatePanel.jsx
@@ -42,7 +42,7 @@ export const TranslatePanel = ({title}) => {
             className={styles.layoutContent}
             hasPadding={false}
             header={(
-                <EditPanelHeader hideLanguageSwitcher title={title}/>
+                <EditPanelHeader hideLanguageSwitcher title={title} targetActionKey='translate/header/3dots'/>
             )}
             content={(
                 <TwoPanelsContent

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/TranslatePanel.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/TranslatePanel.jsx
@@ -42,7 +42,7 @@ export const TranslatePanel = ({title}) => {
             className={styles.layoutContent}
             hasPadding={false}
             header={(
-                <EditPanelHeader hideLanguageSwitcher title={title} targetActionKey='translate/header/3dots'/>
+                <EditPanelHeader hideLanguageSwitcher title={title} targetActionKey="translate/header/3dots"/>
             )}
             content={(
                 <TwoPanelsContent

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/index.js
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/index.js
@@ -1,2 +1,3 @@
 export {translateAction} from './translateAction';
+export {translateEditAction} from './translateEditAction';
 export {translateFieldAction} from './translateFieldAction';

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/translateEditAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/translateEditAction.jsx
@@ -6,7 +6,7 @@ import {useTranslateFormDefinition} from './useTranslateFormDefinition';
 
 export const TranslateEditActionComponent = ({path, render: Render, ...otherProps}) => {
     const api = useContentEditorApiContext();
-    const {nodeData, lang, siteInfo, refetchFormData} = useContentEditorContext();
+    const {nodeData, lang, siteInfo} = useContentEditorContext();
 
     const languages = siteInfo.languages?.filter(l => l.activeInEdit) || [];
     const sourceLang = languages.find(l => l.language !== lang) || languages[0];

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/translateEditAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/translateEditAction.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {useContentEditorApiContext, useContentEditorContext} from '~/ContentEditor/contexts';
+import {TranslatePanel} from './TranslatePanel';
+import {useTranslateFormDefinition} from './useTranslateFormDefinition';
+
+export const TranslateEditActionComponent = ({path, render: Render, ...otherProps}) => {
+    const api = useContentEditorApiContext();
+    const {nodeData, lang, siteInfo, refetchFormData} = useContentEditorContext();
+
+    const languages = siteInfo.languages?.filter(l => l.activeInEdit) || [];
+    const sourceLang = languages.find(l => l.language !== lang) || languages[0];
+
+    return (
+        <Render {...otherProps}
+                isVisible={languages.length > 1}
+                onClick={() => {
+                    api.edit({
+                        uuid: nodeData.uuid,
+                        lang: sourceLang.language,
+                        isFullscreen: true,
+                        dialogProps: {
+                            classes: {}
+                        },
+                        sideBySideContext: {lang},
+                        layout: TranslatePanel,
+                        useFormDefinition: useTranslateFormDefinition
+                    });
+                }}
+        />
+    );
+};
+
+TranslateEditActionComponent.propTypes = {
+    render: PropTypes.func.isRequired,
+    path: PropTypes.string.isRequired
+};
+
+export const translateEditAction = {
+    component: TranslateEditActionComponent
+};

--- a/src/javascript/ContentEditor/actions/registerEditActions.js
+++ b/src/javascript/ContentEditor/actions/registerEditActions.js
@@ -7,8 +7,7 @@ import {editContentAction} from './jcontent/editContent/editContentAction';
 import {openWorkInProgressAction} from './contenteditor/openWorkInProgress/openWorkInProgressAction';
 import {copyLanguageAction} from './contenteditor/copyLanguage/copyLanguageAction';
 import {editContentSourceAction} from '~/ContentEditor/actions/jcontent/editContent/editContentSourceAction';
-import {translateAction} from './contenteditor/translate/translateAction';
-import {translateFieldAction} from './contenteditor/translate';
+import {translateFieldAction, translateAction, translateEditAction} from './contenteditor/translate';
 
 export const registerEditActions = registry => {
     // Edit action button in JContent; need separate actions for content and pages
@@ -120,6 +119,12 @@ export const registerEditActions = registry => {
     registry.add('action', 'copyLanguageAction', copyLanguageAction, {
         buttonIcon: <Copy/>,
         buttonLabel: 'jcontent:label.contentEditor.edit.action.copyLanguage.name'
+    });
+
+    registry.add('action', 'sbsTranslateEdit', translateEditAction, {
+        buttonIcon: <Translate/>,
+        buttonLabel: 'jcontent:label.contentEditor.edit.action.translate.name',
+        dataSelRole: 'sbsTranslateEdit',
     });
 
     registry.add('action', 'sbsTranslate', translateAction, {

--- a/src/javascript/ContentEditor/actions/registerEditActions.js
+++ b/src/javascript/ContentEditor/actions/registerEditActions.js
@@ -95,6 +95,14 @@ export const registerEditActions = registry => {
         dataSelRole: '3dotsMenuAction'
     });
 
+    /* SBS translate 3-dots/header actions */
+    registry.add('action', 'translate/header/3dots', registry.get('action', 'menuAction'), {
+        buttonIcon: <MoreVert/>,
+        buttonLabel: 'jcontent:label.contentEditor.edit.action.moreOptions',
+        menuTarget: 'translate/header/3dots',
+        dataSelRole: '3dotsMenuAction'
+    });
+
     /* 3 dots menu actions (for each field) */
     registry.add('action', 'content-editor/field/3dots', registry.get('action', 'menuAction'), {
         buttonIcon: <MoreVert/>,

--- a/src/javascript/ContentEditor/actions/registerEditActions.js
+++ b/src/javascript/ContentEditor/actions/registerEditActions.js
@@ -124,7 +124,7 @@ export const registerEditActions = registry => {
     registry.add('action', 'sbsTranslateEdit', translateEditAction, {
         buttonIcon: <Translate/>,
         buttonLabel: 'jcontent:label.contentEditor.edit.action.translate.name',
-        dataSelRole: 'sbsTranslateEdit',
+        dataSelRole: 'sbsTranslateEdit'
     });
 
     registry.add('action', 'sbsTranslate', translateAction, {

--- a/src/javascript/JContent.assignActionAndMenuTargets.js
+++ b/src/javascript/JContent.assignActionAndMenuTargets.js
@@ -356,6 +356,7 @@ const actionTargetAssignments = {
     ],
     'content-editor/header/3dots': [
         'goToWorkInProgress',
+        'sbsTranslateEdit',
         'copyLanguageAction'
     ],
     'translate/header/3dots': [

--- a/src/javascript/JContent.assignActionAndMenuTargets.js
+++ b/src/javascript/JContent.assignActionAndMenuTargets.js
@@ -357,6 +357,10 @@ const actionTargetAssignments = {
     'content-editor/header/3dots': [
         'goToWorkInProgress',
         'copyLanguageAction'
+    ],
+    'translate/header/3dots': [
+        'goToWorkInProgress',
+        'copyLanguageAction'
     ]
 };
 


### PR DESCRIPTION
### Description

#### Add new target for translate UI header actions: `translate/header/3dots`
  - Refactored edit header components to be able to pass this target action key depending on the edit UI
  - WIP and copy language has been added to new translate header target
  - CTOL and deepl actions would also need to be migrated to add to this translate header target
 
#### Add translate action to edit header
   - Created separate action for opening translate UI within edit modal
   - We use current selected language as source language 
   - Modified copy from and translate actions in header to not be visible when language < 2 (applies on both edit and translate UI headers)

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
