### PR TITLE
test: improve ChoiceListField helpers

### DIFF
--- a/tests/cypress/page-object/fields/choiceListField.ts
+++ b/tests/cypress/page-object/fields/choiceListField.ts
@@ -7,7 +7,7 @@ export class ChoiceListField extends Field {
      * @param value The value to add (must match exactly).
      */
     addNewValue(value: string): void {
-        this.get().click();
+        this.get().should('exist').click();
         getComponentBySelector(Menu, '[role="list"]').selectByValue(value);
     }
 
@@ -29,13 +29,12 @@ export class ChoiceListField extends Field {
             throw new Error('Cannot use selectValues(string[]) for single-value choice list, use selectValue(string) instead');
         }
 
-        this.get().click();
+        this.openDropdown();
         const menu = getComponent(Menu, this);
         values.forEach(value => {
             menu.selectByValue(value);
         });
-        // Close the dropdown:
-        getComponent(Dropdown, this).get().parent().click();
+        this.closeDropdown();
     }
 
     /**
@@ -48,13 +47,14 @@ export class ChoiceListField extends Field {
             throw new Error('Cannot use selectValue(string) for single-value choice list, use selectValues(string[]) instead');
         }
 
-        this.get().click();
+        this.openDropdown();
         const menu = getComponent(Menu, this);
         menu.selectByValue(value);
+        // For single-value choice lists, selecting the value closes the dropdown, no need to call this.closeDropdown()
     }
 
     /**
-     * Asserts that all currently selected values in a multi-select choice list match the provided values exactly.
+     * Opens the dropdown, asserts that all currently selected values in a multi-select choice list match the provided values exactly and closes the dropdown.
      * The number and content of selected values must match exactly.
      * Throws an error if used on a single-value choice list.
      * @param values The exact set of values expected to be selected.
@@ -64,16 +64,17 @@ export class ChoiceListField extends Field {
             throw new Error('Cannot use shouldHaveSelectedValues(string[]) for single-value choice list, use shouldHaveSelectedValue(string) instead');
         }
 
-        this.get().click(); // Open the dropdown
+        this.openDropdown();
         values.forEach(value => {
             this.get().find(`.moonstone-menuItem[data-value="${value}"][data-selected=true]`).should('exist');
         });
         // The count of selected items should match
         this.get().find('.moonstone-menuItem[data-selected=true]').should('have.length', values.length);
+        this.closeDropdown();
     }
 
     /**
-     * Asserts that the currently selected value in a single-value choice list matches the provided value exactly.
+     * Opens the dropdown, asserts that the currently selected value in a single-value choice list matches the provided value exactly and closes the dropdown.
      * Throws an error if used on a multi-value choice list.
      * @param value The exact value expected to be selected.
      */
@@ -82,30 +83,51 @@ export class ChoiceListField extends Field {
             throw new Error('Cannot use shouldHaveSelectedValue(string) for single-value choice list, use shouldHaveSelectedValues(string[]) instead');
         }
 
-        this.get().click(); // Open the dropdown
+        this.openDropdown();
         this.get().find(`.moonstone-menuItem.moonstone-selected[data-value="${value}"]`).should('exist');
+        this.closeDropdown();
     }
 
     /**
-     * Asserts that the available values in the choice list match the provided list exactly (order and content).
+     * Opens the dropdown, asserts that the available values in the choice list match the provided list exactly (order and content) and closes the dropdown.
      * Opens the dropdown to check and closes it after.
      * @param values The exact set of values expected to be available.
      */
     shouldHaveValues(values: string[]): void {
-        this.get().click();
-        const dropdown = getComponent(Dropdown, this);
-        if (this.multiple) {
-            dropdown.get().click();
-        }
-
-        dropdown.get().should('be.visible');
-
+        this.openDropdown();
         values.forEach(value => {
             this.get().find(`.moonstone-menuItem[data-value="${value}"]`).should('exist');
         });
         // The count of available items should match
         this.get().find('.moonstone-menuItem').should('have.length', values.length);
-        // Close the dropdown:
-        getComponent(Dropdown, this).get().parent().click();
+        this.closeDropdown();
+    }
+
+    private openDropdown(): void {
+        // Ensure the choice list is ready
+        this.get().find('[data-sel-content-editor-select-readonly=false]').should('exist');
+        const dropdown = getComponent(Dropdown, this).get().should('exist');
+        dropdown.then($el => {
+            // Only click if menu is not visible
+            if ($el.find('.moonstone-menu').length === 0) {
+                dropdown.click();
+            }
+        });
+        // Wait for the menu to be visible
+        this.get().find('.moonstone-menu').should('exist');
+    }
+
+    private closeDropdown(): void {
+        // Ensure the choice list is ready
+        this.get().find('[data-sel-content-editor-select-readonly=false]').should('exist');
+        const dropdown = getComponent(Dropdown, this).get().should('exist');
+        dropdown.then($el => {
+            // Only click if menu is visible
+            if ($el.find('.moonstone-menu').length > 0) {
+                dropdown.click();
+            }
+        });
+        // Wait for the menu to be hidden
+        this.get().find('.moonstone-menu').should('not.exist');
     }
 }


### PR DESCRIPTION
Closes https://github.com/Jahia/jahia-private/issues/4609.
Follows https://github.com/Jahia/jcontent/pull/1941.

### Description

Improve the helpers methods of `ChoiceListField` that assert its selected and available values.
The main change is to wait for the data attribute `data-sel-content-editor-select-readonly` to be set to `false` when opening the dropdown, to ensure the dropdown is ready to be inspected / asserted.
This fixes race condition issues that may occur (see https://github.com/Jahia/jahia-ee/actions/runs/16917636574/job/47936829088?pr=874).

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
