### PR TITLE
feat: add comparisonMode parameter in url parameters

### DIFF
--- a/src/javascript/JContent/CompareDialog/FrameManager/FrameManager.jsx
+++ b/src/javascript/JContent/CompareDialog/FrameManager/FrameManager.jsx
@@ -65,12 +65,11 @@ const FrameManager = () => {
     // Load frames
     useEffect(() => {
         if (leftFrame.current && data?.jcr?.result?.renderUrlEdit) {
-            // Add hidePersonaPanel parameter to Hide jexperience persona panel in the page
-            leftFrame.current.contentWindow.location.href = resolveUrlForLiveOrPreview(data.jcr.result.renderUrlEdit, false);
+            leftFrame.current.contentWindow.location.href = `${resolveUrlForLiveOrPreview(data.jcr.result.renderUrlEdit, false)}?comparisonMode`;
         }
 
         if (rightFrame.current && data?.jcr?.result?.renderUrlLive) {
-            rightFrame.current.contentWindow.location.href = resolveUrlForLiveOrPreview(data.jcr.result.renderUrlLive, true, data.jcr.result.site.serverName);
+            rightFrame.current.contentWindow.location.href = `${resolveUrlForLiveOrPreview(data.jcr.result.renderUrlLive, true, data.jcr.result.site.serverName)}?comparisonMode`;
         }
     }, [leftFrame, rightFrame, data]);
 


### PR DESCRIPTION
### Description
A parameter named comparisonMode has been added to the url of the frame displaying the pages in comparison mode.
It will allow to the other modules that the displayed page are not in preview or live.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
