### PR TITLE
fix: handle empty text in multiple field

### DIFF
--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.jsx
@@ -211,7 +211,7 @@ export const Field = ({inputContext, idInput, selectorType, field}) => {
         const {index, value} = _currentValue || {};
 
         let newValues;
-        if (typeof index === 'number' && index >= 0 && value) {
+        if (typeof index === 'number' && index >= 0 && value !== undefined) {
             setFieldValue(field.name, prevValues => {
                 const currentValues = [...prevValues];
                 currentValues[index] = value;

--- a/tests/cypress/e2e/selectorTypes/richText.cy.ts
+++ b/tests/cypress/e2e/selectorTypes/richText.cy.ts
@@ -72,6 +72,10 @@ describe('richText', () => {
 
         cy.log('Verify that the change in rich text 2 does not revert change in rich text 1');
         richText.getData(0).should('have.string', 'This is my text 1 data');
+
+        cy.log('Verify can set blank text');
+        richText.setData('', 0);
+        richText.getData(1).should('have.string', 'This is my text 2 data');
     });
 });
 


### PR DESCRIPTION
### Description

Follow-up to https://github.com/Jahia/jcontent/pull/2107

Handle empty text as normal text 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
