### PR TITLE
test: move testOpenEditEngine to Cypress

### DIFF
--- a/tests/cypress/e2e/jcontent/publicationStatus.cy.ts
+++ b/tests/cypress/e2e/jcontent/publicationStatus.cy.ts
@@ -60,7 +60,7 @@ describe('Publication status badge test', () => {
 
         addNode({
             parentPathOrId: `/sites/${siteKey2}/contents`,
-            name: "multilangText",
+            name: 'multilangText',
             primaryNodeType: 'jnt:text',
             properties: [
                 {name: 'text', value: 'Test EN', language: 'en'},


### PR DESCRIPTION
### Description
Move Selenium test **testOpenEditEngine** to Cypress.
Related ticket : https://github.com/Jahia/selenium/issues/1485

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
