### PR TITLE
test: add copyCutPaste tests

### DIFF
--- a/tests/cypress/e2e/menuActions/copyCutPaste.cy.ts
+++ b/tests/cypress/e2e/menuActions/copyCutPaste.cy.ts
@@ -104,7 +104,7 @@ describe('Copy Cut and Paste tests with jcontent', () => {
             jcontent.getGrid().getCardByName('myfile.pdf').should('be.visible');
             // Go back to files to verify the file is gone
             jcontent.getAccordionItem('media').getTreeItem('files').click();
-            cy.get(`[data-cm-role="grid-content-list-card"][data-sel-role-card="myfile.pdf"]`)
+            cy.get('[data-cm-role="grid-content-list-card"][data-sel-role-card="myfile.pdf"]')
                 .should('not.exist');
         });
 
@@ -136,7 +136,7 @@ describe('Copy Cut and Paste tests with jcontent', () => {
             jcontent.getTable().getRowByName('ContentFolderA').should('be.visible');
             // Go back to contents to verify the folder is gone
             jcontent.getAccordionItem('content-folders').getTreeItem('contents').click();
-            cy.get(`[data-cm-role="table-content-list-row"][data-node-name="myfile.pdf"]`)
+            cy.get('[data-cm-role="table-content-list-row"][data-node-name="myfile.pdf"]')
                 .should('not.exist');
         });
 
@@ -263,7 +263,7 @@ describe('Copy Cut and Paste tests with jcontent', () => {
     // Template 'contentType' from 'jcontent-test-template' has an area content restriction of pbnt:contentRestriction
     // We have the same test in pageBuilder/restrictions as well for page builder
     describe('Template content type restriction', () => {
-        const siteKey = 'restrictedStructuredSite';
+        const sitekey = 'restrictedStructuredSite';
         const pageName = 'myPage';
 
         function getRoleItem(menu: Menu, role: string) {
@@ -272,23 +272,23 @@ describe('Copy Cut and Paste tests with jcontent', () => {
         }
 
         before(() => {
-            createSite(siteKey, {
+            createSite(sitekey, {
                 serverName: 'localhost',
                 locale: 'en',
                 templateSet: 'jcontent-test-template'
             });
-            cy.apollo({mutation: addRestrictedPage(siteKey, pageName)});
+            cy.apollo({mutation: addRestrictedPage(sitekey, pageName)});
             cy.loginAndStoreSession();
         });
 
         after(() => {
             cy.logout();
-            deleteSite(siteKey);
+            deleteSite(sitekey);
         });
 
         it('should check restrictions when displaying paste button', () => {
             const jcontent = JContent
-                .visit(siteKey, 'en', `pages/home/${pageName}`)
+                .visit(sitekey, 'en', `pages/home/${pageName}`)
                 .switchToPageBuilder()
                 .switchToStructuredView();
 


### PR DESCRIPTION
### Description
Move copy cut paste Selenium tests to Cypress:
- testCutPasteFromPages
- testCopyCutPasteGWT
- testCopyCutPaste
inside menuActions\copyCutPaste.cy.ts

The Selenium tests were testing very basic scenarios so I added several basic ones : 
- copy & paste a file
- cut & paste a file
- copy & paste a folder
- cut & paste a folder
- copy & paste a folder in same folder
- clear clipboard
- paste as reference

Also replaced `getRowByLabel` by `getRowByName` in the existing tests as it is now deprecated.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
