### PR TITLE
test: move testQuickPreview selenium test to Cypress

### DIFF
--- a/tests/cypress/e2e/menuActions/preview.cy.ts
+++ b/tests/cypress/e2e/menuActions/preview.cy.ts
@@ -83,7 +83,6 @@ describe('Menu actions preview tests', () => {
     });
 
     describe('Test preview in pages tab', {testIsolation: false}, () => {
-
         it('Can close preview when using pagination', () => {
             const jcontent = JContent.visit('digitall', 'en', 'pages/home');
             jcontent.switchToListMode();
@@ -91,7 +90,7 @@ describe('Menu actions preview tests', () => {
             // Open pagination ans select 10 items per page
             cy.get('[data-sel-role="table-pagination-dropdown-rows-per-page"]').click();
             cy.get('menu.moonstone-menu[role="list"]').should('be.visible');
-            cy.contains('[role="option"]', "10").click();
+            cy.contains('[role="option"]', '10').click();
 
             // Open preview
             jcontent.getTable().getRowByName('how-to-use-this-demo').contextMenu().select('Preview');


### PR DESCRIPTION
### Description
Move Selenium test **testQuickPreview** to Cypress > Jcontent.
Following this ticket : https://github.com/Jahia/selenium/issues/1483


### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
