### PR TITLE
test: Add Translation tests

### DIFF
--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelLanguageSwitcher/EditPanelLanguageSwitcher.jsx
@@ -32,6 +32,9 @@ export const EditPanelLanguageSwitcher = () => {
             group.options.push({
                 label,
                 value: item.language,
+                attributes: {
+                    'data-value': item.language
+                },
                 iconEnd: i18nContext[item.language] ? <Edit/> : null
             });
         });
@@ -51,6 +54,7 @@ export const EditPanelLanguageSwitcher = () => {
                 value={currentLanguage}
                 label={langLabel}
                 size="small"
+                data-selected-value={currentLanguage}
                 onChange={(e, language) => {
                     if (language.value !== currentLanguage) {
                         switchLanguage(language.value);

--- a/src/javascript/ContentEditor/DesignSystem/OrderableValue/OrderableValue.jsx
+++ b/src/javascript/ContentEditor/DesignSystem/OrderableValue/OrderableValue.jsx
@@ -38,6 +38,7 @@ export const OrderableValue = ({id, field, onFieldRemove, onValueReorder, onValu
             )}
             data-sel-content-editor-multiple-generic-field={name}
             data-sel-content-editor-field-readonly={field.readOnly}
+            data-sel-i18n={field.i18n}
             data-handler-id={handlerId}
         >
             {!isReferenceCard && !readOnly &&

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/translateAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/translateAction.jsx
@@ -27,7 +27,7 @@ export const TranslateActionComponent = ({path, render: Render, ...otherProps}) 
                         isFullscreen: true,
                         dialogProps: {
                             classes: {},
-                            dataSelRole: 'translate-dialog',
+                            dataSelRole: 'translate-dialog'
                         },
                         sideBySideContext: {lang},
                         layout: TranslatePanel,

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/translateAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/translateAction.jsx
@@ -26,7 +26,8 @@ export const TranslateActionComponent = ({path, render: Render, ...otherProps}) 
                         lang: sourceLang.language,
                         isFullscreen: true,
                         dialogProps: {
-                            classes: {}
+                            classes: {},
+                            dataSelRole: 'translate-dialog',
                         },
                         sideBySideContext: {lang},
                         layout: TranslatePanel,

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.jsx
@@ -244,6 +244,7 @@ export const Field = ({inputContext, idInput, selectorType, field}) => {
             data-sel-content-editor-field-type={seleniumFieldType}
             data-sel-content-editor-field-picker-type={pickerType}
             data-sel-content-editor-field-readonly={field.readOnly}
+            data-sel-i18n={field.i18n}
         >
             {renderField(inputContext, field, isMultipleField, idInput, hasMandatoryError, t, wipInfo, editorContext, selectorType, onChange, onBlur, shouldDisplayErrors, errorName, errorArgs)}
         </div>

--- a/tests/cypress/e2e/menuActions/translate.cy.ts
+++ b/tests/cypress/e2e/menuActions/translate.cy.ts
@@ -9,9 +9,9 @@ import {
     getComponentByRole, getNodeByPath,
     grantRoles
 } from '@jahia/cypress';
-import {TranslateEditor} from "../../page-object/translateEditor";
-import {JContent} from "../../page-object";
-import {Field, SmallTextField} from "../../page-object/fields";
+import {TranslateEditor} from '../../page-object/translateEditor';
+import {JContent} from '../../page-object';
+import {Field, SmallTextField} from '../../page-object/fields';
 import {Dialog} from '../../page-object/dialog';
 
 describe('translate action tests', () => {
@@ -65,7 +65,7 @@ describe('translate action tests', () => {
         const jcontent = JContent.visit(oneLangSite, 'en', 'pages/home');
         const menu = jcontent.getAccordionItem('pages').getTreeItem('home').contextMenu();
         menu.shouldHaveRoleItem('sbsTranslate');
-        menu.get().find(`.moonstone-menuItem[data-sel-role="sbsTranslate"]`).should('have.attr', 'aria-disabled', 'true');
+        menu.get().find('.moonstone-menuItem[data-sel-role="sbsTranslate"]').should('have.attr', 'aria-disabled', 'true');
     });
 
     it('can open translate dialog on contents and has the correct settings', () => {
@@ -92,7 +92,7 @@ describe('translate action tests', () => {
             'qant:allFields_long',
             'qant:allFields_double',
             'qant:allFields_bigtext',
-            'qant:allFields_color',
+            'qant:allFields_color'
         ].forEach(fieldName => {
             translateEditor.getSourceField(SmallTextField, fieldName)
                 .getTranslateFieldAction()
@@ -125,7 +125,7 @@ describe('translate action tests', () => {
         cy.log('Verify translate fields are `disabled` on empty');
         [
             'htmlHead_jcr:description',
-            'htmlHead_seoKeywords',
+            'htmlHead_seoKeywords'
         ].forEach(fieldName => {
             translateEditor.getSourceField(SmallTextField, fieldName)
                 .getTranslateFieldAction()
@@ -164,7 +164,7 @@ describe('translate action tests', () => {
         translateEditor.getTranslateField(SmallTextField, 'qant:allFields_smallText').checkValue('smallText in English');
 
         cy.log('Verify close prompts unsaved changes');
-        getComponentByRole(Button, 'backButton').click()
+        getComponentByRole(Button, 'backButton').click();
         getComponent(Dialog).get().contains('Unsaved changes').should('be.visible');
         getComponentByRole(Button, 'close-dialog-cancel').click();
 
@@ -173,8 +173,8 @@ describe('translate action tests', () => {
         getNodeByPath(`${parentPath}/${name}`, ['smallText'], 'fr').then(result => {
             cy.log('Verify fr translations');
             const props = result.data.jcr.nodeByPath.properties;
-            const prop = props.find((prop: { name: string; }) => prop.name === 'smallText');
-            expect(prop.value).to.eq('smallText in English');
+            const smallTextProp = props.find((prop: { name: string; }) => prop.name === 'smallText');
+            expect(smallTextProp.value).to.eq('smallText in English');
         });
 
         getNodeByPath(`${parentPath}/${name}`, ['long', 'textarea'], 'de').then(result => {
@@ -186,5 +186,4 @@ describe('translate action tests', () => {
             expect(textareaProp.value).to.eq('textarea in English');
         });
     });
-
 });

--- a/tests/cypress/e2e/menuActions/translate.cy.ts
+++ b/tests/cypress/e2e/menuActions/translate.cy.ts
@@ -1,0 +1,190 @@
+import {
+    addNode,
+    Button,
+    createSite,
+    createUser,
+    deleteSite,
+    enableModule,
+    getComponent,
+    getComponentByRole, getNodeByPath,
+    grantRoles
+} from '@jahia/cypress';
+import {TranslateEditor} from "../../page-object/translateEditor";
+import {JContent} from "../../page-object";
+import {Field, SmallTextField} from "../../page-object/fields";
+import {Dialog} from '../../page-object/dialog';
+
+describe('translate action tests', () => {
+    const siteKey = 'translateSite';
+    const oneLangSite = 'oneLangSite';
+    const editorLogin = {username: 'translateEditor', password: 'password'};
+
+    const parentPath = `/sites/${siteKey}/contents`;
+    const name = 'translate-field-test';
+
+    before('test setup', () => {
+        createSite(siteKey, {
+            languages: 'en,fr,de',
+            templateSet: 'dx-base-demo-templates',
+            serverName: 'localhost',
+            locale: 'en'
+        });
+        enableModule('qa-module', siteKey);
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            primaryNodeType: 'qant:allFields',
+            name,
+            properties: [
+                {name: 'smallText', value: 'smallText in English', language: 'en'},
+                {name: 'textarea', value: 'textarea in English', language: 'en'}
+            ]
+        });
+
+        createSite(oneLangSite, {
+            languages: 'en',
+            templateSet: 'dx-base-demo-templates',
+            serverName: 'localhost',
+            locale: 'en'
+        });
+
+        createUser(editorLogin.username, editorLogin.password);
+        grantRoles(`/sites/${siteKey}`, ['editor'], editorLogin.username, 'USER');
+    });
+
+    after('test cleanup', () => {
+        cy.logout();
+        deleteSite(siteKey);
+        deleteSite(oneLangSite);
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession();
+    });
+
+    it('cannot open translate dialog if content has only one language', () => {
+        const jcontent = JContent.visit(oneLangSite, 'en', 'pages/home');
+        const menu = jcontent.getAccordionItem('pages').getTreeItem('home').contextMenu();
+        menu.shouldHaveRoleItem('sbsTranslate');
+        menu.get().find(`.moonstone-menuItem[data-sel-role="sbsTranslate"]`).should('have.attr', 'aria-disabled', 'true');
+    });
+
+    it('can open translate dialog on contents and has the correct settings', () => {
+        const translateEditor = TranslateEditor.visitContent(siteKey, 'en', 'content-folders/contents', name);
+
+        cy.log('Verify source language is default to English');
+        translateEditor.getSourceLanguageSwitcher().isSelectedLang('en');
+        translateEditor.getTranslateLanguageSwitcher().isNotSelectedLang('en');
+
+        cy.log('Verify source column fields are read-only');
+        translateEditor.getSourceFields()
+            .each($field => new Field(cy.wrap($field)).isReadOnly());
+
+        cy.log('Verify shared languages on translate column are read-only');
+        translateEditor.getTranslateFields().filter('[data-sel-i18n="false"]')
+            .each($field => new Field(cy.wrap($field)).isReadOnly());
+
+        cy.log('Verify shared languages on source column do not contain translate fields button');
+        translateEditor.getSourceFields().filter('[data-sel-i18n="false"]')
+            .each($field => new Field(cy.wrap($field)).getTranslateFieldAction().should('not.exist'));
+
+        cy.log('Verify translate fields are `disabled` on empty');
+        [
+            'qant:allFields_long',
+            'qant:allFields_double',
+            'qant:allFields_bigtext',
+            'qant:allFields_color',
+        ].forEach(fieldName => {
+            translateEditor.getSourceField(SmallTextField, fieldName)
+                .getTranslateFieldAction()
+                .should('have.attr', 'disabled');
+        });
+
+        cy.log('Verify all sections are expanded by default');
+        translateEditor.getSection('content').shouldBeExpanded();
+    });
+
+    it('can open translate dialog on pages and has the correct settings', () => {
+        const translateEditor = TranslateEditor.visitPage(siteKey, 'en', 'pages/home', 'home');
+
+        cy.log('Verify source language is default to English');
+        translateEditor.getSourceLanguageSwitcher().isSelectedLang('en');
+        translateEditor.getTranslateLanguageSwitcher().isNotSelectedLang('en');
+
+        cy.log('Verify source column fields are read-only');
+        translateEditor.getSourceFields()
+            .each($field => new Field(cy.wrap($field)).isReadOnly());
+
+        cy.log('Verify shared languages on translate column are read-only');
+        translateEditor.getTranslateFields().filter('[data-sel-i18n="false"]')
+            .each($field => new Field(cy.wrap($field)).isReadOnly());
+
+        cy.log('Verify shared languages on source column do not contain translate fields button');
+        translateEditor.getSourceFields().filter('[data-sel-i18n="false"]')
+            .each($field => new Field(cy.wrap($field)).getTranslateFieldAction().should('not.exist'));
+
+        cy.log('Verify translate fields are `disabled` on empty');
+        [
+            'htmlHead_jcr:description',
+            'htmlHead_seoKeywords',
+        ].forEach(fieldName => {
+            translateEditor.getSourceField(SmallTextField, fieldName)
+                .getTranslateFieldAction()
+                .should('have.attr', 'disabled');
+        });
+
+        cy.log('Verify all sections are expanded by default');
+        translateEditor.getSection('content').shouldBeExpanded();
+        translateEditor.getSection('seo').shouldBeExpanded();
+    });
+
+    it('can translate fields', () => {
+        const translateEditor = TranslateEditor.visitContent(siteKey, 'en', 'content-folders/contents', name);
+
+        cy.log('Copy smallText from en to fr');
+        translateEditor.getTranslateLanguageSwitcher().selectLangByValue('fr');
+        translateEditor
+            .getSourceField(Field, 'qant:allFields_smallText')
+            .getTranslateFieldAction()
+            .click();
+
+        cy.log('Add user translation in de for long field');
+        translateEditor.getTranslateLanguageSwitcher().selectLangByValue('de');
+        translateEditor
+            .getTranslateField(SmallTextField, 'qant:allFields_long')
+            .addNewValue('123');
+
+        cy.log('Copy textarea from en to de');
+        translateEditor
+            .getSourceField(Field, 'qant:allFields_textarea')
+            .getTranslateFieldAction()
+            .click();
+
+        cy.log('Verify smallText changes in fr is still available');
+        translateEditor.getTranslateLanguageSwitcher().selectLangByValue('fr');
+        translateEditor.getTranslateField(SmallTextField, 'qant:allFields_smallText').checkValue('smallText in English');
+
+        cy.log('Verify close prompts unsaved changes');
+        getComponentByRole(Button, 'backButton').click()
+        getComponent(Dialog).get().contains('Unsaved changes').should('be.visible');
+        getComponentByRole(Button, 'close-dialog-cancel').click();
+
+        translateEditor.saveUnchecked();
+
+        getNodeByPath(`${parentPath}/${name}`, ['smallText'], 'fr').then(result => {
+            cy.log('Verify fr translations');
+            const props = result.data.jcr.nodeByPath.properties;
+            const prop = props.find((prop: { name: string; }) => prop.name === 'smallText');
+            expect(prop.value).to.eq('smallText in English');
+        });
+
+        getNodeByPath(`${parentPath}/${name}`, ['long', 'textarea'], 'de').then(result => {
+            cy.log('Verify de translations');
+            const props = result.data.jcr.nodeByPath.properties;
+            const longProp = props.find((prop: { name: string; }) => prop.name === 'long');
+            expect(longProp.value).to.eq('123');
+            const textareaProp = props.find((prop: { name: string; }) => prop.name === 'textarea');
+            expect(textareaProp.value).to.eq('textarea in English');
+        });
+    });
+
+});

--- a/tests/cypress/page-object/contentEditor.ts
+++ b/tests/cypress/page-object/contentEditor.ts
@@ -100,7 +100,7 @@ export class ContentEditor extends BasePage {
     }
 
     saveUnchecked() {
-        getComponentByRole(Button, 'submitSave').click();
+        this.save(false);
     }
 
     discardErrorDialog() {

--- a/tests/cypress/page-object/dialog.ts
+++ b/tests/cypress/page-object/dialog.ts
@@ -1,5 +1,5 @@
-import {BaseComponent} from "@jahia/cypress";
+import {BaseComponent} from '@jahia/cypress';
 
-export class Dialog extends BaseComponent{
+export class Dialog extends BaseComponent {
     static defaultSelector = '[role="dialog"]:not([aria-hidden="true"])';
 }

--- a/tests/cypress/page-object/dialog.ts
+++ b/tests/cypress/page-object/dialog.ts
@@ -1,0 +1,5 @@
+import {BaseComponent} from "@jahia/cypress";
+
+export class Dialog extends BaseComponent{
+    static defaultSelector = '[role="dialog"]:not([aria-hidden="true"])';
+}

--- a/tests/cypress/page-object/fields/field.ts
+++ b/tests/cypress/page-object/fields/field.ts
@@ -21,7 +21,7 @@ export class Field extends BaseComponent {
     }
 
     isReadOnly() {
-        this.get().should('have.attr', 'data-sel-content-editor-field-readonly', 'true')
+        this.get().should('have.attr', 'data-sel-content-editor-field-readonly', 'true');
     }
 
     getTranslateFieldAction(): Cypress.Chainable {

--- a/tests/cypress/page-object/fields/field.ts
+++ b/tests/cypress/page-object/fields/field.ts
@@ -19,4 +19,12 @@ export class Field extends BaseComponent {
             .should('be.visible')
             .and('have.attr', 'data-sel-content-editor-field-mandatory', 'true');
     }
+
+    isReadOnly() {
+        this.get().should('have.attr', 'data-sel-content-editor-field-readonly', 'true')
+    }
+
+    getTranslateFieldAction(): Cypress.Chainable {
+        return this.get().scrollIntoView().parent().find('[data-sel-role="translate-field"]');
+    }
 }

--- a/tests/cypress/page-object/languageSwitcher.ts
+++ b/tests/cypress/page-object/languageSwitcher.ts
@@ -1,9 +1,37 @@
 import {Dropdown} from '@jahia/cypress';
+import {getComponent} from "@jahia/cypress";
+import {Menu} from "@jahia/cypress";
 
 export class LanguageSwitcher extends Dropdown {
+    static defaultSelector = '[data-cm-role="language-switcher"]';
+
+    // @deprecated use `selectLangByValue` instead
     selectLang(displayLang: string) {
         this.select(displayLang).get()
             .find(`span[title="${displayLang}"]`)
             .should('be.visible');
+    }
+
+    selectLangByValue(value: string): this {
+        this.selectByValue(value);
+        return this.isSelectedLang(value);
+    }
+
+    isSelectedLang(value: string): this {
+        this.should('have.attr', 'data-selected-value', value);
+        return this;
+    }
+
+    isNotSelectedLang(value: string): this {
+        this.should('not.have.attr', 'data-selected-value', value);
+        return this;
+    }
+
+    selectByValue(value: string): Dropdown {
+        this.get().click();
+        const menu = getComponent(Menu, this);
+        menu.should('be.visible');
+        menu.selectByValue(value);
+        return this;
     }
 }

--- a/tests/cypress/page-object/languageSwitcher.ts
+++ b/tests/cypress/page-object/languageSwitcher.ts
@@ -1,6 +1,6 @@
 import {Dropdown} from '@jahia/cypress';
-import {getComponent} from "@jahia/cypress";
-import {Menu} from "@jahia/cypress";
+import {getComponent} from '@jahia/cypress';
+import {Menu} from '@jahia/cypress';
 
 export class LanguageSwitcher extends Dropdown {
     static defaultSelector = '[data-cm-role="language-switcher"]';

--- a/tests/cypress/page-object/translateEditor.ts
+++ b/tests/cypress/page-object/translateEditor.ts
@@ -1,12 +1,11 @@
-import {ContentEditor} from "./contentEditor";
-import {JContent} from "./jcontent";
-import {Field} from "./fields";
-import {ComponentType} from "@jahia/cypress/src/page-object/baseComponent";
-import {BaseComponent, getComponent, getComponentByAttr, getComponentBySelector} from "@jahia/cypress";
-import {LanguageSwitcher} from "./languageSwitcher";
+import {ContentEditor} from './contentEditor';
+import {JContent} from './jcontent';
+import {Field} from './fields';
+import {ComponentType} from '@jahia/cypress/src/page-object/baseComponent';
+import {BaseComponent, getComponentByAttr, getComponentBySelector} from '@jahia/cypress';
+import {LanguageSwitcher} from './languageSwitcher';
 
 export class TranslateEditor extends ContentEditor {
-
     sourceColumnComponent: BaseComponent;
     translateColumnComponent: BaseComponent;
 
@@ -33,6 +32,7 @@ export class TranslateEditor extends ContentEditor {
         if (!this.sourceColumnComponent) {
             this.sourceColumnComponent = new BaseComponent(cy.get('[data-sel-role="left-column"]'));
         }
+
         return this.sourceColumnComponent;
     }
 
@@ -40,6 +40,7 @@ export class TranslateEditor extends ContentEditor {
         if (!this.translateColumnComponent) {
             this.translateColumnComponent = new BaseComponent(cy.get('[data-sel-role="right-column"]'));
         }
+
         return this.translateColumnComponent;
     }
 

--- a/tests/cypress/page-object/translateEditor.ts
+++ b/tests/cypress/page-object/translateEditor.ts
@@ -1,0 +1,73 @@
+import {ContentEditor} from "./contentEditor";
+import {JContent} from "./jcontent";
+import {Field} from "./fields";
+import {ComponentType} from "@jahia/cypress/src/page-object/baseComponent";
+import {BaseComponent, getComponent, getComponentByAttr, getComponentBySelector} from "@jahia/cypress";
+import {LanguageSwitcher} from "./languageSwitcher";
+
+export class TranslateEditor extends ContentEditor {
+
+    sourceColumnComponent: BaseComponent;
+    translateColumnComponent: BaseComponent;
+
+    advancedMode: boolean = true;
+
+    static visitContent(siteKey: string, lang: string, path: string, name) {
+        const jcontent = JContent.visit(siteKey, lang, path).switchToListMode();
+        jcontent.getTable()
+            .getRowByName(name)
+            .contextMenu()
+            .selectByRole('sbsTranslate');
+        return new TranslateEditor();
+    }
+
+    static visitPage(siteKey: string, lang: string, path: string, name) {
+        const jcontent = JContent.visit(siteKey, lang, path);
+        const menu = jcontent.getAccordionItem('pages').getTreeItem(name).contextMenu();
+        menu.shouldHaveRoleItem('sbsTranslate');
+        menu.selectByRole('sbsTranslate');
+        return new TranslateEditor();
+    }
+
+    getSourceColumn(): BaseComponent {
+        if (!this.sourceColumnComponent) {
+            this.sourceColumnComponent = new BaseComponent(cy.get('[data-sel-role="left-column"]'));
+        }
+        return this.sourceColumnComponent;
+    }
+
+    getTranslateColumn(): BaseComponent {
+        if (!this.translateColumnComponent) {
+            this.translateColumnComponent = new BaseComponent(cy.get('[data-sel-role="right-column"]'));
+        }
+        return this.translateColumnComponent;
+    }
+
+    getSourceFields(): Cypress.Chainable {
+        return this.getSourceColumn().get().find('[data-sel-content-editor-field]');
+    }
+
+    getTranslateFields(): Cypress.Chainable {
+        return this.getTranslateColumn().get().find('[data-sel-content-editor-field]');
+    }
+
+    getSourceField<FieldType extends Field>(FieldComponent: ComponentType<FieldType>, fieldName: string): Field {
+        return getComponentByAttr(FieldComponent, 'data-sel-content-editor-field', fieldName, this.getSourceColumn());
+    }
+
+    getTranslateField<FieldType extends Field>(FieldComponent: ComponentType<FieldType>, fieldName: string): Field {
+        return getComponentByAttr(FieldComponent, 'data-sel-content-editor-field', fieldName, this.getTranslateColumn());
+    }
+
+    getSourceLanguageSwitcher() {
+        return this.getMultiLanguageSwitcher(this.getSourceColumn());
+    }
+
+    getTranslateLanguageSwitcher() {
+        return this.getMultiLanguageSwitcher(this.getTranslateColumn());
+    }
+
+    getMultiLanguageSwitcher(parent: BaseComponent): LanguageSwitcher {
+        return getComponentBySelector(LanguageSwitcher, '[data-cm-role="language-switcher"]', parent);
+    }
+}


### PR DESCRIPTION
### Description

- Add `data-value` attributes to language options and `data-selected-value` to the language switcher for better testability and DOM querying.
- Improved language switcher page object, adding functions using new data-value attributes
- Add `data-sel-i18n` attributes to fields, to indicate if a field is internationalized (i18n).
- Add selector to translate dialog
- Add translation tests:
  - verify shared languages in right side is read-only
  - verify no translate field for single language
  - verify all left-side fields is read only
  - verify disabled translate field button on empty
  - verify all sections expanded
  - verify source lang is the current lang
  - verify translate scenarios - translate button, manual input, switch languages, close prompts