### PR TITLE
fix: Show links in structured view

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
@@ -11,7 +11,7 @@ export const PagesQueryHandler = {
 
     structureTreeEntries: (treeEntries, {hideRoot}) => {
         // Filter out internal/external links and menu titles off the tree
-        const typesToFilterOut = ['jnt:nodeLink', 'jnt:externalLink', 'jnt:navMenuText'];
+        const typesToFilterOut = ['jnt:navMenuText'];
         const filteredTreeEntries = treeEntries.filter(entry => !typesToFilterOut.includes(entry.node.primaryNodeType.name));
 
         return BaseTreeQueryHandler.structureTreeEntries(filteredTreeEntries, {hideRoot});


### PR DESCRIPTION
### Description
Show links in structured view. Links are content and can be displayed on the page so they should be shown in structured view.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
