### PR TITLE
fix: Exclude studio and hidden node types

### DIFF
--- a/src/javascript/JContent/EditFrame/Boxes/dataHooks/useButtonsData.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/dataHooks/useButtonsData.jsx
@@ -57,7 +57,7 @@ export const useButtonsData = ({createButtons, language, uilang}) => {
         const node = output.nodes[b.node.path];
         if (node) {
             // Map list of node type names to the full info objects
-            node.acceptedNodeTypes = b.attributes?.nodeTypes?.map(nt => nodeTypeInfoMap.get(nt)) || [];
+            node.acceptedNodeTypes = b.attributes?.nodeTypes?.map(nt => nodeTypeInfoMap.get(nt)).filter(nt => nt !== undefined) || [];
         }
     });
 

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/GqlEditorForms.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/GqlEditorForms.java
@@ -158,7 +158,9 @@ public class GqlEditorForms {
 
         for (String nodeType : nodeTypes) {
             ExtendedNodeType nt = NodeTypeRegistry.getInstance().getNodeType(nodeType);
-            nts.add(new GqlNodeTypeInfo(nt, LanguageCodeConverters.getLocaleFromCode(uiLocale)));
+            if (!nt.isNodeType("jmix:studioOnly") && !nt.isNodeType("jmix:hiddenType")) {
+                nts.add(new GqlNodeTypeInfo(nt, LanguageCodeConverters.getLocaleFromCode(uiLocale)));
+            }
 
         }
 


### PR DESCRIPTION
### Description
Exclude studio and hidden node types as they do not belong in page builder.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
