### PR TITLE
fix: Show default icon for any content button

### DIFF
--- a/src/javascript/ContentEditor/actions/jcontent/createContent/createContent.utils.js
+++ b/src/javascript/ContentEditor/actions/jcontent/createContent/createContent.utils.js
@@ -71,16 +71,16 @@ export function flattenNodeTypes(nodeTypes) {
     return resolvedTypes || [];
 }
 
+function getNodeTypeIcon(nodeType) {
+    if (nodeType.name === 'jnt:category') {
+        return <Tag/>;
+    }
+
+    return nodeType.iconURL && !nodeType.iconURL.endsWith('/nt_base.png') && toIconComponent(nodeType.iconURL);
+}
+
 export function transformNodeTypesToActions(nodeTypes, hasBypassChildrenLimit, parentName) {
     const nodeTypesButtonLimit = contextJsParameters.config.jcontent['createChildrenDirectButtons.limit'];
-
-    function getNodeTypeIcon(nodeType) {
-        if (nodeType.name === 'jnt:category') {
-            return <Tag/>;
-        }
-
-        return nodeType.iconURL && !nodeType.iconURL.endsWith('/nt_base.png') && toIconComponent(nodeType.iconURL);
-    }
 
     if (hasBypassChildrenLimit || nodeTypes.length <= Number(nodeTypesButtonLimit)) {
         return nodeTypes
@@ -102,21 +102,8 @@ export function transformNodeTypesToActions(nodeTypes, hasBypassChildrenLimit, p
     return undefined;
 }
 
-export function transformNodeTypesToActionsPB(nodeTypes, hasBypassChildrenLimit, parentName) {
+export function transformNodeTypesToActionsPB(nodeTypes, hasBypassChildrenLimit, parentName, defaultIcon) {
     const nodeTypesButtonLimit = contextJsParameters.config.jcontent['createChildrenDirectButtons.limit'];
-
-    function getNodeTypeIcon(nodeType) {
-        if (nodeType.name === 'jnt:category') {
-            return <Tag/>;
-        }
-
-        if (nodeType.iconURL) {
-            return !nodeType.iconURL.endsWith('/nt_base.png') && toIconComponent(nodeType.iconURL);
-        }
-
-        // This uses a different data from useNodeInfo which retrieves plain icon url
-        return toIconComponent(`${nodeType.icon}.png`);
-    }
 
     let actions;
 
@@ -128,7 +115,7 @@ export function transformNodeTypesToActionsPB(nodeTypes, hasBypassChildrenLimit,
                 actionKey: 'createContentPB',
                 dataSelRole: nodeType.name === 'jmix:droppableContent' ? 'createContent' : nodeType.name,
                 nodeTypes: [nodeType.name],
-                nodeTypeIcon: getNodeTypeIcon(nodeType),
+                nodeTypeIcon: nodeType.name === 'jmix:droppableContent' ? defaultIcon : getNodeTypeIcon(nodeType),
                 buttonLabel: nodeType.name === 'jmix:droppableContent' ? 'jcontent:label.contentEditor.CMMActions.createNewContent.menu' : 'jcontent:label.contentEditor.CMMActions.createNewContent.contentOfType',
                 buttonLabelParams: {typeName: nodeType.label || nodeType.displayName},
                 tooltipLabel: nodeType.name === 'jmix:droppableContent' ? 'jcontent:label.contentEditor.CMMActions.createNewContent.tooltipGeneric' : 'jcontent:label.contentEditor.CMMActions.createNewContent.tooltipForType',

--- a/src/javascript/ContentEditor/actions/jcontent/createContent/createContentActionPB.jsx
+++ b/src/javascript/ContentEditor/actions/jcontent/createContent/createContentActionPB.jsx
@@ -43,7 +43,7 @@ export const CreateContentPB = ({
 
         // Note: acceptedNodeTypes is based on the DOM if we were able to find it, allowedChildNodeTypes is the info from JCR
         const nodeTypes = resNode.acceptedNodeTypes.length > 0 ? resNode.acceptedNodeTypes : resNode.allowedChildNodeTypes;
-        const actions = transformNodeTypesToActionsPB(nodeTypes, false, resNode?.name);
+        const actions = transformNodeTypesToActionsPB(nodeTypes, false, resNode?.name, otherProps.defaultIcon);
 
         return {
             loading: false,
@@ -51,7 +51,7 @@ export const CreateContentPB = ({
             actions,
             missingNodes: false
         };
-    }, [path, Loading, resNode]);
+    }, [Loading, resNode, path, otherProps.defaultIcon]);
 
     useEffect(() => {
         onVisibilityChanged?.(isVisible);


### PR DESCRIPTION
### Description
Show default icon for any content button as it was before action refactor. 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
