### PR TITLE
test: move Selenium testContentPanelNavigation to Cypress

### DIFF
--- a/tests/cypress/e2e/jcontent/navigation.cy.ts
+++ b/tests/cypress/e2e/jcontent/navigation.cy.ts
@@ -111,4 +111,19 @@ describe('Content navigation', () => {
             .should('contain', 'An error occurred during the rendering of the content')
             .and('contain', 'Toggle the full error');
     });
+
+    it('can enter pages and folders with double click', () => {
+        const jc = JContent.visit('mySite1', 'en', 'pages/home');
+        jc.switchToListMode();
+
+        const row = jc.getTable().getRowByName('search-results');
+        row.get().dblclick();
+        cy.get('h1').contains('Search Results');
+
+        // Switch to media folders
+        jc.getMedia().open();
+        const cardRow = jc.getGrid().getCardByName('bootstrap');
+        cardRow.get().dblclick();
+        cy.get('h1').contains('bootstrap');
+    });
 });


### PR DESCRIPTION
### Description
Move Selenium testContentPanelNavigation to Cypress > jcontent.
Related ticket : https://github.com/Jahia/selenium/issues/1510

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
