### PR TITLE
test: move testContextMenuInFolder to Cypress

### DIFF
--- a/tests/cypress/e2e/jcontent/menu.cy.ts
+++ b/tests/cypress/e2e/jcontent/menu.cy.ts
@@ -90,7 +90,7 @@ describe('Menu tests', () => {
             .getRowByName('bootstrap.css')
             .contextMenu();
 
-        const item = [
+        const items = [
             'Edit',
             'Rename',
             'Download',
@@ -99,7 +99,7 @@ describe('Menu tests', () => {
             'Cut'
         ];
 
-        item.forEach(item => {
+        items.forEach(item => {
             contextMenu.shouldHaveItem(item);
         });
     });


### PR DESCRIPTION
### Description
Move Selenium test testContextMenuInFolder to Cypress --> _jcontent\menu.cy.ts_
Related ticket : https://github.com/Jahia/selenium/issues/1508

Also modified the beforeEach() into a before() to avoid creating the website for each test (we don't do test that modify the website and that could impact the other tests)

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
