### PR TITLE
fix: Don't render boxes for content from references

### DIFF
--- a/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
@@ -61,6 +61,8 @@ function getRelativePos(coord1, coord2) {
 // This determines if the node is included as part of content reference in which case we don't want to have a box for it.
 const isFromReference = (path, nodes) => {
     if (path.includes('@/')) {
+        // Note that parent path cannot be checked directly as parent is not jnt:contentReference but jnt:list or other (/somepath/content-ref@/list/node)
+        // Note that we also check to make sure that what we find is a discoverable node in the tree
         const split = path.split('@/');
         return nodes[split[0]]?.primaryNodeType.name === 'jnt:contentReference';
     }


### PR DESCRIPTION
### Description
Don't render boxes for content from references.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
