### PR TITLE
feat(content-editor): node type in chip title

### DIFF
--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelCompact.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelCompact.jsx
@@ -51,7 +51,7 @@ export const EditPanelCompact = ({title, createAnother}) => {
                     <HeaderThreeDotsActions/>
                 </div>
                 <div className={clsx('flexRow', 'alignCenter')}>
-                    <Chip color="accent" label={nodeTypeDisplayName || nodeTypeName} icon={getNodeTypeIcon(nodeTypeName)}/>
+                    <Chip color="accent" label={nodeTypeDisplayName || nodeTypeName} icon={getNodeTypeIcon(nodeTypeName)} title={nodeTypeName}/>
                     <div className="flexFluid"/>
                     <HeaderBadges mode={mode}/>
                 </div>

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/EditPanelHeader.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/EditPanelHeader.jsx
@@ -50,7 +50,7 @@ export const EditPanelHeader = ({title, isShowPublish, hideLanguageSwitcher, act
                     nodeData?.path?.startsWith('/sites') && <ContentPath path={nodeData.path}/>
                 )}
                 contentType={(
-                    <Chip color="accent" label={nodeTypeDisplayName || nodeTypeName} icon={getNodeTypeIcon(nodeTypeName)}/>
+                    <Chip color="accent" label={nodeTypeDisplayName || nodeTypeName} icon={getNodeTypeIcon(nodeTypeName)} title={nodeTypeName}/>
                 )}
                 mainActions={(
                     <div className={clsx(styles.headerMainActions, 'flexRow_center', 'alignCenter')}>


### PR DESCRIPTION
### Description

Hi!

Dead simple (🧛) improvement for integrators: added a tooltip on the node type label with the underlying node type name

<img width="303" height="125" alt="image" src="https://github.com/user-attachments/assets/477ee2c7-405e-4b41-aea1-7c9bcc5978fb" />

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
