### PR TITLE
chore: added cypress tests for usages badges

### DIFF
--- a/tests/cypress/e2e/contentEditor/usagesBadge.cy.ts
+++ b/tests/cypress/e2e/contentEditor/usagesBadge.cy.ts
@@ -20,7 +20,6 @@ describe('Usages badge in content editor', () => {
             ],
             parentPathOrId: `/sites/${siteKey}/contents`
         });
-        cy.apollo({mutationFile: 'contentEditor/usagesBadge/createTestNodes.graphql'});
     });
 
     after(() => {


### PR DESCRIPTION
### Description
This PR adds a cypress test for the usages badge in CE.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
