### PR TITLE
fix: Disable action in create mode and if no languages

### DIFF
--- a/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/copyLanguageAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/copyLanguageAction.jsx
@@ -8,13 +8,14 @@ import {useFormikContext} from 'formik';
 
 export const CopyLanguageActionComponent = ({render: Render, ...otherProps}) => {
     const {render, destroy} = useContext(ComponentRendererContext);
-    const {nodeData, lang, siteInfo} = useContentEditorContext();
+    const {mode, nodeData, lang, siteInfo} = useContentEditorContext();
     const {sideBySideContext} = useContentEditorConfigContext();
     const formik = useFormikContext();
     const availableLanguages = siteInfo.languages.filter(l => l.language !== lang && nodeData.translationLanguages?.includes(l.language));
 
     return (
         <Render {...otherProps}
+                enabled={mode !== 'create' && availableLanguages.length > 0}
                 isVisible={siteInfo.languages.length > 1 && nodeData.hasWritePermission && !nodeData.lockedAndCannotBeEdited}
                 onClick={() => {
                     render('CopyLanguageDialog', CopyLanguageDialog, {

--- a/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/copyLanguageAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/copyLanguageAction.jsx
@@ -15,7 +15,7 @@ export const CopyLanguageActionComponent = ({render: Render, ...otherProps}) => 
 
     return (
         <Render {...otherProps}
-                enabled={mode !== 'create' && availableLanguages.length > 0}
+                enabled={mode !== 'create'}
                 isVisible={siteInfo.languages.length > 1 && nodeData.hasWritePermission && !nodeData.lockedAndCannotBeEdited}
                 onClick={() => {
                     render('CopyLanguageDialog', CopyLanguageDialog, {

--- a/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/copyLanguageAction.spec.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/copyLanguageAction.spec.jsx
@@ -28,7 +28,8 @@ describe('copy language action', () => {
                     {displayName: 'Deutsch', language: 'de', activeInEdit: true},
                     {displayName: 'Français', language: 'fr', activeInEdit: true}
                 ]
-            }
+            },
+            mode: 'edit'
         };
         useContentEditorContext.mockReturnValue(contentEditorContext);
         defaultProps = {
@@ -44,7 +45,7 @@ describe('copy language action', () => {
             dsGenericTheme
         );
 
-        expect(cmp.props().enabled).toBeFalsy();
+        expect(cmp.props().isVisible).toBeFalsy();
     });
 
     it('should render not be enabled when the node is locked', () => {
@@ -55,7 +56,7 @@ describe('copy language action', () => {
             dsGenericTheme
         );
 
-        expect(cmp.props().enabled).toBeFalsy();
+        expect(cmp.props().isVisible).toBeFalsy();
     });
 
     it('should be visible when there is more than one language', () => {


### PR DESCRIPTION
### Description
Disable copy from language action in create mode and if there is no languages.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
