### PR TITLE
test: Stabilize tests

### DIFF
--- a/src/javascript/JContent/EditFrame/Box/Box.jsx
+++ b/src/javascript/JContent/EditFrame/Box/Box.jsx
@@ -287,6 +287,9 @@ export const Box = React.memo(({
              className={clsx(styles.root, isBarAlwaysDisplayed ? styles.alwaysDisplayedZIndex : styles.defaultZIndex)}
              data-sel-role="page-builder-box"
              data-jahia-path={node.path}
+             data-box-hovered={isHovered}
+             data-box-selected={isSelected}
+             data-box-clicked={isClicked}
              data-jahia-id={element.getAttribute('id')}
              style={currentOffset}
         >

--- a/tests/cypress/e2e/contentEditor/contentEditorForm.cy.ts
+++ b/tests/cypress/e2e/contentEditor/contentEditorForm.cy.ts
@@ -171,8 +171,9 @@ describe('Content editor form', () => {
         const contentEditor = jcontent.createContent('jnt:text');
         const field = contentEditor.getField(SmallTextField, 'jnt:text_text');
         field.get().find('input').should('not.have.attr', 'readonly', 'readonly');
-        cy.login('mathias', 'password');
 
+        cy.logout();
+        cy.login('mathias', 'password');
         jcontent = JContent.visit('contentEditorSite', 'en', 'content-folders/contents');
         const contentEditor2 = jcontent.createContent('jnt:text');
         const field2 = contentEditor2.getField(SmallTextField, 'jnt:text_text');
@@ -182,8 +183,9 @@ describe('Content editor form', () => {
     it('Should not see see field for reviewer', () => {
         const contentEditor = jcontent.createContent('jnt:news');
         contentEditor.getField(SmallTextField, 'jnt:news_desc');
-        cy.login('mathias', 'password');
 
+        cy.logout();
+        cy.login('mathias', 'password');
         jcontent = JContent.visit('contentEditorSite', 'en', 'content-folders/contents');
         jcontent.createContent('jnt:news');
         cy.get('[data-sel-content-editor-field="jnt:news_desc"]').should('not.exist');

--- a/tests/cypress/e2e/contentEditor/previewContent.cy.ts
+++ b/tests/cypress/e2e/contentEditor/previewContent.cy.ts
@@ -8,7 +8,7 @@ describe('Preview tests', () => {
 
     before(() => {
         cy.apollo({mutationFile: 'jcontent/enableLegacyPageComposer.graphql'});
-        enableModule('jcontent-test-module', 'digitall');
+        enableModule('jcontent-test-module', siteKey);
         addNode({
             parentPathOrId: `/sites/${siteKey}/home`,
             name: 'chocolate,-sweets,-cakes',
@@ -26,6 +26,7 @@ describe('Preview tests', () => {
 
     after(() => {
         deleteNode(`/sites/${siteKey}/home/chocolate,-sweets,-cakes`);
+        deleteNode(`/sites/${siteKey}/contents/simpleText`);
         disableModule('jcontent-test-module', siteKey);
     });
 
@@ -76,30 +77,28 @@ describe('Preview tests', () => {
 
     it('It updates preview after save', () => {
         addNode({
-            parentPathOrId: '/sites/digitall/contents',
-            name: 'Simple text',
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: 'simpleText',
             primaryNodeType: 'jnt:text'
         });
 
         cy.loginAndStoreSession();
-        const jcontent = JContent.visit('digitall', 'en', 'content-folders/contents');
-        const contentEditor = new ContentEditor();
-
-        jcontent.editComponentByText('Simple text');
+        const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents/simpleText');
+        const contentEditor = jcontent.editContent();
         contentEditor.switchToAdvancedMode();
 
-        // Check preview badge is not displayed
+        cy.log('Check preview badge is not displayed');
         cy.contains('span', 'Preview will update on save', {timeout: 5000}).should('not.exist');
 
-        // Update content
+        cy.log('Update content');
         contentEditor.getSmallTextField('jnt:text_text').addNewValue('Text updated');
 
-        // Check preview badge is displayed
+        cy.log('Check preview badge is displayed');
         cy.contains('span', 'Preview will update on save', {timeout: 5000}).should('exist');
 
         contentEditor.save();
 
-        // Check preview badge is not displayed
+        cy.log('Check preview badge is not displayed after save');
         cy.contains('span', 'Preview will update on save', {timeout: 5000}).should('not.exist');
         contentEditor.validateContentIsVisibleInPreview('Text updated');
     });

--- a/tests/cypress/e2e/jcontent/createContent.cy.ts
+++ b/tests/cypress/e2e/jcontent/createContent.cy.ts
@@ -76,8 +76,8 @@ describe('Create content tests', () => {
         });
 
         it('Create content in page builder using insertion points', () => {
-            const module = jcontent.getModule(`/sites/${siteKey}/home/landing`);
-            module.click({force: true});
+            const module = jcontent.getModule(`/sites/${siteKey}/home/landing`, false);
+            module.getHeader(true);
             const buttons = module.getCreateButtons();
             buttons.getInsertionButtonByIndex(1).click();
             const contentEditor = jcontent.getCreateContent().getContentTypeSelector().searchForContentType('jnt:bigText').selectContentType('jnt:bigText').create();

--- a/tests/cypress/e2e/jcontent/createMedia.cy.ts
+++ b/tests/cypress/e2e/jcontent/createMedia.cy.ts
@@ -21,9 +21,12 @@ describe('Create media tests', () => {
     });
 
     after(function () {
-        cy.logout();
         deleteUser(user.name);
         cy.executeGroovy('jcontent/deleteSite.groovy', {SITEKEY: 'jcontentSite'});
+    });
+
+    afterEach(() => {
+        cy.logout();
     });
 
     it('Can create and delete basic folder', function () {
@@ -70,8 +73,7 @@ describe('Create media tests', () => {
             .createInvalidFolder('media/files', '[]*|/%');
     });
 
-    // https://github.com/Jahia/jcontent/issues/1772
-    it.skip('Can open created file in advanced mode with preview', function () {
+    it('Can open created file in advanced mode with preview', function () {
         cy.loginAndStoreSession();
         jcontent = JContent.visit(siteKey, 'en', 'media/files');
         const menu = jcontent.getMedia()

--- a/tests/cypress/e2e/menuActions/deleteAdvanced.cy.ts
+++ b/tests/cypress/e2e/menuActions/deleteAdvanced.cy.ts
@@ -78,6 +78,10 @@ describe('delete tests', () => {
 
         cy.log('mark published page for deletion');
         jcontent.getAccordionItem('pages').getTreeItem('test-subpage3').contextMenu().select('Delete');
+        // Sometimes this test fails with dialog showing 'You are about to delete 4 items' instead of 3 items
+        // - page itself + area-main and landing sections
+        // Toggle the row to see what is going on
+        getComponent(DeleteDialog).toggleRowExpanded();
         getComponent(DeleteDialog).markForDeletion('You are about to delete 3 items, including 1 page(s)');
 
         cy.log('Publish deletion');

--- a/tests/cypress/e2e/menuActions/translate.cy.ts
+++ b/tests/cypress/e2e/menuActions/translate.cy.ts
@@ -157,6 +157,9 @@ describe('translate action tests', () => {
 
         cy.log('Add user translation in de for long field');
         translateEditor.getTranslateLanguageSwitcher().selectLangByValue('de');
+        // Need to make sure focus on first field in source column is focused before typing
+        translateEditor.getSourceColumn().get().find('.moonstone-loader', {timeout: 5000}).should('not.exist');
+        translateEditor.getSourceFields().find('input').should('have.focus');
         translateEditor
             .getTranslateField(SmallTextField, 'qant:allFields_long')
             .addNewValue('123');

--- a/tests/cypress/e2e/pageBuilder/boxesHeader.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/boxesHeader.cy.ts
@@ -30,7 +30,7 @@ describe('Page builder - boxes and header tests', () => {
     });
 
     it('should show box with name, status and edit buttons', () => {
-        const header = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content4`).getHeader(true);
+        const header = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content4`, false).getHeader(true);
         header.get().should('be.visible').find('p').contains('test-content4');
         header.assertStatus('Not published');
         header.getButton('edit');
@@ -38,7 +38,7 @@ describe('Page builder - boxes and header tests', () => {
     });
 
     it('should trim long titles', () => {
-        const header = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content8-long-text`).getHeader(true);
+        const header = jcontent.getModule(`/sites/${siteKey}/home/area-main/test-content8-long-text`, false).getHeader(true);
         header.get().should('be.visible').find('p').contains('Lorem ipsum dolor sit am...');
     });
 });

--- a/tests/cypress/e2e/pageBuilder/clickSelectionAndNavigation.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/clickSelectionAndNavigation.cy.ts
@@ -46,7 +46,7 @@ describe('Page builder - navigation tests', () => {
         const pageBuilder = new JContentPageBuilder(jcontent);
 
         const contentPath = `/sites/${siteKey}/home/landing/my-text`;
-        const module = pageBuilder.getModule(contentPath);
+        const module = pageBuilder.getModule(contentPath, false);
 
         cy.log('Click on the module to show header');
         module.getHeader(true).assertHeaderText('my sample text');
@@ -61,7 +61,7 @@ describe('Page builder - navigation tests', () => {
         const pageBuilder: JContentPageBuilder = jcontent.switchToPageBuilder();
 
         const contentPath = `/sites/${siteKey}/home/landing/my-text`;
-        let module = pageBuilder.getModule(contentPath);
+        let module = pageBuilder.getModule(contentPath, false);
 
         cy.log('Click on the module to show header');
         module.getHeader(true).assertHeaderText('my sample text');

--- a/tests/cypress/e2e/pageBuilder/clickSelectionAndNavigation.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/clickSelectionAndNavigation.cy.ts
@@ -1,5 +1,5 @@
 import {JContent, JContentPageBuilder} from '../../page-object';
-import {addNode, createSite, deleteNode, deleteSite} from '@jahia/cypress';
+import {addNode, createSite, deleteSite} from '@jahia/cypress';
 
 describe('Page builder - navigation tests', () => {
     const siteKey = 'pbNavigationTestSite';
@@ -13,7 +13,7 @@ describe('Page builder - navigation tests', () => {
             children: [{
                 name: 'my-text',
                 primaryNodeType: 'jnt:text',
-                properties: [{ name: "text", language: "en", value: "my sample text" }]
+                properties: [{name: 'text', language: 'en', value: 'my sample text'}]
             }]
         });
         addNode({

--- a/tests/cypress/e2e/pageBuilder/clipboard.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/clipboard.cy.ts
@@ -26,7 +26,7 @@ describe('Page builder - clipboard tests', () => {
     it('should show paste button when we copy', function () {
         // We don't force right-click otherwise it might bring up page context menu
         const contentPath = `/sites/${siteKey}/home/area-main/test-content1`;
-        const contextMenu = jcontent.getModule(contentPath).contextMenu(true, false);
+        const contextMenu = jcontent.getModule(contentPath, false).contextMenu(true, false);
 
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(1000); // Wait for the context menu to appear

--- a/tests/cypress/e2e/pageBuilder/contentStatus.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/contentStatus.cy.ts
@@ -59,8 +59,8 @@ describe('Page builder - content status', () => {
                 .visit(siteKey, 'en', `pages/home/${page}`)
                 .switchToPageBuilder();
 
-            getContent(page, 'wip-all').getBoxStatus('workInProgress').should('be.visible');
-            getContent(page, 'wip-en').getBoxStatus('workInProgress').should('be.visible');
+            getContent(page, 'wip-all').getBox().getStatus('workInProgress').should('be.visible');
+            getContent(page, 'wip-en').getBox().getStatus('workInProgress').should('be.visible');
 
             cy.log('Should not display status when deleted');
             getContent(page, 'wip-for-deletion').getForDeletionStatus().should('be.visible');
@@ -74,8 +74,8 @@ describe('Page builder - content status', () => {
                 .switchToPageBuilder();
             cy.log('wip-en should have no WIP status for FR language');
             jContentPageBuilder.getLanguageSwitcher().select('fr');
-            getContent(page, 'wip-en').getBoxStatus('noTranslation').should('be.visible').and('contain', 'FR');
-            getContent(page, 'wip-en').assertNoBoxStatus('workInProgress');
+            getContent(page, 'wip-en').getBox().getStatus('noTranslation').should('be.visible').and('contain', 'FR');
+            getContent(page, 'wip-en').getBox().assertNoStatus('workInProgress');
         });
 
         it('should display no visibility (language), untranslated badges', () => {
@@ -84,17 +84,17 @@ describe('Page builder - content status', () => {
                 .switchToPageBuilder();
 
             cy.log('should display untranslated badge');
-            getContent(page, 'wip-all').getBoxStatus('workInProgress').should('be.visible');
-            getContent(page, 'wip-all').getBoxStatus('noTranslation').should('be.visible').and('contain', 'FR');
-            getContent(page, 'wip-all').getBox().should('contain', 'Nothing to display');
+            getContent(page, 'wip-all').getBox().getStatus('workInProgress').should('be.visible');
+            getContent(page, 'wip-all').getBox().getStatus('noTranslation').should('be.visible').and('contain', 'FR');
+            getContent(page, 'wip-all').getBox().get().should('contain', 'Nothing to display');
 
             cy.log('should display untranslated badge (with visible content)');
-            getContent(page, 'visibility-lang-with-display-content').getBoxStatus('noTranslation').should('be.visible').and('contain', 'FR');
-            getContent(page, 'visibility-lang-with-display-content').getBox().should('not.contain', 'Nothing to display');
+            getContent(page, 'visibility-lang-with-display-content').getBox().getStatus('noTranslation').should('be.visible').and('contain', 'FR');
+            getContent(page, 'visibility-lang-with-display-content').getBox().get().should('not.contain', 'Nothing to display');
 
             cy.log('should display no visibility badge');
-            getContent(page, 'visibility-lang').getBoxStatus('notVisible').should('be.visible');
-            getContent(page, 'visibility-lang').getBox().should('contain', 'Nothing to display');
+            getContent(page, 'visibility-lang').getBox().getStatus('notVisible').should('be.visible');
+            getContent(page, 'visibility-lang').getBox().get().should('contain', 'Nothing to display');
         });
     });
 
@@ -109,10 +109,10 @@ describe('Page builder - content status', () => {
         it('does not show any publication status when page is not published', () => {
             jContentPageBuilder.getStatusSelector().assertCount('published', 0);
             jContentPageBuilder.getStatusSelector().showPublication();
-            getContent(page, 'wip-all').getBoxStatus('workInProgress').should('be.visible');
-            getContent(page, 'wip-all').getBoxStatus('workInProgress').should('be.visible');
-            getContent(page, 'wip-en').assertNoBoxStatus('notPublished');
-            getContent(page, 'wip-en').assertNoBoxStatus('notPublished');
+            getContent(page, 'wip-all').getBox().getStatus('workInProgress').should('be.visible');
+            getContent(page, 'wip-all').getBox().getStatus('workInProgress').should('be.visible');
+            getContent(page, 'wip-en').getBox().assertNoStatus('notPublished');
+            getContent(page, 'wip-en').getBox().assertNoStatus('notPublished');
         });
 
         it('shows publication status when page is published', () => {
@@ -121,10 +121,10 @@ describe('Page builder - content status', () => {
 
             jContentPageBuilder.getStatusSelector().assertCount('published', 2);
             jContentPageBuilder.getStatusSelector().showPublication();
-            getContent(page, 'wip-all').getBoxStatus('workInProgress').should('be.visible');
-            getContent(page, 'wip-all').getBoxStatus('workInProgress').should('be.visible');
-            getContent(page, 'wip-en').getBoxStatus('notPublished').should('be.visible');
-            getContent(page, 'wip-en').getBoxStatus('notPublished').should('be.visible');
+            getContent(page, 'wip-all').getBox().getStatus('workInProgress').should('be.visible');
+            getContent(page, 'wip-all').getBox().getStatus('workInProgress').should('be.visible');
+            getContent(page, 'wip-en').getBox().getStatus('notPublished').should('be.visible');
+            getContent(page, 'wip-en').getBox().getStatus('notPublished').should('be.visible');
         });
     });
 
@@ -144,14 +144,14 @@ describe('Page builder - content status', () => {
             getContent(page, 'visibility-datetime').assertNoBox();
 
             jContentPageBuilder.getStatusSelector().showVisibility();
-            getContent(page, 'visibility-lang').getBoxStatus('visibilityConditions').should('be.visible');
-            getContent(page, 'visibility-datetime').getBoxStatus('visibilityConditions').should('be.visible');
+            getContent(page, 'visibility-lang').getBox().getStatus('visibilityConditions').should('be.visible');
+            getContent(page, 'visibility-datetime').getBox().getStatus('visibilityConditions').should('be.visible');
         });
 
         it('shows permission status', () => {
             jContentPageBuilder.getStatusSelector().assertCount('permissions', 1);
             jContentPageBuilder.getStatusSelector().showPermission();
-            getContent(page, 'permission').getBoxStatus('permissions').should('be.visible');
+            getContent(page, 'permission').getBox().getStatus('permissions').should('be.visible');
         });
 
         it('does not include to status count when marked for deletion', () => {

--- a/tests/cypress/e2e/pageBuilder/selections.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/selections.cy.ts
@@ -36,27 +36,27 @@ describe('Page builder - selections test', () => {
     it('Selects all items with meta key and deselect them with meta key', () => {
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
         let module = jcontent.getModule(item1);
-        module.click({metaKey: true});
+        module.select();
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
 
         module = jcontent.getModule(item2);
-        module.click({metaKey: true});
+        module.select();
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '2 items selected');
 
         module = jcontent.getModule(item3);
-        module.click({metaKey: true});
+        module.select();
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '3 items selected');
 
         // Unselect by clicking
-        module.click({metaKey: true});
+        module.unselect();
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '2 items selected');
 
         module = jcontent.getModule(item2);
-        module.click({metaKey: true});
+        module.unselect();
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
 
         module = jcontent.getModule(item1);
-        module.click({metaKey: true});
+        module.unselect();
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
     });
 

--- a/tests/cypress/e2e/pageBuilder/selections.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/selections.cy.ts
@@ -27,7 +27,7 @@ describe('Page builder - selections test', () => {
 
     it('Selects and unselects one item when clicking outside the selected module', () => {
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
-        jcontent.getModule(item1).getHeader(true).select();
+        jcontent.getModule(item1, false).getHeader(true).select();
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
         jcontent.iframe(true).get().find('.wrapper').parent().parent().click('left', {timeout: 1000, force: true});
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
@@ -35,7 +35,7 @@ describe('Page builder - selections test', () => {
 
     it('Selects all items with meta key and deselect them with meta key', () => {
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
-        let module = jcontent.getModule(item1);
+        let module = jcontent.getModule(item1, false);
         module.select();
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
 
@@ -62,7 +62,7 @@ describe('Page builder - selections test', () => {
 
     it('Clears selection when unselected', () => {
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
-        const module = jcontent.getModule(item1);
+        const module = jcontent.getModule(item1, false);
         jcontent.getModule(item1).getHeader(true).select();
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
 
@@ -78,7 +78,7 @@ describe('Page builder - selections test', () => {
 
     it('Allows to select with right click', () => {
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
-        let module = jcontent.getModule(item1);
+        let module = jcontent.getModule(item1, false);
         module.click();
         module.getHeader().select();
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
@@ -95,7 +95,7 @@ describe('Page builder - selections test', () => {
         // Note that in some cases it may be possible to just refresh and not be able to select anything,
         // but it appears to be a different issue as we don't get 'language is required' exception from useNodeInfo
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
-        jcontent.getModule(item2).getHeader(true).select();
+        jcontent.getModule(item2, false).getHeader(true).select();
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
 
         jcontent.clearSelection();
@@ -107,7 +107,7 @@ describe('Page builder - selections test', () => {
 
     it('Opens Content Editor on double click', () => {
         cy.get('div[data-sel-role="selection-infos"]').should('not.exist');
-        jcontent.getModule(item1).getHeader(true).select();
+        jcontent.getModule(item1, false).getHeader(true).select();
         jcontent.getSelectionDropdown().get().find('span').should('have.text', '1 item selected');
         jcontent.getModule(item1).doubleClick();
         const contentEditor = new ContentEditor();

--- a/tests/cypress/page-object/contentEditor.ts
+++ b/tests/cypress/page-object/contentEditor.ts
@@ -186,7 +186,7 @@ export class ContentEditor extends BasePage {
     }
 
     validateContentIsNotVisibleInPreview(content: string) {
-        cy.frameLoaded('[data-sel-role="edit-preview-frame"]'   , {timeout: 30000});
+        cy.frameLoaded('[data-sel-role="edit-preview-frame"]', {timeout: 30000});
         cy.iframe('[data-sel-role="edit-preview-frame"]').should($body => {
             expect($body.text()).not.to.include(content);
         }, {timeout: 10000});

--- a/tests/cypress/page-object/contentEditor.ts
+++ b/tests/cypress/page-object/contentEditor.ts
@@ -177,14 +177,19 @@ export class ContentEditor extends BasePage {
     }
 
     validateContentIsVisibleInPreview(content: string) {
-        cy.iframe('[data-sel-role="edit-preview-frame"]', {timeout: 90000})
-            .contains(content, {timeout: 90000}).should('be.visible'); // Will retry until content is found
+        cy.frameLoaded('[data-sel-role="edit-preview-frame"]', {timeout: 90000});
+        cy.iframe('[data-sel-role="edit-preview-frame"]').should($body => {
+            // Sometimes iframe is not fully loaded, so we check if body is not empty
+            expect($body.text().trim().length).to.be.greaterThan(0);
+            expect($body.text()).to.include(content);
+        }, {timeout: 10000});
     }
 
     validateContentIsNotVisibleInPreview(content: string) {
-        cy.iframe('[data-sel-role="edit-preview-frame"]', {timeout: 30000, log: true}).within(() => {
-            cy.contains(content, {timeout: 5000}).should('not.exist');
-        });
+        cy.frameLoaded('[data-sel-role="edit-preview-frame"]'   , {timeout: 30000});
+        cy.iframe('[data-sel-role="edit-preview-frame"]').should($body => {
+            expect($body.text()).not.to.include(content);
+        }, {timeout: 10000});
     }
 
     assertValidationErrorsNotExist() {

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
@@ -3,7 +3,7 @@ import ClickOptions = Cypress.ClickOptions;
 import {PageBuilderModuleHeader} from './pageBuilderModuleHeader';
 import {PageBuilderModuleFooter} from './pageBuilderModuleFooter';
 import {PageBuilderModuleCreateButton} from './pageBuilderModuleCreateButton';
-import {PageBuilderModuleBox} from "./pageBuilderModuleBox";
+import {PageBuilderModuleBox} from './pageBuilderModuleBox';
 
 export class PageBuilderModule extends BaseComponent {
     static defaultSelector = '[jahiatype="module"]';
@@ -44,9 +44,11 @@ export class PageBuilderModule extends BaseComponent {
     getHeader(selectFirst = false): PageBuilderModuleHeader {
         this.hover();
         if (selectFirst) {
+            // Hovered state is only for unselected modules; this fails if the module is already selected
             this.getBox().assertIsHovered();
             this.click(); // Header shows up only when selected
         }
+
         return this.getBox().getHeader();
     }
 
@@ -97,12 +99,12 @@ export class PageBuilderModule extends BaseComponent {
         this.get().scrollIntoView();
         this.get().click(clickOptions);
         if (clickOptions?.metaKey) {
-            const assertSelected = clickOptions?.hasOwnProperty('assertSelected') ? clickOptions.assertSelected : true;
+            const assertSelected = (clickOptions && Object.prototype.hasOwnProperty.call(clickOptions, 'assertSelected')) ? clickOptions.assertSelected : true;
             if (assertSelected) {
                 this.getBox().assertIsSelected();
             }
         } else {
-            const assertClicked = clickOptions?.hasOwnProperty('assertClicked') ? clickOptions.assertClicked : true
+            const assertClicked = (clickOptions && Object.prototype.hasOwnProperty.call(clickOptions, 'assertClicked')) ? clickOptions.assertClicked : true;
             if (assertClicked) {
                 this.getBox().assertIsClicked();
             }

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
@@ -1,8 +1,9 @@
-import {BaseComponent, getComponentBySelector, Menu} from '@jahia/cypress';
+import {BaseComponent, getComponentByAttr, getComponentBySelector, Menu} from '@jahia/cypress';
 import ClickOptions = Cypress.ClickOptions;
 import {PageBuilderModuleHeader} from './pageBuilderModuleHeader';
 import {PageBuilderModuleFooter} from './pageBuilderModuleFooter';
 import {PageBuilderModuleCreateButton} from './pageBuilderModuleCreateButton';
+import {PageBuilderModuleBox} from "./pageBuilderModuleBox";
 
 export class PageBuilderModule extends BaseComponent {
     static defaultSelector = '[jahiatype="module"]';
@@ -11,31 +12,17 @@ export class PageBuilderModule extends BaseComponent {
 
     hover() {
         this.get().realHover();
+        this.getBox().assertIsHovered();
         return this.get();
     }
 
-    getBox() {
-        return cy.get(`@component${this.parentFrame.id}`)
-            .find(`[data-sel-role="page-builder-box"][data-jahia-path="${this.path}"]`);
+    getBox(): PageBuilderModuleBox {
+        return getComponentByAttr(PageBuilderModuleBox, 'data-jahia-path', this.path, this.parentFrame);
     }
 
     assertNoBox() {
         return cy.get(`@component${this.parentFrame.id}`)
             .find(`[data-sel-role="page-builder-box"][data-jahia-path="${this.path}"]`).should('not.exist');
-    }
-
-    getBoxStatus(status: string) {
-        this.getBox().find(`[data-sel-role="content-status"][data-status-type="${status}"]`).scrollIntoView();
-        return this.getBox().find(`[data-sel-role="content-status"][data-status-type="${status}"]`);
-    }
-
-    /*
-     * Use specifically to check when expected for content to have other statuses displayed (i.e. box element exists)
-     * Otherwise use `assertBoxNotExist` when there are no badges displayed
-     */
-    assertNoBoxStatus(status: string) {
-        this.getBox().scrollIntoView();
-        return this.getBox().find(`[data-sel-role="content-status"][data-status-type="${status}"]`).should('not.exist');
     }
 
     getForDeletionStatus() {
@@ -55,13 +42,12 @@ export class PageBuilderModule extends BaseComponent {
         });
     }
 
-    getHeader(selectFirst = false) {
+    getHeader(selectFirst = false): PageBuilderModuleHeader {
         this.hover();
         if (selectFirst) {
             this.click(); // Header shows up only when selected
         }
-
-        return new PageBuilderModuleHeader(this.getBox().find('[jahiatype="header"]'));
+        return this.getBox().getHeader();
     }
 
     getFooter() {
@@ -85,8 +71,9 @@ export class PageBuilderModule extends BaseComponent {
 
     contextMenu(selectFirst = false, force = true): Menu {
         if (selectFirst) {
-            this.click();
-            this.getHeader().get().should('be.visible').rightclick({force, waitForAnimations: true});
+            this.getHeader(selectFirst).get()
+                .should('be.visible')
+                .rightclick({force, waitForAnimations: true});
         } else {
             this.hover();
             this.get().rightclick({force, waitForAnimations: true});
@@ -103,6 +90,7 @@ export class PageBuilderModule extends BaseComponent {
 
     click(clickOptions?: Partial<ClickOptions>) {
         this.get().scrollIntoView().click(clickOptions);
+        this.getBox().assertIsClicked();
     }
 
     doubleClick(clickOptions?: Partial<ClickOptions>) {

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModuleBox.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModuleBox.ts
@@ -1,5 +1,5 @@
-import {BaseComponent} from "@jahia/cypress";
-import {PageBuilderModuleHeader} from "./pageBuilderModuleHeader";
+import {BaseComponent} from '@jahia/cypress';
+import {PageBuilderModuleHeader} from './pageBuilderModuleHeader';
 
 export class PageBuilderModuleBox extends BaseComponent {
     static readonly defaultSelector: string = '[data-sel-role="page-builder-box"]';

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModuleBox.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModuleBox.ts
@@ -1,0 +1,36 @@
+import {BaseComponent} from "@jahia/cypress";
+import {PageBuilderModuleHeader} from "./pageBuilderModuleHeader";
+
+export class PageBuilderModuleBox extends BaseComponent {
+    static readonly defaultSelector: string = '[data-sel-role="page-builder-box"]';
+
+    getHeader(): PageBuilderModuleHeader {
+        return new PageBuilderModuleHeader(this.get().find('[jahiatype="header"]'));
+    }
+
+    getStatus(status: string) {
+        this.get().find(`[data-sel-role="content-status"][data-status-type="${status}"]`).scrollIntoView();
+        return this.get().find(`[data-sel-role="content-status"][data-status-type="${status}"]`);
+    }
+
+    /*
+     * Use specifically to check when expected for content to have other statuses displayed (i.e. box element exists)
+     * Otherwise use `assertBoxNotExist` when there are no badges displayed
+     */
+    assertNoStatus(status: string) {
+        this.get().scrollIntoView();
+        return this.get().find(`[data-sel-role="content-status"][data-status-type="${status}"]`).should('not.exist');
+    }
+
+    assertIsHovered(): Cypress.Chainable<JQuery> {
+        return this.get().should('have.attr', 'data-box-hovered', 'true');
+    }
+
+    assertIsSelected(): Cypress.Chainable<JQuery> {
+        return this.get().should('have.attr', 'data-box-selected', 'true');
+    }
+
+    assertIsClicked(): Cypress.Chainable<JQuery> {
+        return this.get().should('have.attr', 'data-box-clicked', 'true');
+    }
+}

--- a/tests/cypress/page-object/translateEditor.ts
+++ b/tests/cypress/page-object/translateEditor.ts
@@ -62,11 +62,11 @@ export class TranslateEditor extends ContentEditor {
         return getComponentByAttr(FieldComponent, 'data-sel-content-editor-field', fieldName, this.getTranslateColumn());
     }
 
-    getSourceLanguageSwitcher() {
+    getSourceLanguageSwitcher(): LanguageSwitcher {
         return this.getMultiLanguageSwitcher(this.getSourceColumn());
     }
 
-    getTranslateLanguageSwitcher() {
+    getTranslateLanguageSwitcher(): LanguageSwitcher {
         return this.getMultiLanguageSwitcher(this.getTranslateColumn());
     }
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -28,7 +28,7 @@
     "@types/node": "^22.14.0",
     "@typescript-eslint/eslint-plugin": "^8.29.1",
     "@typescript-eslint/parser": "^8.29.1",
-    "cypress": "^14.2.1",
+    "cypress": "^14.5.4",
     "cypress-iframe": "^1.0.1",
     "cypress-multi-reporters": "^2.0.5",
     "cypress-terminal-report": "^5.0.2",

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -25,15 +25,10 @@
     tslib "^2.3.0"
     zen-observable-ts "^1.2.5"
 
-"@colors/colors@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
-  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
-
-"@cypress/request@^3.0.8":
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.8.tgz#992f1f42ba03ebb14fa5d97290abe9d015ed0815"
-  integrity sha512-h0NFgh1mJmm1nr4jCwkGHwKneVYKghUyWe6TMNrk0B9zsjAJxpg8C4/+BAcmLgCPa1vj1V8rNUaILl+zYRUWBQ==
+"@cypress/request@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.9.tgz#8ed6e08fea0c62998b5552301023af7268f11625"
+  integrity sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -41,7 +36,7 @@
     combined-stream "~1.0.6"
     extend "~3.0.2"
     forever-agent "~0.6.1"
-    form-data "~4.0.0"
+    form-data "~4.0.4"
     http-signature "~1.4.0"
     is-typedarray "~1.0.0"
     isstream "~0.1.2"
@@ -876,14 +871,14 @@ cli-progress@^3.4.0:
   dependencies:
     string-width "^4.2.3"
 
-cli-table3@~0.6.5:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.5.tgz#013b91351762739c16a9567c21a04632e449bf2f"
-  integrity sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==
+cli-table3@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.1.tgz#36ce9b7af4847f288d3cdd081fbd09bf7bd237b8"
+  integrity sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==
   dependencies:
     string-width "^4.2.0"
   optionalDependencies:
-    "@colors/colors" "1.5.0"
+    colors "1.4.0"
 
 cli-truncate@^2.1.0:
   version "2.1.0"
@@ -950,6 +945,11 @@ colorette@^2.0.16:
   version "2.0.17"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.17.tgz#5dd4c0d15e2984b7433cb4a9f2ead45063b80c47"
   integrity sha512-hJo+3Bkn0NCHybn9Tu35fIeoOKGOk5OCC32y4Hz2It+qlCO2Q3DeQ1hRn/tDDMQKRYUEzqsl7jbF6dYKjlE60g==
+
+colors@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
@@ -1064,12 +1064,12 @@ cypress-wait-until@^1.7.2:
   resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz#7f534dd5a11c89b65359e7a0210f20d3dfc22107"
   integrity sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==
 
-cypress@^14.2.1:
-  version "14.2.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-14.2.1.tgz#2628696588d3d3961bf0ea0ad87baeb359790dcd"
-  integrity sha512-5xd0E7fUp0pjjib1D7ljkmCwFDgMkWuW06jWiz8dKrI7MNRrDo0C65i4Sh+oZ9YHjMHZRJBR0XZk1DfekOhOUw==
+cypress@^14.5.4:
+  version "14.5.4"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-14.5.4.tgz#d821fbb6220c3328e7413acc7724b75319c9e64d"
+  integrity sha512-0Dhm4qc9VatOcI1GiFGVt8osgpPdqJLHzRwcAB5MSD/CAAts3oybvPUPawHyvJZUd8osADqZe/xzMsZ8sDTjXw==
   dependencies:
-    "@cypress/request" "^3.0.8"
+    "@cypress/request" "^3.0.9"
     "@cypress/xvfb" "^1.2.4"
     "@types/sinonjs__fake-timers" "8.1.1"
     "@types/sizzle" "^2.3.2"
@@ -1082,7 +1082,7 @@ cypress@^14.2.1:
     check-more-types "^2.24.0"
     ci-info "^4.1.0"
     cli-cursor "^3.1.0"
-    cli-table3 "~0.6.5"
+    cli-table3 "0.6.1"
     commander "^6.2.1"
     common-tags "^1.8.0"
     dayjs "^1.10.4"
@@ -1095,6 +1095,7 @@ cypress@^14.2.1:
     figures "^3.2.0"
     fs-extra "^9.1.0"
     getos "^3.2.1"
+    hasha "5.2.2"
     is-installed-globally "~0.4.0"
     lazy-ass "^1.6.0"
     listr2 "^3.8.3"
@@ -1265,6 +1266,16 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
   dependencies:
     es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -1613,13 +1624,15 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
-form-data@~4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+form-data@~4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
+  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
     mime-types "^2.1.12"
 
 fs-extra@^10.0.0, fs-extra@^10.1.0:
@@ -1698,7 +1711,7 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -1897,10 +1910,25 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-symbols@^1.1.0:
+has-symbols@^1.0.3, has-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
   integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
+has-tostringtag@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
+  dependencies:
+    has-symbols "^1.0.3"
+
+hasha@5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/hasha/-/hasha-5.2.2.tgz#a48477989b3b327aea3c04f53096d816d97522a1"
+  integrity sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==
+  dependencies:
+    is-stream "^2.0.0"
+    type-fest "^0.8.0"
 
 hasown@^2.0.2:
   version "2.0.2"
@@ -3329,6 +3357,11 @@ type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-fest@^0.8.0:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
+  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
### Description

- Added more selectors and validation around selection, hovering of page builder boxes
  -  Refactored page builder box into a separate page object.
- Enable checks for create buttons (bypassFrameLoadedCheck=false) when using `jcontent.getModule()`
  - create buttons were popping up and causing screen to shift during hover and click actions on page builder boxes 
- Fix issue with iframe checking with dynamic content on preview test
-  Some authentication issues encountered on createMedia, contentEditorForms; Added logout steps
- Sync issues when testing translate UI because of field focus that happens on first field that interrupts testing.
- Update to latest minor cypress 14.x (v15 recently came out but holding off for now)
- There is still this flakiness that happens on deleteAdvanced that sometimes shows different counts for number of items to be deleted. I added a step for debugging.

Multiple re-runs have been passing consecutively with these latest changes https://github.com/Jahia/jcontent/actions/runs/17479947900 but will try to monitor after merge.

