### PR TITLE
fix: Explicitly check for mimetype

### DIFF
--- a/tests/cypress/e2e/jcontent/sort.cy.ts
+++ b/tests/cypress/e2e/jcontent/sort.cy.ts
@@ -40,7 +40,9 @@ describe('Table sorting tests', () => {
         const header = jcontent.getTable().getHeaderByRole('type');
         header.sort();
         jcontent.getTable().getRowByIndex(2).element.contains('myfile.txt');
+        jcontent.getTable().getRowByIndex(2).element.contains('text/plain');
         header.sort();
         jcontent.getTable().getRowByIndex(2).element.contains('myfile.hol');
+        jcontent.getTable().getRowByIndex(2).element.contains('application/octet-stream');
     });
 });


### PR DESCRIPTION
### Description
Explicitly check for mimetype in sort test

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
