### PR TITLE
test: move Selenium test testToggle to Cypress

### DIFF
--- a/tests/cypress/e2e/contentEditor/contentEditorForm.cy.ts
+++ b/tests/cypress/e2e/contentEditor/contentEditorForm.cy.ts
@@ -291,7 +291,7 @@ describe('Content editor form', () => {
             .find('input[type="checkbox"]')
             .should('have.attr', 'aria-checked', 'true');
 
-        // uncheck
+        // Uncheck
         cy.get('[data-sel-content-editor-field="qant:allFields_boolean"]')
             .find('input[type="checkbox"]')
             .uncheck({force: true});


### PR DESCRIPTION
### Description
Move Selenium test `testToggle` to Cypress.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
