### PR TITLE
fix: Add functionality check for required Promise API in PDFViewer

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PDFViewer/PDFViewer.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PDFViewer/PDFViewer.jsx
@@ -15,6 +15,7 @@ import clsx from 'clsx';
 import styles from './PDFViewer.scss';
 
 import {pdfjs, Document, Page} from 'react-pdf';
+import {useTranslation} from 'react-i18next';
 
 // Set local worker
 pdfjs.GlobalWorkerOptions.workerSrc = `${window.contextJsParameters?.contextPath}/modules/jcontent/javascript/apps/pdf.worker.min.mjs`;
@@ -22,12 +23,25 @@ pdfjs.GlobalWorkerOptions.workerSrc = `${window.contextJsParameters?.contextPath
 const scaleSizes = [0.25, 0.33, 0.5, 0.67, 0.75, 0.8, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2];
 
 export const PDFViewer = ({file, isFullScreen}) => {
+    const {t} = useTranslation('jcontent');
     const [page, setPage] = useState(1);
     const [pages, setPages] = useState(null);
     const [scaleSize, setScaleSize] = useState(6);
     const [showScale, setShowScale] = useState(false);
 
     const scaleTimeout = useRef();
+
+    // Check if the browser supports Promise.withResolvers (required by pdfjs-dist)
+    const isSupported = typeof Promise.withResolvers === 'function';
+    if (!isSupported) {
+        return (
+            <div className={clsx(styles.pdfContainer, isFullScreen && styles.fullScreen)}>
+                <Typography variant="body" style={{padding: '20px', textAlign: 'center'}}>
+                    {t('jcontent:label.contentManager.preview.browserNotSupported')}
+                </Typography>
+            </div>
+        );
+    }
 
     // Called when PDF is fully loaded
     const onDocumentLoadSuccess = ({numPages}) => {

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -13,7 +13,8 @@
           "metadata": "Metadaten",
           "quickEdit": "Schnellbearbeitung"
         },
-        "show": "Vorschau öffnen"
+        "show": "Vorschau öffnen",
+        "browserNotSupported": "Die Vorschau wird von diesem Browser nicht unterstützt. Bitte aktualisieren Sie Ihren Browser auf eine neuere Version oder laden Sie die Datei herunter, um sie anzuzeigen."
       },
       "rename": "Umbenennen",
       "workInProgress": "In Arbeit: {{wipLang}} (ausgenommen gemeinsame Eigenschaften)",

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -13,7 +13,8 @@
           "metadata": "Metadata",
           "quickEdit": "Quick Edit"
         },
-        "show": "Show Preview"
+        "show": "Show Preview",
+        "browserNotSupported": "Preview is not supported in this browser. Please update your browser to a more recent version or download the file to view it."
       },
       "rename": "Rename",
       "workInProgress": "Work in progress: {{wipLang}} (excluding non-localized properties)",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -13,7 +13,8 @@
           "metadata": "Metadata",
           "quickEdit": "Edition rapide"
         },
-        "show": "Afficher l'aperçu"
+        "show": "Afficher l'aperçu",
+        "browserNotSupported": "La prévisualisation n'est pas prise en charge par ce navigateur. Veuillez mettre à jour votre navigateur ou télécharger le fichier pour le consulter."
       },
       "rename": "Renommer",
       "workInProgress": "Travail en cours: {{wipLang}} (propriétés communes exclues)",


### PR DESCRIPTION
### Description

We have a failing selenium tests because of the fact that pdfjs-dist is using a fairly recent Promise API `withResolvers` that doesn't exist in the browser (chrome 92) being used in selenium (to be verified).

Add check for that functionality and display error message if it doesn't exist.
