### PR TITLE
fix: Prevent flicker by keeping buttons in the dom

### DIFF
--- a/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
@@ -18,6 +18,7 @@ import InsertionPoints from '../InsertionPoints';
 import BoxesContextMenu from './BoxesContextMenu';
 import useClearSelection from './useClearSelection';
 import {resetContentStatusPaths} from '~/JContent/redux/contentStatus.redux';
+import styles from './Boxes.scss';
 
 const getModuleElement = (currentDocument, target) => {
     let element = target;
@@ -374,10 +375,6 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
     const el = currentElement?.element;
 
     const memoizedPlaceholders = useMemo(() => {
-        if (clickedElement) {
-            return null;
-        }
-
         return placeholders
             .map(element => ({
                 element,
@@ -386,17 +383,19 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
             }))
             .filter(({node}) => node && !isMarkedForDeletion(node) && !findAvailableBoxConfig(node)?.isBoxActionsHidden)
             .map(({node, element}) => (
-                <Create key={element.getAttribute('id')}
-                        node={node}
-                        nodes={nodes}
-                        element={element}
-                        addIntervalCallback={addIntervalCallback}
-                        clickedElement={clickedElement}
-                        onMouseOver={onMouseOver}
-                        onMouseOut={onMouseOut}
-                        onClick={onClick}
-                        onSaved={onSaved}
-                />
+                <div key={`createButtons-${node.path}`} className={clickedElement ? styles.displayNone : ''}>
+                    <Create key={element.getAttribute('id')}
+                            node={node}
+                            nodes={nodes}
+                            element={element}
+                            addIntervalCallback={addIntervalCallback}
+                            clickedElement={clickedElement}
+                            onMouseOver={onMouseOver}
+                            onMouseOut={onMouseOut}
+                            onClick={onClick}
+                            onSaved={onSaved}
+                    />
+                </div>
             ));
     }, [
         clickedElement,

--- a/src/javascript/JContent/EditFrame/Boxes/Boxes.scss
+++ b/src/javascript/JContent/EditFrame/Boxes/Boxes.scss
@@ -1,0 +1,3 @@
+.displayNone {
+    display: none;
+}

--- a/tests/cypress/e2e/jcontent/createContent.cy.ts
+++ b/tests/cypress/e2e/jcontent/createContent.cy.ts
@@ -79,7 +79,7 @@ describe('Create content tests', () => {
             const module = jcontent.getModule(`/sites/${siteKey}/home/landing`);
             module.click({force: true});
             const buttons = module.getCreateButtons();
-            buttons.getFirstInsertionButton().click();
+            buttons.getInsertionButtonByIndex(1).click();
             const contentEditor = jcontent.getCreateContent().getContentTypeSelector().searchForContentType('jnt:bigText').selectContentType('jnt:bigText').create();
             contentEditor.getRichTextField('jnt:bigText_text').type('Newly inserted content');
             contentEditor.create();

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModuleCreateButton.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModuleCreateButton.ts
@@ -15,6 +15,10 @@ export class PageBuilderModuleCreateButton extends BaseComponent {
         return new Button(this.get().find('button[data-sel-role="createContent"]').first());
     }
 
+    getInsertionButtonByIndex(index: number): Button {
+        return new Button(this.get().find('button[data-sel-role="createContent"]').eq(index));
+    }
+
     assertHasNoButton(): void {
         this.get().find('.moonstone-button').should('not.exist');
     }

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModuleCreateButton.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModuleCreateButton.ts
@@ -11,10 +11,6 @@ export class PageBuilderModuleCreateButton extends BaseComponent {
         return getComponentByRole(Button, role, this);
     }
 
-    getFirstInsertionButton(): Button {
-        return new Button(this.get().find('button[data-sel-role="createContent"]').first());
-    }
-
     getInsertionButtonByIndex(index: number): Button {
         return new Button(this.get().find('button[data-sel-role="createContent"]').eq(index));
     }


### PR DESCRIPTION
### Description
Prevent flicker by keeping create buttons in the dom so that it doesn't look like the page is refreshing.
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
