### PR TITLE
test: move testSecondaryActionsInActionBar to Cypress

### DIFF
--- a/tests/cypress/e2e/menuActions/actionBars.cy.ts
+++ b/tests/cypress/e2e/menuActions/actionBars.cy.ts
@@ -1,5 +1,5 @@
 import {JContent} from '../../page-object/jcontent';
-import {addNode} from "@jahia/cypress";
+import {addNode} from '@jahia/cypress';
 
 describe('test jcontent actionbar', () => {
     let jcontent: JContent;


### PR DESCRIPTION
### Description
Move testSecondaryActionsInActionBar to Cypress.
Related ticket https://github.com/Jahia/selenium/issues/1529.

Also added a step to existing test "test actionbar" to check the presence of "new page" action in the header.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
