### PR TITLE
fix: resolved error in thumbnail view, enabled double click for CMIS mounts.

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.utils.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.utils.js
@@ -69,7 +69,7 @@ export const getFileExtension = node => {
 };
 
 export const getMimeType = node => {
-    const mimetype = node.content?.mimeType.value;
+    const mimetype = node.content?.mimeType?.value;
     if (!mimetype || mimetype === 'null') {
         // Try to get mimetype using file extension
         return node.path.replace(/^.*[/\\]/, '').includes('.') ? mime.getType(node.path) : '';

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.jsx
@@ -100,7 +100,7 @@ export const FileCard = ({
     // let columnNumber = (index % 2) + 1;
     const encodedPath = node.path.replace(/[^/]/g, encodeURIComponent);
     const showSubNodes = node.primaryNodeType.name !== 'jnt:page' && node?.subNodes?.pageInfo?.totalCount > 0;
-    const dblClick = onDoubleClick ? onDoubleClick : allowDoubleClickNavigation(node.primaryNodeType.name, null, () => setPath(siteKey, node.path, mode));
+    const dblClick = onDoubleClick ? onDoubleClick : allowDoubleClickNavigation(node.primaryNodeType.name, null, () => setPath(siteKey, node.path, mode), node);
 
     return (
         <div

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FilesGrid.jsx
@@ -11,7 +11,7 @@ import {cmSetPreviewSelection, cmSetPreviewState} from '~/JContent/redux/preview
 import {CM_DRAWER_STATES, cmGoto, cmOpenPaths} from '~/JContent/redux/JContent.redux';
 import classNames from 'clsx';
 import clsx from 'clsx';
-import {clickHandler, extractPaths} from '~/JContent/JContent.utils';
+import {clickHandler, extractPaths, isCMISFolder} from '~/JContent/JContent.utils';
 import {useKeyboardNavigation} from '../useKeyboardNavigation';
 import JContentConstants from '~/JContent/JContent.constants';
 import styles from './FilesGrid.scss';
@@ -82,9 +82,11 @@ export const FilesGrid = ({isContentNotFound, totalCount, rows, isLoading}) => {
         }
     };
 
-    const allowDoubleClickNavigation = nodeType => {
+    const allowDoubleClickNavigation = node => {
         return Constants.mode.SEARCH !== mode &&
-            ((tableConfig.canAlwaysDoubleClickOnType && tableConfig.canAlwaysDoubleClickOnType(nodeType)) || (['jnt:folder', 'jnt:contentFolder'].includes(nodeType)));
+            ((tableConfig.canAlwaysDoubleClickOnType && tableConfig.canAlwaysDoubleClickOnType(node.primaryNodeType.name)) ||
+             (['jnt:folder', 'jnt:contentFolder'].includes(node.primaryNodeType.name)) ||
+             isCMISFolder(node));
     };
 
     const setPageSize = pageSize => dispatch(cmSetPageSize(pageSize));
@@ -176,7 +178,7 @@ export const FilesGrid = ({isContentNotFound, totalCount, rows, isLoading}) => {
                                   contextualMenuAction="contentItemActionsMenu"
                                   tableConfig={tableConfig}
                                   onClick={e => {
-                                      if (allowDoubleClickNavigation(node.primaryNodeType.name)) {
+                                      if (allowDoubleClickNavigation(node)) {
                                           clickHandler.handleEvent(e, () => onClick(node, index, e));
                                       } else {
                                           onClick(node, index, e);

--- a/src/javascript/JContent/JContent.utils.js
+++ b/src/javascript/JContent/JContent.utils.js
@@ -110,8 +110,10 @@ export const getNewCounter = nodes => {
     return max + 1;
 };
 
-export const allowDoubleClickNavigation = (nodeType, subNodes, fcn) => {
-    if (['jnt:page', 'jnt:folder', 'jnt:contentFolder'].indexOf(nodeType) !== -1 || (subNodes && subNodes > 0)) {
+export const allowDoubleClickNavigation = (nodeType, subNodes, fcn, node = null) => {
+    if (['jnt:page', 'jnt:folder', 'jnt:contentFolder'].indexOf(nodeType) !== -1 ||
+        (subNodes && subNodes > 0) ||
+        (node && isCMISFolder(node))) {
         return fcn;
     }
 
@@ -363,4 +365,22 @@ export const resolveUrlForLiveOrPreview = (url, isLive, serverName) => {
     }
 
     return `${location.protocol}//${host}:${location.port}${url}`;
+};
+
+/**
+ * Check if a node is a CMIS folder based on its mixin types
+ * @param {Object} node - The node object with mixinTypes array
+ * @returns {boolean} - True if the node has the cmismix:folder mixin
+ */
+export const isCMISFolder = node => {
+    return hasMixin(node, 'cmismix:folder');
+};
+
+/**
+ * Check if a node is a CMIS file/document based on its mixin types
+ * @param {Object} node - The node object with mixinTypes array
+ * @returns {boolean} - True if the node has the cmismix:document mixin
+ */
+export const isCMISFile = node => {
+    return hasMixin(node, 'cmismix:document');
 };

--- a/src/javascript/utils/getIcon.jsx
+++ b/src/javascript/utils/getIcon.jsx
@@ -23,6 +23,7 @@ import {
     Tag,
     SiteWeb
 } from '@jahia/moonstone';
+import {isCMISFile, isCMISFolder} from '~/JContent/JContent.utils';
 
 const imgExtensions = ['avif', 'png', 'jpeg', 'jpg', 'gif', 'svg', 'img', 'webp'];
 const videoExtensions = ['avi', 'mp4', 'mkv', 'mpg', 'wmv', 'mpeg', 'mov', 'webm', 'video'];
@@ -197,14 +198,11 @@ export function getIconFromNode(node, props = {}) {
         return <div {...props} style={{'--bg-image': `url(${props.thumbnailUrl})`}}/>;
     }
 
-    const isCMISFile = node?.mixinTypes?.find(m => m.name && m.name === 'cmismix:document') !== undefined;
-    const isCMISFolder = node?.mixinTypes?.find(m => m.name && m.name === 'cmismix:folder') !== undefined;
-
-    if (isCMISFile) {
+    if (isCMISFile(node)) {
         return getFileIcon(node, props);
     }
 
-    if (isCMISFolder) {
+    if (isCMISFolder(node)) {
         return <Folder {...props}/>;
     }
 


### PR DESCRIPTION
### Description
This PR fixed the error when opening CMIS mounts in thumbnail view, and enables double-click for CMIS folders.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
