### PR TITLE
fix: Add custom status properties for usages

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.jsx
@@ -164,7 +164,15 @@ export const FileCard = ({
                         </Typography>
                     )}
                 </div>
-                <ContentStatuses className={styles.statuses} node={node} uilang={uilang} language={lang} renderedStatuses={['published', 'locked', 'workInProgress', 'modified', 'markedForDeletion', 'usagesCount']}/>
+                <ContentStatuses
+                    hasLabel={false}
+                    className={styles.statuses}
+                    node={node}
+                    uilang={uilang}
+                    language={lang}
+                    renderedStatuses={['published', 'locked', 'workInProgress', 'modified', 'markedForDeletion', 'usagesCount']}
+                    statusProps={{usagesCount: {hasLabel: true}}}
+                />
             </div>
         </div>
     );

--- a/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.test.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.test.jsx
@@ -13,7 +13,7 @@ describe('ContentStatuses', () => {
     it('should only render a \'Not Published\' status', () => {
         const wrapper = shallow(<ContentStatuses {...defaultProps} node={{}}/>);
 
-        expect(wrapper.containsMatchingElement(<Status hasLabel={false} type="notPublished"/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<Status type="notPublished"/>)).toBeTruthy();
         expect(wrapper.find('Status')).toHaveLength(1);
     });
 
@@ -25,7 +25,7 @@ describe('ContentStatuses', () => {
         };
         const wrapper = shallow(<ContentStatuses {...defaultProps} node={node}/>);
 
-        expect(wrapper.containsMatchingElement(<Status hasLabel={false} type="notPublished"/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<Status type="notPublished"/>)).toBeTruthy();
         expect(wrapper.find('Status')).toHaveLength(1);
     });
 
@@ -38,7 +38,7 @@ describe('ContentStatuses', () => {
         const wrapper = shallow(<ContentStatuses {...defaultProps} node={node}/>);
         const expectedTooltip = 'translated_label.contentManager.publicationStatus.published';
 
-        expect(wrapper.containsMatchingElement(<Status hasLabel={false} type="published" tooltip={expectedTooltip}/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<Status type="published" tooltip={expectedTooltip}/>)).toBeTruthy();
         expect(wrapper.find('Status')).toHaveLength(1);
     });
 
@@ -51,8 +51,8 @@ describe('ContentStatuses', () => {
         const wrapper = shallow(<ContentStatuses {...defaultProps} node={node}/>);
         const expectedTooltip = 'translated_label.contentManager.lockedBy';
 
-        expect(wrapper.containsMatchingElement(<Status hasLabel={false} type="locked" tooltip={expectedTooltip}/>)).toBeTruthy();
-        expect(wrapper.containsMatchingElement(<Status hasLabel={false} type="notPublished"/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<Status type="locked" tooltip={expectedTooltip}/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<Status type="notPublished"/>)).toBeTruthy();
         expect(wrapper.find('Status')).toHaveLength(2);
     });
 
@@ -65,8 +65,8 @@ describe('ContentStatuses', () => {
         const wrapper = shallow(<ContentStatuses {...defaultProps} node={node}/>);
         const expectedTooltip = 'translated_label.contentManager.publicationStatus.markedForDeletion';
 
-        expect(wrapper.containsMatchingElement(<Status hasLabel={false} type="markedForDeletion" tooltip={expectedTooltip}/>)).toBeTruthy();
-        expect(wrapper.containsMatchingElement(<Status hasLabel={false} type="notPublished"/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<Status type="markedForDeletion" tooltip={expectedTooltip}/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<Status type="notPublished"/>)).toBeTruthy();
         expect(wrapper.find('Status')).toHaveLength(2);
     });
 
@@ -79,8 +79,8 @@ describe('ContentStatuses', () => {
         const wrapper = shallow(<ContentStatuses {...defaultProps} node={node}/>);
         const expectedTooltip = 'translated_label.contentManager.publicationStatus.modified';
 
-        expect(wrapper.containsMatchingElement(<Status hasLabel={false} type="modified" tooltip={expectedTooltip}/>)).toBeTruthy();
-        expect(wrapper.containsMatchingElement(<Status hasLabel={false} type="published"/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<Status type="modified" tooltip={expectedTooltip}/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<Status type="published"/>)).toBeTruthy();
         expect(wrapper.find('Status')).toHaveLength(2);
     });
 
@@ -93,7 +93,7 @@ describe('ContentStatuses', () => {
         const wrapper = shallow(<ContentStatuses {...defaultProps} node={node}/>);
         const expectedTooltip = 'translated_label.contentManager.publicationStatus.unknown';
 
-        expect(wrapper.containsMatchingElement(<Status hasLabel={false} type="warning" tooltip={expectedTooltip}/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<Status type="warning" tooltip={expectedTooltip}/>)).toBeTruthy();
         expect(wrapper.find('Status')).toHaveLength(1);
     });
 
@@ -104,8 +104,8 @@ describe('ContentStatuses', () => {
         const wrapper = shallow(<ContentStatuses {...defaultProps} node={node}/>);
         const expectedTooltip = 'translated_label.contentManager.workInProgressAll';
 
-        expect(wrapper.containsMatchingElement(<Status hasLabel={false} type="workInProgress" tooltip={expectedTooltip}/>)).toBeTruthy();
-        expect(wrapper.containsMatchingElement(<Status hasLabel={false} type="notPublished"/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<Status type="workInProgress" tooltip={expectedTooltip}/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<Status type="notPublished"/>)).toBeTruthy();
         expect(wrapper.find('Status')).toHaveLength(2);
     });
 
@@ -117,8 +117,8 @@ describe('ContentStatuses', () => {
         const wrapper = shallow(<ContentStatuses {...defaultProps} node={node} language="fr"/>);
         const expectedTooltip = 'translated_label.contentManager.workInProgress';
 
-        expect(wrapper.containsMatchingElement(<Status hasLabel={false} type="workInProgress" tooltip={expectedTooltip}/>)).toBeTruthy();
-        expect(wrapper.containsMatchingElement(<Status hasLabel={false} type="notPublished"/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<Status type="workInProgress" tooltip={expectedTooltip}/>)).toBeTruthy();
+        expect(wrapper.containsMatchingElement(<Status type="notPublished"/>)).toBeTruthy();
         expect(wrapper.find('Status')).toHaveLength(2);
     });
 
@@ -129,7 +129,7 @@ describe('ContentStatuses', () => {
         };
         const wrapper = shallow(<ContentStatuses {...defaultProps} node={node}/>);
 
-        expect(wrapper.containsMatchingElement(<Status hasLabel={false} type="workInProgress"/>)).toBeFalsy();
+        expect(wrapper.containsMatchingElement(<Status type="workInProgress"/>)).toBeFalsy();
     });
 
     it('should a \'Usages\' status', () => {


### PR DESCRIPTION
### Description

Partial revert of `ContentStatuses` and jest tests from https://github.com/Jahia/jcontent/pull/2076.

We use `statusProps` instead to specifically style usages count and apply label in `FileGrid`. 

Also added (generated) jsdoc for `ContentStatuses` and highlight custom styling using statusProps with examples.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
