### PR TITLE
fix: Add apostrophe to validation

### DIFF
--- a/src/javascript/JContent/JContent.constants.js
+++ b/src/javascript/JContent/JContent.constants.js
@@ -1,5 +1,5 @@
 const JContentConstants = {
-    namingInvalidCharactersRegexp: /[\\/:*?"<>|%]/g,
+    namingInvalidCharactersRegexp: /[\\/:*?"'<>|%]/g,
     maxCreateContentOfTypeDirectItems: 5,
     availablePublicationStatuses: {
         PUBLISHED: 'PUBLISHED',


### PR DESCRIPTION
### Description
Add apostrophe to validation. This is the easiest case which solves file uploads with apostrophe, note that it still requires user action. Metadata is handled as usual. 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
