### PR TITLE
test: move testPublishUnpublish to Cypress

### DIFF
--- a/tests/cypress/e2e/jcontent/publicationStatus.cy.ts
+++ b/tests/cypress/e2e/jcontent/publicationStatus.cy.ts
@@ -40,7 +40,7 @@ describe('Publication status badge test', () => {
     }
 
     before(() => {
-        createSite(siteKey, {templateSet: 'jcontent-test-template', serverName: 'localhost', locale: 'en'});
+        createSite(siteKey, {templateSet: 'dx-base-demo-templates', serverName: 'localhost', locale: 'en'});
         cy.executeGroovy('contentEditor/contentMultiLanguage/contentMultiLanguageSite.groovy', {SITEKEY: siteKey2});
         createUser(editor.username, editor.password);
         grantRoles(`/sites/${siteKey}`, ['editor'], editor.username, 'USER');


### PR DESCRIPTION
### Description
Move Selenium test testPublishUnpublish to Cypress.
Related ticket : https://github.com/Jahia/selenium/issues/1531
--> I added a test about "publish all under" on a page solo language + a test about "publish all under" on a folder on a multilanguage site.
--> I replaced the templateSet by `dx-base-demo-templates` because `jcontent-test-template` has no subpage under home and it doesn't affect the existing tests to use `dx-base-demo-templates` instead.

Also replaced getRowByLabel by getRowByName in existing test because it is now deprecated.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
