### PR TITLE
fix: Add translate site permission checks on translate actions

### DIFF
--- a/src/javascript/ContentEditor/ContentEditor/edit.gql-queries.js
+++ b/src/javascript/ContentEditor/ContentEditor/edit.gql-queries.js
@@ -90,6 +90,7 @@ const NodeDataFragment = {
                 }
                 hasWritePermission: hasPermission(permissionName: $writePermission)
                 hasPublishPermission: hasPermission(permissionName: "publish")
+                hasTranslatePermission: hasPermission(permissionName: "translateAction")
                 hasStartPublicationWorkflowPermission: hasPermission(permissionName: "publication-start")
                 lockInfo {
                     details(language: $language) {

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/translateAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/translateAction.jsx
@@ -18,6 +18,7 @@ export const TranslateActionComponent = ({path, render: Render, ...otherProps}) 
     const sourceLang = languages.find(l => l.language !== lang) || languages[0];
     return (res.loading) ? null : (
         <Render {...otherProps}
+                isVisible={res.checksResult}
                 enabled={languages.length > 1}
                 onClick={() => {
                     api.edit({

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/translateEditAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/translateEditAction.jsx
@@ -13,7 +13,7 @@ export const TranslateEditActionComponent = ({path, render: Render, ...otherProp
 
     return (
         <Render {...otherProps}
-                isVisible={languages.length > 1}
+                isVisible={nodeData?.hasTranslatePermission && languages.length > 1}
                 onClick={() => {
                     api.edit({
                         uuid: nodeData.uuid,

--- a/src/javascript/ContentEditor/actions/registerEditActions.js
+++ b/src/javascript/ContentEditor/actions/registerEditActions.js
@@ -131,7 +131,7 @@ export const registerEditActions = registry => {
         buttonIcon: <Translate/>,
         buttonLabel: 'jcontent:label.contentEditor.edit.action.translate.name',
         dataSelRole: 'sbsTranslate',
-        requiredSitePermission: ['editAction']
+        requiredSitePermission: ['translateAction']
     });
 
     registry.add('action', 'translateField', translateFieldAction, {


### PR DESCRIPTION
### Description

Add site permission check for `translateAction` to enable/disable context menu and edit actions.

- Added `hasTranslatePermission` to nodeData query for contentEditor action

