### PR TITLE
test: move Selenium test OnChangeAction to Cypress

### DIFF
--- a/tests/cypress/e2e/contentEditor/editContent.cy.ts
+++ b/tests/cypress/e2e/contentEditor/editContent.cy.ts
@@ -21,6 +21,11 @@ describe('Create content tests', () => {
             name: 'My simple text',
             primaryNodeType: 'jnt:text'
         });
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: 'On change text',
+            primaryNodeType: 'jnt:text'
+        });
     });
 
     after(() => {
@@ -113,5 +118,18 @@ describe('Create content tests', () => {
         contentEditor.cancel();
 
         cy.url().should('contain', '?param=test');
+    });
+
+    it('should display the on-change div', () => {
+        const contentEditor = jcontent.editComponentByRowName('On change text');
+        contentEditor.switchToAdvancedMode();
+
+        cy.get('#sel-content-editor-field-on-change').should('not.exist');
+        contentEditor.getSmallTextField('jnt:text_text').addNewValue('update');
+        contentEditor.save();
+
+        cy.get('#sel-content-editor-field-on-change')
+            .should('have.attr', 'data-previous-value', 'updat')
+            .should('have.attr', 'data-current-value', 'update');
     });
 });


### PR DESCRIPTION
### Description
Move Selenium test OnChangeAction to Cypress.
We had 2 Selenium tests checking the on-change div on edition / creation / on more than 10 different components and input fields.
It is not necessary to test on all the components/fields inside Jahia.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
