### PR TITLE
fix: Fix value override issue in multiple fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "dayjs": "^1.10.6",
     "ellipsize": "^0.5.0",
     "es-toolkit": "^1.39.4",
-    "formik": "^2.4.6",
+    "formik": "^2.4.9",
     "graphql": "^16.10.0",
     "graphql-tag": "^2.12.6",
     "history": "^5.3.0",

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/MultipleField.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/MultipleField.jsx
@@ -16,9 +16,7 @@ export const MultipleField = ({editorContext, inputContext, field, onChange, onB
     const {reorderedItems, handleReorder, reset} = useReorderList(fieldValue);
 
     const multipleFieldOnChange = (index, newData) => {
-        let updatedValues = [...values[field.name]];
-        updatedValues[index] = newData;
-        onChange(updatedValues);
+        onChange({index, value: newData});
     };
 
     const onFieldRemove = index => {

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/MultipleField.spec.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/MultipleField.spec.jsx
@@ -93,7 +93,7 @@ describe('Multiple component', () => {
         // Change field2
         field2.simulate('change', 'Updated2');
         expect(defaultProps.onChange.mock.calls.length).toBe(1);
-        expect(defaultProps.onChange).toHaveBeenCalledWith(['Dummy1', 'Updated2', 'Dummy3']);
+        expect(defaultProps.onChange).toHaveBeenCalledWith({index: 1, value: 'Updated2'});
     });
 
     it('should display remove button when field is not readOnly', () => {

--- a/tests/cypress/e2e/selectorTypes/richText.cy.ts
+++ b/tests/cypress/e2e/selectorTypes/richText.cy.ts
@@ -1,30 +1,77 @@
 import {JContent} from '../../page-object';
 import {RichTextField} from '../../page-object/fields';
+import {addNode, createSite, deleteSite, enableModule} from '@jahia/cypress';
+import gql from 'graphql-tag';
 
-describe('richText', {testIsolation: false}, () => {
-    let jcontent: JContent;
-    let contentEditor;
-    let richText;
+describe('richText', () => {
+    const siteKey = 'richTextSite';
+
+    function addCk5Exclude(_siteKey: string) {
+        // We use CK4 for now for this test
+        return cy.apollo({mutation: gql`mutation disableCK5 {
+                admin {
+                    jahia {
+                        configuration(pid:"org.jahia.modules.richtextCKEditor5") {
+                            mutateList(name: "excludeSites") {
+                                addValue(value: "${_siteKey}")
+                            }
+                        }
+                    }
+                }
+        }`});
+    }
 
     before(() => {
-        cy.loginAndStoreSession();
-        jcontent = JContent
-            .visit('digitall', 'en', 'pages/home')
-            .switchToListMode();
-        contentEditor = jcontent.editComponentByText('Digitall’s global network');
+        createSite(siteKey);
+        enableModule('qa-module', siteKey);
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: 'all-fields-multiple',
+            primaryNodeType: 'qant:allFieldsMultiple',
+            properties: [
+                {name: 'sharedBigtext', values: ['<p>value 1</p>', '<p>value 2</p>'], language: 'en'}
+            ]
+        });
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: 'richText',
+            primaryNodeType: 'jnt:bigText',
+            properties: [{name: 'text', value: 'value1', language: 'en'}]
+        });
+        addCk5Exclude(siteKey);
+    });
+
+    after(() => {
+        deleteSite(siteKey);
     });
 
     beforeEach(() => {
-        richText = contentEditor.getField(RichTextField, 'jnt:bigText_text');
+        cy.loginAndStoreSession();
     });
 
-    it('can edit rich text with ckeditor', function () {
+    it('can edit rich text with ckeditor', () => {
+        const contentEditor = JContent.visit(siteKey, 'en', 'content-folders/contents/richText').editContent();
+        const richText = contentEditor.getField(RichTextField, 'jnt:bigText_text');
         richText.type('test');
     });
 
-    it('shows ckeditor notifications', function () {
-        richText.get().find('.cke_button__paste_icon').click();
+    it('shows ckeditor notifications', () => {
+        const contentEditor = JContent.visit(siteKey, 'en', 'content-folders/contents/richText').editContent();
+        const richText = contentEditor.getField(RichTextField, 'jnt:bigText_text');
+        richText.get().find('.cke_button__paste_icon').parent().should('have.attr', 'aria-disabled', 'false').click();
         cy.get('.cke_notifications_area');
+    });
+
+    it('can edit multiple rich text fields without side effects', () => {
+        const contentEditor = JContent.visit(siteKey, 'en', 'content-folders/contents/all-fields-multiple').editContent();
+        const richText = contentEditor.getField(RichTextField, 'qant:allFieldsMultiple_sharedBigtext');
+
+        richText.getData(0).should('have.string', 'value 1');
+        richText.setData('This is my text 1 data', 0);
+        richText.setData('This is my text 2 data', 1);
+
+        cy.log('Verify that the change in rich text 2 does not revert change in rich text 1');
+        richText.getData(0).should('have.string', 'This is my text 1 data');
     });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8363,10 +8363,10 @@ format@^0.2.0:
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==
 
-formik@^2.4.6:
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/formik/-/formik-2.4.6.tgz#4da75ca80f1a827ab35b08fd98d5a76e928c9686"
-  integrity sha512-A+2EI7U7aG296q2TLGvNapDNTZp1khVt5Vk0Q/fyfSROss0V/V6+txt2aJnwEos44IxTCW/LYAi/zgWzlevj+g==
+formik@^2.4.9:
+  version "2.4.9"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.4.9.tgz#7e5b81e9c9e215d0ce2ac8fed808cf7fba0cd204"
+  integrity sha512-5nI94BMnlFDdQRBY4Sz39WkhxajZJ57Fzs8wVbtsQlm5ScKIR1QLYqv/ultBnobObtlUyxpxoLodpixrsf36Og==
   dependencies:
     "@types/hoist-non-react-statics" "^3.3.1"
     deepmerge "^2.1.1"


### PR DESCRIPTION
### Description

#### Problem

Multiple fields have a race condition where editing one field can overwrite unsaved changes in other fields. This occurs because `MultipleField` uses stale array values when constructing updates because Formik does not always refresh `values` from Formik context after calling `setFieldValue`

#### Solution 

- update formik and use a setState-like function in formik >= 2.4.8 https://github.com/jaredpalmer/formik/issues/3960 `setFieldValue` function where it takes a function that includes latest up-to-date `value` as a param, similar to how React `useState` setter behaves. 
- Overloaded the `onChange` function in Field.jsx to support both single-value updates and index-based updates for multiple fields and modified `MultipleField` to use this new param instead of passing in the entire array. `onChange` handler to detect index-based updates and only modify the specific array element

#### Misc

- Modify `richTextField.ts` page object to support data modifications on multiple field
- Add cypress test 
- Adjust jest test for `onChange` new param call for multiple field.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [x] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
