### PR TITLE
fix: site switcher loading/disabled style, moonstone bump to 2.16.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@jahia/data-helper": "^1.1.14",
     "@jahia/design-system-kit": "^1.2.1",
     "@jahia/icons": "^1.1.2",
-    "@jahia/moonstone": "^2.16.1",
+    "@jahia/moonstone": "^2.16.2",
     "@jahia/react-material": "^3.0.5",
     "@jahia/ui-extender": "^1.1.1",
     "@material-ui/core": "^3.9.3",

--- a/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SiteSwitcher.jsx
+++ b/src/javascript/JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SiteSwitcher.jsx
@@ -71,7 +71,7 @@ const SiteSwitcher = ({selector, onSelectAction, isSiteEnabled}) => {
 
                     if (loading) {
                         return (
-                            <Dropdown isDisabled
+                            <Dropdown isLoading
                                       data={[{label: 'none', value: 'none', name: 'none', site: 'none'}]}
                                       className={styles.siteSwitcher}
                                       onChange={() => {}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1858,14 +1858,13 @@
     mdi-material-ui "^5.10.0"
     recompose "^0.30.0"
 
-"@jahia/moonstone@^2.16.1":
-  version "2.16.1"
-  resolved "https://npm.jahia.com/@jahia%2fmoonstone/-/moonstone-2.16.1.tgz#55f5d86132abb2a6cf0b45362bc32efac237f3a7"
-  integrity sha512-Zj2osvLHUR9GcXTRv6NKiBvh7UhamkcpBqzl18u5c00mbTaDtY88AH5RvEb4e8TY9UTXYrmnqpzhG0qKFogjjw==
+"@jahia/moonstone@^2.16.2":
+  version "2.16.2"
+  resolved "https://npm.jahia.com/@jahia%2fmoonstone/-/moonstone-2.16.2.tgz#58e20d251599dc334d90e0b9ced2c89921388aa2"
+  integrity sha512-qFwDgNFjd64Sncpj8UFjV3R7MfT9UYtqH+HJYSXL2dxEsgYB7ghewS/0St4PuFCxsgL2yl3y7SPLxpuzvLA25g==
   dependencies:
     "@floating-ui/react" "^0.27.7"
     clsx "^2.1.1"
-    prop-types "^15.8.1"
     re-resizable "^6.11.2"
     to-px "^1.1.0"
 


### PR DESCRIPTION
### Description
This PR bumps the moonstone and uses the new isLoading prop for site switcher

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
