### PR TITLE
chore: Fix translations for button 'go to source'

### DIFF
--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -597,7 +597,7 @@
         "title": "Content bearbeiten",
         "contentEdit": "Content bearbeiten",
         "contentEditAdvanced": "Erweitertes Editieren",
-        "contentEditSource": "Referenzquelle bearbeiten",
+        "contentEditSource": "Zur Quelle gehen",
         "validation": {
           "required": "erforderlich",
           "invalidForm": "Fehler im Formular",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -598,7 +598,7 @@
         "title": "Éditer le contenu",
         "contentEdit": "Editer",
         "contentEditAdvanced": "Edition avancée",
-        "contentEditSource": "Référence source",
+        "contentEditSource": "Aller à la source",
         "validation": {
           "required": "Requis",
           "invalidForm": "Formulaire non valide",


### PR DESCRIPTION
### Description
Fixed translations in French and German for new button "go to source".

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
