### PR TITLE
chore: Remove translate edit action in CE header

### DIFF
--- a/src/javascript/JContent.assignActionAndMenuTargets.js
+++ b/src/javascript/JContent.assignActionAndMenuTargets.js
@@ -356,7 +356,6 @@ const actionTargetAssignments = {
     ],
     'content-editor/header/3dots': [
         'goToWorkInProgress',
-        'sbsTranslateEdit',
         'copyLanguageAction'
     ],
     'translate/header/3dots': [


### PR DESCRIPTION
### Description

Keeping the implementation for now but only removing translate edit action in the header as we are postponing full implementation for now until next iteration.

