### PR TITLE
feat: Restrict translate action on node types

### DIFF
--- a/src/javascript/ContentEditor/actions/registerEditActions.js
+++ b/src/javascript/ContentEditor/actions/registerEditActions.js
@@ -124,6 +124,7 @@ export const registerEditActions = registry => {
     registry.add('action', 'sbsTranslateEdit', translateEditAction, {
         buttonIcon: <Translate/>,
         buttonLabel: 'jcontent:label.contentEditor.edit.action.translate.name',
+        showOnNodeTypes: ['jnt:page', 'jmix:mainResource', 'jmix:editorialContent', 'jmix:translatableScreen'],
         dataSelRole: 'sbsTranslateEdit'
     });
 
@@ -131,6 +132,7 @@ export const registerEditActions = registry => {
         buttonIcon: <Translate/>,
         buttonLabel: 'jcontent:label.contentEditor.edit.action.translate.name',
         dataSelRole: 'sbsTranslate',
+        showOnNodeTypes: ['jnt:page', 'jmix:mainResource', 'jmix:editorialContent', 'jmix:translatableScreen'],
         requiredSitePermission: ['translateAction']
     });
 

--- a/tests/cypress/e2e/menuActions/translate.cy.ts
+++ b/tests/cypress/e2e/menuActions/translate.cy.ts
@@ -68,6 +68,14 @@ describe('translate action tests', () => {
         menu.get().find('.moonstone-menuItem[data-sel-role="sbsTranslate"]').should('have.attr', 'aria-disabled', 'true');
     });
 
+    it('cannot open on invalid node types e.g. folders', () => {
+        const jcontent = JContent.visit(oneLangSite, 'en', 'media/files').switchToListMode();
+        jcontent.getTable()
+            .getRowByName('bootstrap')
+            .contextMenu()
+            .shouldNotHaveRoleItem('sbsTranslate');
+    });
+
     it('can open translate dialog on contents and has the correct settings', () => {
         const translateEditor = TranslateEditor.visitContent(siteKey, 'en', 'content-folders/contents', name);
 

--- a/tests/cypress/page-object/jcontent.ts
+++ b/tests/cypress/page-object/jcontent.ts
@@ -74,11 +74,24 @@ export class JContent extends BasePage {
             .create();
     }
 
+    // @deprecated: use editComponentByRowName instead
     editComponentByText(text: string) {
         const row = new TableRow(getElement(TableRow.defaultSelector, this.getTable()).contains(text));
         row.get().scrollIntoView();
         row.contextMenu().select('Edit');
         return new ContentEditor();
+    }
+
+    editComponentByRowName(name: string) {
+        this.selectContextMenuByRowName(name, 'edit');
+        return new ContentEditor();
+    }
+
+    selectContextMenuByRowName(rowName: string, menuRole: string): Menu {
+        return this.getTable()
+            .getRowByName(rowName)
+            .contextMenu()
+            .selectByRole(menuRole);
     }
 
     getCreatePage(): void {
@@ -104,12 +117,6 @@ export class JContent extends BasePage {
         getComponentByRole(Button, 'browseControlBarMenu').click();
         cy.get('li[data-sel-role="import"]').should('exist').and('be.visible').click();
         cy.get('#file-upload-input').selectFile(filename, {force: true});
-    }
-
-    viewSubContentComponentByText(text: string) {
-        const row = new TableRow(getElement(TableRow.defaultSelector, this.getTable()).contains(text));
-        row.get().scrollIntoView();
-        row.contextMenu().select('View sub-contents');
     }
 
     getSiteSwitcher(): Dropdown {

--- a/tests/cypress/page-object/translateEditor.ts
+++ b/tests/cypress/page-object/translateEditor.ts
@@ -14,7 +14,12 @@ export class TranslateEditor extends ContentEditor {
     static visitContent(siteKey: string, lang: string, path: string, name: string) {
         const jcontent = JContent.visit(siteKey, lang, path).switchToListMode();
         jcontent.selectContextMenuByRowName(name, 'sbsTranslate');
-        return new TranslateEditor();
+
+        const _instance = new TranslateEditor();
+        // Make sure the translate editor is loaded before proceeding
+        _instance.getTranslateColumn().get().get('.moonstone-loader', {timeout: 5000}).should('not.exist');
+        _instance.getSourceColumn().get().get('.moonstone-loader', {timeout: 5000}).should('not.exist');
+        return _instance;
     }
 
     static visitPage(siteKey: string, lang: string, path: string, name) {

--- a/tests/cypress/page-object/translateEditor.ts
+++ b/tests/cypress/page-object/translateEditor.ts
@@ -11,12 +11,9 @@ export class TranslateEditor extends ContentEditor {
 
     advancedMode: boolean = true;
 
-    static visitContent(siteKey: string, lang: string, path: string, name) {
+    static visitContent(siteKey: string, lang: string, path: string, name: string) {
         const jcontent = JContent.visit(siteKey, lang, path).switchToListMode();
-        jcontent.getTable()
-            .getRowByName(name)
-            .contextMenu()
-            .selectByRole('sbsTranslate');
+        jcontent.selectContextMenuByRowName(name, 'sbsTranslate');
         return new TranslateEditor();
     }
 


### PR DESCRIPTION
### Description

- Added restrictions for when to show translate action as specified in story.
- Added cypress test
- Added new jcontent page object util for showing context menu in table view 
  - Cleaned up viewSubContentComponentByText; didn't find any usage for it
  - deprecated `editComponentByText`; replaced by `editComponentByRowName`

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
