### PR TITLE
test: add breadcrumb tests

### DIFF
--- a/tests/cypress/e2e/jcontent/breadcrumbs.cy.ts
+++ b/tests/cypress/e2e/jcontent/breadcrumbs.cy.ts
@@ -21,12 +21,12 @@ describe('Breadcrumb navigation test', () => {
             name: 'childpageA',
             primaryNodeType: 'jnt:page',
             properties: [
-                { name: 'jcr:title', value: 'childpageA', language: 'en' },
-                { name: 'j:templateName', type: 'STRING', value: 'simple' }
+                {name: 'jcr:title', value: 'childpageA', language: 'en'},
+                {name: 'j:templateName', type: 'STRING', value: 'simple'}
             ]
         });
         // Create several nested folders
-        const folders = ['A','B','C','D'];
+        const folders = ['A', 'B', 'C', 'D'];
         let parentPath = `/sites/${siteKey}/contents`;
 
         folders.forEach(name => {


### PR DESCRIPTION
### Description
Move Selenium test testBreadcrumbs to Cypress.
Related ticket : https://github.com/Jahia/selenium/issues/1532

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
