### PR TITLE
fix: Add memoization to prevent unwanted flickering

### DIFF
--- a/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
@@ -374,6 +374,58 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
 
     const el = currentElement?.element;
 
+    const memoizedPlaceholders = useMemo(() => {
+        if (clickedElement) {
+            return null;
+        }
+
+        return placeholders
+            .map(element => ({
+                element,
+                node: nodes?.[element.dataset.jahiaParent &&
+                element.ownerDocument.getElementById(element.dataset.jahiaParent).getAttribute('path')]
+            }))
+            .filter(({node}) => node && !isMarkedForDeletion(node) && !findAvailableBoxConfig(node)?.isBoxActionsHidden)
+            .map(({node, element}) => (
+                <Create key={element.getAttribute('id')}
+                        node={node}
+                        nodes={nodes}
+                        element={element}
+                        addIntervalCallback={addIntervalCallback}
+                        clickedElement={clickedElement}
+                        onMouseOver={onMouseOver}
+                        onMouseOut={onMouseOut}
+                        onClick={onClick}
+                        onSaved={onSaved}
+                />
+            ));
+    }, [
+        clickedElement,
+        placeholders,
+        nodes,
+        addIntervalCallback,
+        onMouseOver,
+        onMouseOut,
+        onClick,
+        onSaved
+    ]);
+
+    const MemoizedInsertionPoints = useMemo(() => (
+        <InsertionPoints
+            currentDocument={currentDocument}
+            addIntervalCallback={addIntervalCallback}
+            clickedElement={clickedElement}
+            nodes={nodes}
+            onSaved={onSaved}
+        />
+    ), [
+        currentDocument,
+        addIntervalCallback,
+        clickedElement,
+        nodes,
+        onSaved
+    ]);
+
     return (
         <div>
             <BoxesContextMenu
@@ -422,25 +474,8 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
                     />
                 ))}
 
-            {!clickedElement && placeholders.map(element => ({
-                element,
-                node: nodes?.[element.dataset.jahiaParent && element.ownerDocument.getElementById(element.dataset.jahiaParent).getAttribute('path')]
-            }))
-                .filter(({node}) => node && !isMarkedForDeletion(node) && !findAvailableBoxConfig(node)?.isBoxActionsHidden)
-                .map(({node, element}) => (
-                    <Create key={element.getAttribute('id')}
-                            node={node}
-                            nodes={nodes}
-                            element={element}
-                            addIntervalCallback={addIntervalCallback}
-                            clickedElement={clickedElement}
-                            onMouseOver={onMouseOver}
-                            onMouseOut={onMouseOut}
-                            onClick={onClick}
-                            onSaved={onSaved}
-                    />
-                ))}
-            <InsertionPoints currentDocument={currentDocument} addIntervalCallback={addIntervalCallback} clickedElement={clickedElement} nodes={nodes} onSaved={onSaved}/>
+            {memoizedPlaceholders}
+            {MemoizedInsertionPoints}
         </div>
     );
 };

--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
 import styles from './Create.scss';
 import PropTypes from 'prop-types';
@@ -183,14 +183,14 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
         }
     }
 
-    const onAction = onActionFn => {
+    const onAction = useCallback(onActionFn => {
         const needsReorder = element.getAttribute('type') !== 'placeholder';
         return data => {
             if (needsReorder) {
                 onActionFn(data);
             }
         };
-    };
+    }, [element]);
 
     const createAction = useMemo(() => (
         <DisplayAction

--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -163,7 +163,9 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
 
     const sizers = [...Array(10).keys()].filter(i => currentOffset.width < i * 150).map(i => `sizer${i}`);
     const isDisabled = clickedElement && clickedElement.path !== parentPath;
-    const btnRenderer = (isInsertionPoint && !isEmpty) ? ButtonRendererNoLabel : ButtonRenderer;
+    const btnRenderer = useMemo(() => {
+        return (isInsertionPoint && !isEmpty) ? ButtonRendererNoLabel : ButtonRenderer;
+    }, [isInsertionPoint, isEmpty]);
 
     const insertionStyle = {};
     if (isInsertionPoint && !isEmpty) {
@@ -190,6 +192,21 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
         };
     };
 
+    const createAction = useMemo(() => (
+        <DisplayAction
+            isIncludeSubTypes
+            actionKey="createContent"
+            path={parentPath}
+            name={nodePath}
+            isDisabled={isDisabled}
+            nodeTypes={nodeTypes}
+            loading={() => false}
+            render={btnRenderer}
+            onVisibilityChanged={onCreateVisibilityChanged}
+            onCreate={onAction(({name}) => reorderNodes([name], nodeName))}
+        />
+    ), [parentPath, nodePath, isDisabled, nodeTypes, btnRenderer, onCreateVisibilityChanged, onAction, reorderNodes, nodeName]);
+
     return !anyDragging && (
         <div ref={drop}
              jahiatype="createbuttons" // eslint-disable-line react/no-unknown-property
@@ -207,17 +224,7 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
              onMouseOut={onMouseOut}
              onClick={onClick}
         >
-            {copyPasteNodes.length === 0 &&
-                <DisplayAction isIncludeSubTypes
-                               actionKey="createContent"
-                               path={parentPath}
-                               name={nodePath}
-                               isDisabled={isDisabled}
-                               nodeTypes={nodeTypes}
-                               loading={() => false}
-                               render={btnRenderer}
-                               onVisibilityChanged={onCreateVisibilityChanged}
-                               onCreate={onAction(({name}) => reorderNodes([name], nodeName))}/>}
+            {copyPasteNodes.length === 0 && createAction}
             <DisplayAction actionKey="paste"
                            isDisabled={isDisabled}
                            path={parentPath}


### PR DESCRIPTION
### Description
Add memoization to prevent unwanted flickering of create buttons' icons. The problem doesn't go away fully but this makes it a lot better based on what I can see.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
