### PR TITLE
feat: Add toggle behavior for unmark WIP if enabled only in one language

### DIFF
--- a/src/javascript/ContentEditor/actions/contenteditor/openWorkInProgress/openWorkInProgressAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/openWorkInProgress/openWorkInProgressAction.jsx
@@ -17,13 +17,11 @@ export const OpenWorkInProgressModal = ({render: Render, ...otherProps}) => {
 
     const wipInfo = formik.values[Constants.wip.fieldName];
     const singleLanguage = siteInfo.languages.length === 1;
-    const isWIP = (wipInfo, currentLanguage) => {
-        const wipForLang = wipInfo?.status === Constants.wip.status.LANGUAGES && wipInfo?.languages?.includes(currentLanguage);
-        return wipInfo?.status === Constants.wip.status.ALL_CONTENT || wipForLang;
-    };
-
-    const isWIPStatus = isWIP(wipInfo, lang);
-    const buttonLabel = `jcontent:label.contentEditor.edit.action.workInProgress.label.${isWIPStatus ? 'unmark' : 'mark'}`;
+    const wipForLang = wipInfo?.status === Constants.wip.status.LANGUAGES && wipInfo?.languages?.includes(lang);
+    // Content is marked as WIP only for this lang; we can just toggle this status instead of showing modal
+    const wipOnlyForLang = wipForLang && wipInfo.languages.length === 1;
+    const isWIP = wipInfo?.status === Constants.wip.status.ALL_CONTENT || wipForLang;
+    const buttonLabel = `jcontent:label.contentEditor.edit.action.workInProgress.label.${isWIP ? 'unmark' : 'mark'}`;
 
     const openModal = () => {
         componentRenderer.render(
@@ -43,16 +41,16 @@ export const OpenWorkInProgressModal = ({render: Render, ...otherProps}) => {
     };
 
     const switchButton = useCallback(() => {
-        const status = isWIPStatus ? Constants.wip.status.DISABLED : Constants.wip.status.ALL_CONTENT;
+        const status = isWIP ? Constants.wip.status.DISABLED : Constants.wip.status.ALL_CONTENT;
         formik.setFieldValue(Constants.wip.fieldName, {status, languages: []});
-    }, [isWIPStatus, formik]);
+    }, [isWIP, formik]);
 
     return (
         <Render
                 {...otherProps}
                 buttonLabel={buttonLabel}
                 enabled={!nodeData.lockedAndCannotBeEdited && nodeData.hasWritePermission && !Constants.wip.notAvailableFor.includes(nodeData.primaryNodeType.name)}
-                onClick={singleLanguage ? switchButton : openModal}/>
+                onClick={(singleLanguage || wipOnlyForLang) ? switchButton : openModal}/>
     );
 };
 

--- a/tests/cypress/e2e/menuActions/markAsWIP.cy.ts
+++ b/tests/cypress/e2e/menuActions/markAsWIP.cy.ts
@@ -1,4 +1,4 @@
-import {createSite, addNode, deleteSite, getComponentByRole, Button} from '@jahia/cypress';
+import {createSite, addNode, deleteSite, getComponentByRole, Button, getNodeByPath} from '@jahia/cypress';
 import {ContentEditor, JContent} from '../../page-object';
 
 describe('Mark as WIP action tests', () => {
@@ -73,7 +73,14 @@ describe('Mark as WIP action tests', () => {
         ce = jcontent.editComponentByRowName('wipFR');
         cy.get('[data-sel-role="wip-info-chip"]', {timeout: 5000}).should('be.visible');
         getComponentByRole(Button, 'goToWorkInProgress').should('contain', 'Unmark as Work in progress');
-        ce.cancel();
+
+        cy.log('toggle WIP status as unmarked if only one language');
+        getComponentByRole(Button, 'goToWorkInProgress').click(); // No WIP modal
+        ce.save();
+
+        getNodeByPath(`${parentPath}/wipFR`, ['j:workInProgressStatus']).then(resp => {
+            expect(resp?.data.jcr.nodeByPath.properties?.length).to.be.eq(0, 'WIP status for wipFR content has been removed');
+        });
     });
 });
 


### PR DESCRIPTION
### Description

Follow-up PR to https://github.com/Jahia/jcontent/pull/2039

Refactored variables/functions a bit to track different WIP statuses and add toggle behavior when WIP status is applied only for a single language.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
