### PR TITLE
test: add menu actions checks

### DIFF
--- a/tests/cypress/e2e/menuActions/visibility.cy.ts
+++ b/tests/cypress/e2e/menuActions/visibility.cy.ts
@@ -16,10 +16,10 @@ describe('Actions visibility', () => {
 
     beforeEach(() => {
         cy.loginAndStoreSession();
-        jcontent = JContent.visit(SITEKEY, 'en', 'pages/home');
     });
 
     it('Displays accordionContent actions', () => {
+        jcontent = JContent.visit(SITEKEY, 'en', 'pages/home');
         const item = jcontent.getAccordionItem('pages').getTreeItem('home');
         const menu = item.contextMenu();
         menu.shouldHaveItem('New Page');
@@ -34,6 +34,7 @@ describe('Actions visibility', () => {
     });
 
     it('Displays browserControlBar action', () => {
+        jcontent = JContent.visit(SITEKEY, 'en', 'pages/home');
         const menu = jcontent.getBrowseControlMenu();
         menu.shouldHaveItem('Advanced editing');
         menu.shouldHaveItem('Lock');
@@ -47,8 +48,9 @@ describe('Actions visibility', () => {
     });
 
     it('Displays contentItemContext actions', () => {
+        jcontent = JContent.visit(SITEKEY, 'en', 'pages/home');
         jcontent.switchToListMode();
-        const menu = jcontent.getTable().getRowByLabel('Search Results').contextMenu();
+        const menu = jcontent.getTable().getRowByName('search-results').contextMenu();
         menu.shouldHaveItem('Edit');
         menu.shouldHaveItem('Advanced editing');
         menu.shouldHaveItem('Lock');
@@ -63,8 +65,9 @@ describe('Actions visibility', () => {
     });
 
     it('Displays contentItem actions', () => {
+        jcontent = JContent.visit(SITEKEY, 'en', 'pages/home');
         jcontent.switchToListMode();
-        const row = jcontent.getTable().getRowByLabel('Search Results');
+        const row = jcontent.getTable().getRowByName('search-results');
         const button = getComponentByRole(Button, 'contentItemActionsMenu', row);
         button.click();
         const menu = getComponentByRole(Menu, 'jcontent-contentItemActionsMenu');
@@ -79,5 +82,51 @@ describe('Actions visibility', () => {
         menu.shouldHaveItem('Import content');
         menu.shouldHaveItem('Show in Repository Explorer');
         menu.shouldHaveItem('Open in Page Composer');
+    });
+
+    it('Checks actions inside contextual menu of a folder', function () {
+        jcontent = JContent.visit(SITEKEY, 'en', 'media/files');
+        jcontent.switchToListMode();
+
+        const contextMenu = jcontent
+            .getTable()
+            .getRowByName('bootstrap')
+            .contextMenu();
+
+        const items = [
+            'Rename',
+            'New folder',
+            'Copy',
+            'Upload file(s)',
+            'Lock',
+            'Download as zip'
+        ];
+
+        items.forEach(item => {
+            contextMenu.shouldHaveItem(item);
+        });
+    });
+
+    it('Checks actions inside contextual menu of a file', function () {
+        jcontent = JContent.visit(SITEKEY, 'en', 'media/files/bootstrap/css');
+        jcontent.switchToListMode();
+
+        const contextMenu = jcontent
+            .getTable()
+            .getRowByName('bootstrap.css')
+            .contextMenu();
+
+        const items = [
+            'Edit',
+            'Rename',
+            'Download',
+            'Replace with',
+            'Preview',
+            'Cut'
+        ];
+
+        items.forEach(item => {
+            contextMenu.shouldHaveItem(item);
+        });
     });
 });


### PR DESCRIPTION
### Description
Move testContextMenuInFolder to Cypress.
Related ticket https://github.com/Jahia/selenium/issues/1508
We already have some checks on pages in menuActions\visibility.cy.ts so I only added some checks for files and folders.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
