### PR TITLE
fix: Avoid showing 'unselected' if lang available

### DIFF
--- a/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/CopyLanguageDialog.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/CopyLanguageDialog.jsx
@@ -47,14 +47,12 @@ export const CopyLanguageDialog = ({
         .find(e => e.value === sideBySideContext.lang);
 
     const defaultLanguageOption = useMemo(() => {
-        if (defaultLanguage !== language) {
-            const availableLanguageOption = availableLanguages.find(al => al.language === defaultLanguage);
-            if (availableLanguageOption) {
-                return {
-                    label: availableLanguageOption.uiLanguageDisplayName,
-                    value: availableLanguageOption.language
-                };
-            }
+        const availableLanguageOption = availableLanguages.find(al => al.language === defaultLanguage) || availableLanguages[0];
+        if (availableLanguageOption) {
+            return {
+                label: availableLanguageOption.uiLanguageDisplayName,
+                value: availableLanguageOption.language
+            };
         }
     }, [defaultLanguage, language, availableLanguages]);
 
@@ -115,12 +113,12 @@ export const CopyLanguageDialog = ({
                         size="medium"
                         data-sel-role="from-language-selector"
                         isDisabled={Boolean(sbsOption)}
-                        data={[defaultOption].concat(availableLanguages.map(element => {
+                        data={sbsOption || defaultLanguageOption ? availableLanguages.map(element => {
                             return {
                                 value: element.language,
                                 label: element.uiLanguageDisplayName
                             };
-                        }))}
+                        }) : [defaultOption]}
                         onChange={handleOnChange}
                     />}
                 <Typography className={styles.label}>

--- a/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/CopyLanguageDialog.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/CopyLanguageDialog.jsx
@@ -54,7 +54,7 @@ export const CopyLanguageDialog = ({
                 value: availableLanguageOption.language
             };
         }
-    }, [defaultLanguage, language, availableLanguages]);
+    }, [defaultLanguage, availableLanguages]);
 
     const defaultOption = sbsOption || {
         label: t('jcontent:label.contentEditor.edit.action.copyLanguage.defaultValue'),


### PR DESCRIPTION
### Description
Avoid showing 'unselected' if language is available, try to select default or first available language instead.

Note that I couldn't reproduce original issue, I saw it only once, it looks like it happened only once for Sonia as well. Instead of focusing of reproducing the issue I went with the general idea of removing `unselected` from drop down if we have available languages. Default or first available language is used for selection.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
