### PR TITLE
fix: check function existing to avoid error in browser console

### DIFF
--- a/src/javascript/JContent/MenuItemRenderer.jsx
+++ b/src/javascript/JContent/MenuItemRenderer.jsx
@@ -19,7 +19,10 @@ export let MenuItemRenderer = ({buttonLabel, buttonLabelParams, menuContext, men
     }
 
     const onEnter = e => {
-        onMouseEnter(e);
+        if (onMouseEnter) {
+            onMouseEnter(e);
+        }
+
         setHover(true);
     };
 


### PR DESCRIPTION
### Description
Check if onMouseEnter is defined in MenuItemRenderer before calling it to avoid to have error in the browser console

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
