### PR TITLE
fix: Add missing publication info for jcontent header badge

### DIFF
--- a/src/javascript/JContent/ContentHeader/ContentHeader.jsx
+++ b/src/javascript/JContent/ContentHeader/ContentHeader.jsx
@@ -89,9 +89,10 @@ const ContentHeader = () => {
     const viewSelector = registry.get('accordionItem', mode)?.tableConfig?.viewSelector;
     const sortSelector = registry.get('accordionItem', mode)?.tableConfig?.sortSelector;
 
-    const {loading, node} = useNodeInfo({path, language: language, displayLanguage}, {
+    const {loading, node} = useNodeInfo({path, language, displayLanguage}, {
         getPrimaryNodeType: true,
         getDisplayName: true,
+        getAggregatedPublicationInfo: {subNodes: true},
         applyFragment: contentStatusFragment
     });
 

--- a/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.gql-queries.js
@@ -45,42 +45,10 @@ export const GetContentStatuses = gql`
         jcr {
             result: nodeByPath(path: $path) {
                 ...NodeCacheRequiredFields
+                ...ContentStatus
                 aggregatedPublicationInfo(language: $language, subNodes: true) {
                     publicationStatus
                     existsInLive
-                }
-                lastModifiedBy: property(name: "jcr:lastModifiedBy", language: $language) {
-                    value
-                }
-                lastModified: property(name: "jcr:lastModified", language: $language) {
-                    value
-                }
-                lastPublished: property(name: "j:lastPublished", language: $language) {
-                    value
-                }
-                lastPublishedBy: property(name: "j:lastPublishedBy", language: $language) {
-                    value
-                }
-                deletedBy: property(name: "j:deletionUser", language: $language) {
-                    value
-                }
-                deleted: property(name: "j:deletionDate", language: $language) {
-                    value
-                }
-                mixinTypes {
-                    name
-                }
-                lockOwner: property(name: "jcr:lockOwner") {
-                    value
-                }
-                lockTypes: property(name: "j:lockTypes") {
-                    values
-                }                
-                wipStatus: property(name: "j:workInProgressStatus") {
-                    value
-                }
-                wipLangs: property(name: "j:workInProgressLanguages") {
-                    values
                 }
                 ancestors(fieldFilter: {filters: {fieldName: "deleted", evaluation: NOT_EMPTY}}) {
                     deleted:property(name: "j:deletionDate") {
@@ -93,4 +61,6 @@ export const GetContentStatuses = gql`
             }
         }
     }
-    ${PredefinedFragments.nodeCacheRequiredFields.gql}`;
+    ${contentStatusFragment.gql}
+    ${PredefinedFragments.nodeCacheRequiredFields.gql}
+`;

--- a/tests/cypress/e2e/jcontent/publicationStatus.cy.ts
+++ b/tests/cypress/e2e/jcontent/publicationStatus.cy.ts
@@ -14,6 +14,7 @@ describe('Publication status badge test', () => {
     const siteKey = 'publicationStatusSite';
     const editor = {username: 'editor', password: 'password'};
     const textName = 'test-text';
+    const folderName = 'test-folder';
 
     function createHomeSubpage(titleName: string) {
         return addNode({
@@ -49,6 +50,12 @@ describe('Publication status badge test', () => {
             properties: [{name: 'text', value: 'Test 1', language: 'en'}]
         });
 
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: folderName,
+            primaryNodeType: 'jnt:contentFolder'
+        });
+
         createHomeSubpage('publishedPage')
             .then(() => createHomeSubpage('unpublishedPage'))
             .then(() => createHomeSubpage('notPublishedPage'))
@@ -63,6 +70,16 @@ describe('Publication status badge test', () => {
     after(() => {
         deleteSite(siteKey);
         cy.logout();
+    });
+
+    it('should show correct publication status for content folders', () => {
+        cy.login();
+        const jcontent = JContent.visit(siteKey, 'en', `content-folders/contents/${folderName}`);
+        jcontent.assertStatusType('notPublished');
+        jcontent.publishAll();
+
+        cy.log('Check content folder publication status');
+        JContent.visit(siteKey, 'en', `content-folders/contents/${folderName}`).assertStatusType('published');
     });
 
     it('should show the last publisher, not the last editor', () => {


### PR DESCRIPTION
### Description

Add missing publication info when fetching `useNodeInfo` from content header.

Reused existing fragment for fetching content status and removed duplicates in query.

Added cypress test.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
