### PR TITLE
feat: Show query content in list, structured views

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/PagesQueryHandler.js
@@ -33,14 +33,14 @@ export const PagesQueryHandler = {
 
         if (tableView.viewMode === JContentConstants.tableView.viewMode.STRUCTURED) {
             if (tableView.viewType === JContentConstants.tableView.viewType.CONTENT) {
-                queryVariables.typeFilter = ['jnt:content'];
+                queryVariables.typeFilter = ['jnt:content', 'jmix:queryContent'];
             } else if (tableView.viewType === JContentConstants.tableView.viewType.PAGES) {
                 queryVariables.typeFilter = ['jnt:page'];
             }
         } else if (subContent) {
-            queryVariables.typeFilter = ['jnt:content', 'jnt:contentFolder'];
+            queryVariables.typeFilter = ['jnt:content', 'jnt:contentFolder', 'jmix:queryContent'];
         } else {
-            queryVariables.typeFilter = JContentConstants.tableView.viewType.PAGES === tableView.viewType ? ['jnt:page'] : ['jmix:editorialContent'];
+            queryVariables.typeFilter = JContentConstants.tableView.viewType.PAGES === tableView.viewType ? ['jnt:page'] : ['jmix:editorialContent', 'jmix:queryContent'];
             queryVariables.recursionTypesFilter = {
                 multi: 'NONE',
                 types: ['jnt:page', 'jnt:contentFolder', 'jnt:folder', 'jnt:usersFolder', 'jnt:groupsFolder']};


### PR DESCRIPTION
### Description

`jmix:queryContent` is on the same level as `jnt:content` so we need to add in the list of displayable nodetypes in list and structured views 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
