### PR TITLE
test: move listOrdering to Cypress

### DIFF
--- a/tests/cypress/e2e/contentEditor/listOrdering.cy.ts
+++ b/tests/cypress/e2e/contentEditor/listOrdering.cy.ts
@@ -105,7 +105,7 @@ describe('Test list ordering', () => {
         contentEditor.switchToAdvancedMode();
 
         contentEditor.getSection('listOrdering').should('exist');
-        cy.get('[data-sel-role-automatic-ordering="jmix:orderedList"]').should('not.exist');
+        cy.get('[data-sel-role-automatic-ordering="jmix:orderedList"]', {timeout: 5000}).should('not.exist');
     });
 
     it('should only be automatically orderable', () => {
@@ -116,7 +116,7 @@ describe('Test list ordering', () => {
 
         contentEditor.getSection('listOrdering').should('exist');
         cy.get('[data-sel-role-automatic-ordering="jmix:orderedList"]').should('exist');
-        cy.get('[data-sel-field-picker-action="openPicker"]').should('not.exist');
+        cy.get('[data-sel-field-picker-action="openPicker"]', {timeout: 5000}).should('not.exist');
     });
 
     it('should not display sub-nodes', () => {
@@ -127,6 +127,6 @@ describe('Test list ordering', () => {
 
         contentEditor.getSection('listOrdering').should('exist');
         cy.get('[data-sel-role-automatic-ordering="jmix:orderedList"]').should('exist');
-        cy.get('[data-sel-field-picker-action="openPicker"]').should('not.exist');
+        cy.get('[data-sel-field-picker-action="openPicker"]', {timeout: 5000}).should('not.exist');
     });
 });


### PR DESCRIPTION
### Description
Move ListOrderingTest.java Selenium tests to Cypress.
It includes : 
- testContentListOrdering
- testContentListOrderingOption
- testDisplaySubNodes

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
