### PR TITLE
fix: Number validation should take into account the type

### DIFF
--- a/src/javascript/ContentEditor/ContentEditor/updateNode/updateNode.js
+++ b/src/javascript/ContentEditor/ContentEditor/updateNode/updateNode.js
@@ -72,6 +72,8 @@ export const updateNode = ({
         refetchPreview(getPreviewPath(info.updatedNode), language);
         return info;
     }, error => {
+        // Log error information as the toast is not very informative
+        console.error(error);
         onServerError(error, actions, i18nContext, language, notificationContext, t, dataToMutate.propFieldNameMapping, 'jcontent:label.contentEditor.edit.action.save.error');
     });
 };

--- a/src/javascript/ContentEditor/validation/validate.js
+++ b/src/javascript/ContentEditor/validation/validate.js
@@ -123,8 +123,6 @@ const rangeFieldValidation = (values, field) => {
             }
         })
         .some(isConstraintRespected => isConstraintRespected === true) ? undefined : 'invalidRange';
-    console.log(r);
-    return r;
 };
 
 const patternFieldValidation = (values, field) => {

--- a/src/javascript/ContentEditor/validation/validate.js
+++ b/src/javascript/ContentEditor/validation/validate.js
@@ -80,7 +80,21 @@ const rangeFieldValidation = (values, field) => {
     // Ok to not validate empty (undefined) values; they are ignored when saving
     fieldValues = fieldValues.filter(value => typeof value !== 'undefined');
     // If one value is invalid, error !
-    if (fieldValues.some(value => isNaN(value))) {
+    // Note that we need to take into consideration value type otherwise user can input 2.3 for LONG
+    const hasInvalidType = fieldValues.some(value => {
+        const num = Number(value);
+        switch (field.requiredType) {
+            case 'LONG':
+                return !Number.isInteger(num);
+            case 'DECIMAL':
+            case 'DOUBLE':
+                return typeof num !== 'number';
+            default:
+                return false;
+        }
+    });
+
+    if (hasInvalidType) {
         return 'invalidNumber';
     }
 
@@ -109,6 +123,8 @@ const rangeFieldValidation = (values, field) => {
             }
         })
         .some(isConstraintRespected => isConstraintRespected === true) ? undefined : 'invalidRange';
+    console.log(r);
+    return r;
 };
 
 const patternFieldValidation = (values, field) => {

--- a/tests/cypress/e2e/contentEditor/numbersValidation.cy.ts
+++ b/tests/cypress/e2e/contentEditor/numbersValidation.cy.ts
@@ -1,0 +1,52 @@
+import {createSite, deleteSite, enableModule} from '@jahia/cypress';
+import {JContent} from '../../page-object';
+import {NumberField} from '../../page-object/fields';
+
+describe('Numbers validation tests', {testIsolation: false}, () => {
+    const siteKey = 'validation';
+    let jcontent : JContent;
+
+    before(function () {
+        createSite(siteKey);
+        enableModule('jcontent-test-module', siteKey);
+        cy.login();
+        jcontent = JContent
+            .visit(siteKey, 'en', 'content-folders/contents')
+            .switchToListMode();
+    });
+
+    after(function () {
+        deleteSite(siteKey);
+    });
+
+    it('gives appropriate feedback for incorrect number types', () => {
+        const ce = jcontent.createContent('cent:numbers');
+        // Required field checked
+        ce.createUnchecked();
+        cy.contains('There is one validation error').find('a').contains('longReq');
+        ce.discardErrorDialog();
+
+        // Incorrect long does not pass validation
+        ce.getField(NumberField, 'cent:numbers_longReq', false).addNewValue('234');
+        ce.getField(NumberField, 'cent:numbers_long', false).addNewValue('2.3');
+        ce.createUnchecked();
+        cy.contains('There is one validation error').find('a').contains('long');
+        ce.discardErrorDialog();
+
+        ce.getField(NumberField, 'cent:numbers_long', false).addNewValue('23');
+        // Note that cypress does not allow to type something like 32.-+323, which would be useful here to test empty value
+        ce.getField(NumberField, 'cent:numbers_longReq', false).addNewValue('32.34');
+        ce.createUnchecked();
+        cy.contains('There is one validation error').find('a').contains('longReq');
+        ce.discardErrorDialog();
+
+        // Content is saved
+        ce.getField(NumberField, 'cent:numbers_longReq', false).addNewValue('234');
+        ce.getField(NumberField, 'cent:numbers_long', false).addNewValue('23');
+        ce.getField(NumberField, 'cent:numbers_double', false).addNewValue('32');
+        ce.createUnchecked();
+
+        cy.contains('There is one validation error').should('not.exist');
+    });
+});
+

--- a/tests/cypress/page-object/contentEditor.ts
+++ b/tests/cypress/page-object/contentEditor.ts
@@ -103,6 +103,10 @@ export class ContentEditor extends BasePage {
         getComponentByRole(Button, 'submitSave').click();
     }
 
+    discardErrorDialog() {
+        getComponentByRole(Button, 'content-type-dialog-cancel').click();
+    }
+
     editSavedContent() {
         cy.get('[role="alertdialog"]').should('be.visible').find('.moonstone-button').click();
     }

--- a/tests/cypress/page-object/fields/index.ts
+++ b/tests/cypress/page-object/fields/index.ts
@@ -5,3 +5,4 @@ export * from './field';
 export * from './pickerField';
 export * from './richTextField';
 export * from './smallTextField';
+export * from './numberField';

--- a/tests/cypress/page-object/fields/numberField.ts
+++ b/tests/cypress/page-object/fields/numberField.ts
@@ -1,0 +1,35 @@
+import {Field} from './field';
+
+export class NumberField extends Field {
+    addNewValue(newValue: string, force = false) {
+        this.get().find('input[type="number"]').as('numberinput');
+        // Prevent field from being hidden by sticky header
+        this.get().scrollIntoView();
+        cy.get('@numberinput').clear({force: force, scrollBehavior: false});
+        cy.get('@numberinput').type(String(newValue), {force: force, scrollBehavior: false});
+        cy.get('@numberinput').should('have.value', String(newValue));
+
+        return this;
+    }
+
+    clearValue(force = false) {
+        this.get().find('input[type="number"]').as('numberinput');
+        // Prevent field from being hidden by sticky header
+        this.get().scrollIntoView();
+        cy.get('@numberinput').clear({force: force, scrollBehavior: false});
+
+        return this;
+    }
+
+    checkValue(expectedValue: string) {
+        return this.get().find('input').last().should('have.value', expectedValue);
+    }
+
+    isReadOnly() {
+        return this.get().find('input').should('have.attr', 'readonly');
+    }
+
+    isNotReadOnly() {
+        return this.get().find('input').should('not.have.attr', 'readonly');
+    }
+}

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -186,3 +186,8 @@
 
 [cent:boundComponent] > jnt:content, jmix:siteComponent, jmix:droppableContent, jmix:bindedComponent
 - text (string, richtext)
+
+[cent:numbers] > jnt:content, mix:title, jmix:basicContent, jmix:editorialContent
+- long (long)
+- double (double)
+- longReq (long) mandatory


### PR DESCRIPTION
### Description
Number validation should take into account the type. Currently it is possible to submit 2.3 for LONG which results in server error but does not give any meaningful feedback to the user. This fix esures the user cannot submit the form if that is the case.

<img width="1060" height="638" alt="Screenshot 2025-08-15 at 7 28 17 AM" src="https://github.com/user-attachments/assets/f343054e-7aff-48ac-aba0-8bca1a8247ab" />


### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
