### PR TITLE
fix: Prevent validation onBlur when editing

### DIFF
--- a/src/javascript/ContentEditor/ContentEditor/Edit.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/Edit.jsx
@@ -67,6 +67,7 @@ export const Edit = () => {
                 <Formik
                     validateOnMount
                     validateOnChange={false}
+                    validateOnBlur={false}
                     initialValues={initialValues}
                     validate={validate(sections)}
                     onSubmit={handleSubmit}


### PR DESCRIPTION
### Description
Prevent validation onBlur when editing. It causes undesired validation when other sections are edited as fields lose focus.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
