### PR TITLE
feat: provide content history graphql API node extension

### DIFF
--- a/.chachalog/DYb3afbM.md
+++ b/.chachalog/DYb3afbM.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Provide content history graphql API node extension (#2269)

--- a/.chachalog/DYb3afbM.md
+++ b/.chachalog/DYb3afbM.md
@@ -3,4 +3,4 @@
 "@jahia/jcontent": minor
 ---
 
-Provide content history graphql API node extension (#2269)
+Added a GraphQL API for content history (#2269)

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
             org.jahia.services.content.decorator,
             org.jahia.services.content.nodetypes,
             org.jahia.services.content.nodetypes.initializers,
+            org.jahia.services.history,
             org.jahia.services.render,
             org.jahia.services.render.filter,
             org.jahia.services.scheduler,

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/GqlContentHistory.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/GqlContentHistory.java
@@ -53,14 +53,14 @@ public class GqlContentHistory {
             @GraphQLName("action") @GraphQLDescription("Filter entries by action (e.g., 'published', 'created', 'updated', 'deleted')") String action,
             @GraphQLName("offset") @GraphQLDescription("Number of entries to skip (default: 0)") Integer offset,
             @GraphQLName("limit") @GraphQLDescription("Maximum number of entries to return (default: 50)") Integer limit) {
-        
+
         boolean withLang = withLanguageNodes != null ? withLanguageNodes : false;
         int offsetValue = offset != null ? offset : 0;
         int limitValue = limit != null ? limit : 50;
 
         return ContentHistoryAdapter.getHistory(node, withLang, action, offsetValue, limitValue)
                 .stream()
-                .map(GqlContentHistoryEntry::new)
+                .map(entry -> new GqlContentHistoryEntry(entry, node))
                 .collect(Collectors.toList());
     }
 
@@ -69,7 +69,7 @@ public class GqlContentHistory {
     public int getCount(
             @GraphQLName("withLanguageNodes") @GraphQLDescription("Include language-specific nodes in the count (default: false)") Boolean withLanguageNodes,
             @GraphQLName("action") @GraphQLDescription("Filter count by action (e.g., 'published', 'created', 'updated', 'deleted')") String action) {
-        
+
         boolean withLang = withLanguageNodes != null ? withLanguageNodes : false;
         return ContentHistoryAdapter.getHistoryCount(node, withLang, action);
     }

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/GqlContentHistory.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/GqlContentHistory.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 public class GqlContentHistory {
 
     private final JCRNodeWrapper node;
+    private static final int MAX_ENTRIES  = 100;
 
     public GqlContentHistory(GqlJcrNode node) {
         this.node = node.getNode();
@@ -51,7 +52,7 @@ public class GqlContentHistory {
 
     @GraphQLField
     @GraphQLRequiresPermission("viewHistoryTab")
-    @GraphQLDescription("Get paginated content history entries for the node")
+    @GraphQLDescription("Get paginated content history entries for the node, the maximum number of returned entries is 100")
     public List<GqlContentHistoryEntry> getEntries(
             @GraphQLName("withLanguageNodes") @GraphQLDescription("Include language-specific nodes in the result (default: false)") Boolean withLanguageNodes,
             @GraphQLName("action") @GraphQLDescription("Filter entries by action (e.g., 'published', 'created', 'updated', 'deleted')") String action,
@@ -60,7 +61,7 @@ public class GqlContentHistory {
 
         boolean withLang = withLanguageNodes != null ? withLanguageNodes : false;
         int offsetValue = offset != null ? offset : 0;
-        int limitValue = limit != null ? limit : 20;
+        int limitValue = limit != null ? Math.min(limit, MAX_ENTRIES) : 20;
 
         if (offsetValue < 0 || limitValue < 0) {
             throw new IllegalArgumentException("Offset or Limit cannot be negative");

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/GqlContentHistory.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/GqlContentHistory.java
@@ -28,6 +28,7 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import org.jahia.modules.contenteditor.graphql.api.types.history.ContentHistoryAdapter;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNode;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
 import org.jahia.services.content.JCRNodeWrapper;
 
 import java.util.ArrayList;
@@ -49,6 +50,7 @@ public class GqlContentHistory {
     }
 
     @GraphQLField
+    @GraphQLRequiresPermission("viewHistoryTab")
     @GraphQLDescription("Get paginated content history entries for the node")
     public List<GqlContentHistoryEntry> getEntries(
             @GraphQLName("withLanguageNodes") @GraphQLDescription("Include language-specific nodes in the result (default: false)") Boolean withLanguageNodes,
@@ -71,6 +73,7 @@ public class GqlContentHistory {
     }
 
     @GraphQLField
+    @GraphQLRequiresPermission("viewHistoryTab")
     @GraphQLDescription("Get total count of history entries for the node")
     public int getCount(
             @GraphQLName("withLanguageNodes") @GraphQLDescription("Include language-specific nodes in the count (default: false)") Boolean withLanguageNodes,

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/GqlContentHistory.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/GqlContentHistory.java
@@ -30,6 +30,8 @@ import org.jahia.modules.contenteditor.graphql.api.types.history.ContentHistoryA
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNode;
 import org.jahia.services.content.JCRNodeWrapper;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -52,11 +54,15 @@ public class GqlContentHistory {
             @GraphQLName("withLanguageNodes") @GraphQLDescription("Include language-specific nodes in the result (default: false)") Boolean withLanguageNodes,
             @GraphQLName("action") @GraphQLDescription("Filter entries by action (e.g., 'published', 'created', 'updated', 'deleted')") String action,
             @GraphQLName("offset") @GraphQLDescription("Number of entries to skip (default: 0)") Integer offset,
-            @GraphQLName("limit") @GraphQLDescription("Maximum number of entries to return (default: 50)") Integer limit) {
+            @GraphQLName("limit") @GraphQLDescription("Maximum number of entries to return (default: 20)") Integer limit) {
 
         boolean withLang = withLanguageNodes != null ? withLanguageNodes : false;
         int offsetValue = offset != null ? offset : 0;
-        int limitValue = limit != null ? limit : 50;
+        int limitValue = limit != null ? limit : 20;
+
+        if (offsetValue < 0 || limitValue < 0) {
+            throw new IllegalArgumentException("Offset or Limit cannot be negative");
+        }
 
         return ContentHistoryAdapter.getHistory(node, withLang, action, offsetValue, limitValue)
                 .stream()

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/GqlContentHistory.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/GqlContentHistory.java
@@ -1,0 +1,74 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2002 - 2022 Jahia Solutions Group. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jahia.modules.contenteditor.graphql.api.types;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+import org.jahia.modules.contenteditor.graphql.api.types.history.ContentHistoryAdapter;
+import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNode;
+import org.jahia.services.content.JCRNodeWrapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * GraphQL wrapper for content history operations.
+ * Delegates to ContentHistoryAdapter which handles version-specific implementations.
+ */
+@GraphQLDescription("Content history information for a node")
+public class GqlContentHistory {
+
+    private final JCRNodeWrapper node;
+
+    public GqlContentHistory(GqlJcrNode node) {
+        this.node = node.getNode();
+    }
+
+    @GraphQLField
+    @GraphQLDescription("Get paginated content history entries for the node")
+    public List<GqlContentHistoryEntry> getEntries(
+            @GraphQLName("withLanguageNodes") @GraphQLDescription("Include language-specific nodes in the result (default: false)") Boolean withLanguageNodes,
+            @GraphQLName("offset") @GraphQLDescription("Number of entries to skip (default: 0)") Integer offset,
+            @GraphQLName("limit") @GraphQLDescription("Maximum number of entries to return (default: 50)") Integer limit) {
+        
+        boolean withLang = withLanguageNodes != null ? withLanguageNodes : false;
+        int offsetValue = offset != null ? offset : 0;
+        int limitValue = limit != null ? limit : 50;
+
+        return ContentHistoryAdapter.getHistory(node, withLang, offsetValue, limitValue)
+                .stream()
+                .map(GqlContentHistoryEntry::new)
+                .collect(Collectors.toList());
+    }
+
+    @GraphQLField
+    @GraphQLDescription("Get total count of history entries for the node")
+    public int getCount(
+            @GraphQLName("withLanguageNodes") @GraphQLDescription("Include language-specific nodes in the count (default: false)") Boolean withLanguageNodes) {
+        
+        boolean withLang = withLanguageNodes != null ? withLanguageNodes : false;
+        return ContentHistoryAdapter.getHistoryCount(node, withLang);
+    }
+}

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/GqlContentHistory.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/GqlContentHistory.java
@@ -50,6 +50,7 @@ public class GqlContentHistory {
     @GraphQLDescription("Get paginated content history entries for the node")
     public List<GqlContentHistoryEntry> getEntries(
             @GraphQLName("withLanguageNodes") @GraphQLDescription("Include language-specific nodes in the result (default: false)") Boolean withLanguageNodes,
+            @GraphQLName("action") @GraphQLDescription("Filter entries by action (e.g., 'published', 'created', 'updated', 'deleted')") String action,
             @GraphQLName("offset") @GraphQLDescription("Number of entries to skip (default: 0)") Integer offset,
             @GraphQLName("limit") @GraphQLDescription("Maximum number of entries to return (default: 50)") Integer limit) {
         
@@ -57,7 +58,7 @@ public class GqlContentHistory {
         int offsetValue = offset != null ? offset : 0;
         int limitValue = limit != null ? limit : 50;
 
-        return ContentHistoryAdapter.getHistory(node, withLang, offsetValue, limitValue)
+        return ContentHistoryAdapter.getHistory(node, withLang, action, offsetValue, limitValue)
                 .stream()
                 .map(GqlContentHistoryEntry::new)
                 .collect(Collectors.toList());
@@ -66,9 +67,10 @@ public class GqlContentHistory {
     @GraphQLField
     @GraphQLDescription("Get total count of history entries for the node")
     public int getCount(
-            @GraphQLName("withLanguageNodes") @GraphQLDescription("Include language-specific nodes in the count (default: false)") Boolean withLanguageNodes) {
+            @GraphQLName("withLanguageNodes") @GraphQLDescription("Include language-specific nodes in the count (default: false)") Boolean withLanguageNodes,
+            @GraphQLName("action") @GraphQLDescription("Filter count by action (e.g., 'published', 'created', 'updated', 'deleted')") String action) {
         
         boolean withLang = withLanguageNodes != null ? withLanguageNodes : false;
-        return ContentHistoryAdapter.getHistoryCount(node, withLang);
+        return ContentHistoryAdapter.getHistoryCount(node, withLang, action);
     }
 }

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/GqlContentHistoryEntry.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/GqlContentHistoryEntry.java
@@ -26,10 +26,19 @@ package org.jahia.modules.contenteditor.graphql.api.types;
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.content.JCRSessionFactory;
+import org.jahia.services.content.nodetypes.ExtendedNodeType;
+import org.jahia.services.content.nodetypes.ExtendedPropertyDefinition;
 import org.jahia.services.history.HistoryEntry;
+import org.jahia.utils.LanguageCodeConverters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.jcr.RepositoryException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 /**
@@ -38,9 +47,13 @@ import java.util.TimeZone;
 @GraphQLDescription("Represents a content change event entry")
 public class GqlContentHistoryEntry {
 
-    private final HistoryEntry historyEntry;
+    private static final Logger logger = LoggerFactory.getLogger(GqlContentHistoryEntry.class);
 
-    public GqlContentHistoryEntry(HistoryEntry historyEntry) {
+    private final HistoryEntry historyEntry;
+    private final JCRNodeWrapper node;
+
+    public GqlContentHistoryEntry(HistoryEntry historyEntry, JCRNodeWrapper node) {
+        this.node = node;
         this.historyEntry = historyEntry;
     }
 
@@ -108,5 +121,50 @@ public class GqlContentHistoryEntry {
     @GraphQLDescription("The language code if the entry is for a language-specific node")
     public String getLanguage() {
         return historyEntry.getLocale() != null ? historyEntry.getLocale().toString() : null;
+    }
+
+    @GraphQLField
+    @GraphQLDescription("The localized display name of the property if the action was on a specific property")
+    public String getPropertyNameDisplay(@GraphQLName("language") @GraphQLDescription("Language code for the display name") String language) {
+        String propertyName = historyEntry.getPropertyName();
+        if (propertyName == null || propertyName.trim().isEmpty()) {
+            return null;
+        }
+
+        try {
+
+            if (node == null) {
+                return propertyName;
+            }
+
+            // Get the node type
+            ExtendedNodeType nodeType = node.getPrimaryNodeType();
+
+            // Get the property definition
+            ExtendedPropertyDefinition propertyDef = nodeType.getPropertyDefinitionsAsMap().get(propertyName);
+
+            if (propertyDef == null) {
+                // Try to find in mixins
+                for (ExtendedNodeType mixin : node.getMixinNodeTypes()) {
+                    propertyDef = mixin.getPropertyDefinitionsAsMap().get(propertyName);
+                    if (propertyDef != null) {
+                        nodeType = mixin;
+                        break;
+                    }
+                }
+            }
+
+            if (propertyDef != null) {
+                Locale locale = language != null ? LanguageCodeConverters.languageCodeToLocale(language) : Locale.ENGLISH;
+                return propertyDef.getLabel(locale, nodeType);
+            }
+
+            return propertyName;
+        } catch (RepositoryException e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Could not resolve property display name for property '{}' on node '{}'", propertyName, historyEntry.getUuid(), e);
+            }
+            return propertyName;
+        }
     }
 }

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/GqlContentHistoryEntry.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/GqlContentHistoryEntry.java
@@ -1,0 +1,112 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2002 - 2022 Jahia Solutions Group. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jahia.modules.contenteditor.graphql.api.types;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+import org.jahia.services.history.HistoryEntry;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+/**
+ * GraphQL representation of a content history entry
+ */
+@GraphQLDescription("Represents a content change event entry")
+public class GqlContentHistoryEntry {
+
+    private final HistoryEntry historyEntry;
+
+    public GqlContentHistoryEntry(HistoryEntry historyEntry) {
+        this.historyEntry = historyEntry;
+    }
+
+    @GraphQLField
+    @GraphQLDescription("The unique identifier of the history entry")
+    public String getId() {
+        return historyEntry.getId();
+    }
+
+    @GraphQLField
+    @GraphQLDescription("The timestamp of the history entry in ISO 8601 format")
+    public String getDate() {
+        if (historyEntry.getDate() == null) {
+            return null;
+        }
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return sdf.format(new Date(historyEntry.getDate()));
+    }
+
+    @GraphQLField
+    @GraphQLDescription("The timestamp of the history entry as milliseconds since epoch")
+    public Long getTimestamp() {
+        return historyEntry.getDate();
+    }
+
+    @GraphQLField
+    @GraphQLDescription("The path of the node at the time of the event")
+    public String getPath() {
+        return historyEntry.getPath();
+    }
+
+    @GraphQLField
+    @GraphQLDescription("The UUID of the node")
+    public String getUuid() {
+        return historyEntry.getUuid();
+    }
+
+    @GraphQLField
+    @GraphQLDescription("The action performed (e.g., created, updated, deleted, published)")
+    public String getAction() {
+        return historyEntry.getAction();
+    }
+
+    @GraphQLField
+    @GraphQLDescription("The property name if the action was on a specific property")
+    public String getPropertyName() {
+        return historyEntry.getPropertyName();
+    }
+
+    @GraphQLField
+    @GraphQLDescription("The user key who performed the action")
+    public String getUserKey() {
+        return historyEntry.getUserKey();
+    }
+
+    @GraphQLField
+    @GraphQLDescription("Additional message about the event")
+    public String getMessage() {
+        return historyEntry.getMessage();
+    }
+
+    @GraphQLField
+    @GraphQLName("language")
+    @GraphQLDescription("The language code if the entry is for a language-specific node")
+    public String getLanguage() {
+        return historyEntry.getLocale() != null ? historyEntry.getLocale().toString() : null;
+    }
+}

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ContentHistoryAdapter.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ContentHistoryAdapter.java
@@ -59,12 +59,13 @@ public final class ContentHistoryAdapter {
      * 
      * @param node the JCR node
      * @param withLanguageNodes whether to include language-specific nodes
+     * @param action filter by specific action (null for all actions)
      * @param offset number of entries to skip
      * @param limit maximum number of entries to return
      * @return list of history entries
      */
-    public static List<HistoryEntry> getHistory(JCRNodeWrapper node, boolean withLanguageNodes, int offset, int limit) {
-        return getProvider().getHistory(node, withLanguageNodes, offset, limit);
+    public static List<HistoryEntry> getHistory(JCRNodeWrapper node, boolean withLanguageNodes, String action, int offset, int limit) {
+        return getProvider().getHistory(node, withLanguageNodes, action, offset, limit);
     }
 
     /**
@@ -72,10 +73,11 @@ public final class ContentHistoryAdapter {
      * 
      * @param node the JCR node
      * @param withLanguageNodes whether to include language-specific nodes
+     * @param action filter by specific action (null for all actions)
      * @return count of history entries
      */
-    public static int getHistoryCount(JCRNodeWrapper node, boolean withLanguageNodes) {
-        return getProvider().getHistoryCount(node, withLanguageNodes);
+    public static int getHistoryCount(JCRNodeWrapper node, boolean withLanguageNodes, String action) {
+        return getProvider().getHistoryCount(node, withLanguageNodes, action);
     }
 
     private static ContentHistoryProvider getProvider() {

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ContentHistoryAdapter.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ContentHistoryAdapter.java
@@ -1,0 +1,122 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2002 - 2022 Jahia Solutions Group. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jahia.modules.contenteditor.graphql.api.types.history;
+
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.history.ContentHistoryService;
+import org.jahia.services.history.HistoryEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * Adapter to handle version-specific ContentHistoryService method calls.
+ * 
+ * This class encapsulates version detection logic and delegates to the appropriate implementation:
+ * - Jahia 8.2.4.0+: Uses {@link ModernContentHistoryAdapter} (optimized methods)
+ * - Jahia 8.2.1.0-8.2.3.x: Uses {@link LegacyContentHistoryAdapter} (deprecated methods with stream pagination)
+ * 
+ * @since jContent 3.x
+ * @deprecated This adapter will be removed when Jahia 8.2.4.0 becomes the minimum required version.
+ *             Direct calls to ContentHistoryService optimized methods will be used instead.
+ */
+@Deprecated(since = "jContent 3.x", forRemoval = true)
+public final class ContentHistoryAdapter {
+
+    private static final Logger logger = LoggerFactory.getLogger(ContentHistoryAdapter.class);
+    private static volatile ContentHistoryProvider provider;
+    private static volatile boolean initialized = false;
+
+    private ContentHistoryAdapter() {
+        // Utility class
+    }
+
+    /**
+     * Get paginated history entries for a node.
+     * 
+     * @param node the JCR node
+     * @param withLanguageNodes whether to include language-specific nodes
+     * @param offset number of entries to skip
+     * @param limit maximum number of entries to return
+     * @return list of history entries
+     */
+    public static List<HistoryEntry> getHistory(JCRNodeWrapper node, boolean withLanguageNodes, int offset, int limit) {
+        return getProvider().getHistory(node, withLanguageNodes, offset, limit);
+    }
+
+    /**
+     * Get total count of history entries for a node.
+     * 
+     * @param node the JCR node
+     * @param withLanguageNodes whether to include language-specific nodes
+     * @return count of history entries
+     */
+    public static int getHistoryCount(JCRNodeWrapper node, boolean withLanguageNodes) {
+        return getProvider().getHistoryCount(node, withLanguageNodes);
+    }
+
+    private static ContentHistoryProvider getProvider() {
+        if (!initialized) {
+            synchronized (ContentHistoryAdapter.class) {
+                if (!initialized) {
+                    provider = detectProvider();
+                    initialized = true;
+                }
+            }
+        }
+        return provider;
+    }
+
+    private static ContentHistoryProvider detectProvider() {
+        if (hasModernMethods()) {
+            logger.info("Detected Jahia 8.2.4.0+ - Using optimized ContentHistoryService methods");
+            return new ModernContentHistoryAdapter();
+        } else {
+            logger.info("Detected Jahia 8.2.1.0-8.2.3.x - Using legacy ContentHistoryService methods with stream pagination");
+            return new LegacyContentHistoryAdapter();
+        }
+    }
+
+    private static boolean hasModernMethods() {
+        try {
+            Method paginatedMethod = ContentHistoryService.class.getMethod(
+                    "getNodeHistory",
+                    JCRNodeWrapper.class,
+                    boolean.class,
+                    int.class,
+                    int.class
+            );
+            Method countMethod = ContentHistoryService.class.getMethod(
+                    "getNodeHistoryCount",
+                    JCRNodeWrapper.class,
+                    boolean.class
+            );
+            return paginatedMethod != null && countMethod != null;
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ContentHistoryProvider.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ContentHistoryProvider.java
@@ -41,18 +41,20 @@ interface ContentHistoryProvider {
      * 
      * @param node the JCR node
      * @param withLanguageNodes whether to include language-specific nodes
+     * @param action filter by specific action (null for all actions)
      * @param offset number of entries to skip
      * @param limit maximum number of entries to return (-1 for all)
      * @return list of history entries
      */
-    List<HistoryEntry> getHistory(JCRNodeWrapper node, boolean withLanguageNodes, int offset, int limit);
+    List<HistoryEntry> getHistory(JCRNodeWrapper node, boolean withLanguageNodes, String action, int offset, int limit);
 
     /**
      * Get total count of history entries for a node.
      * 
      * @param node the JCR node
      * @param withLanguageNodes whether to include language-specific nodes
+     * @param action filter by specific action (null for all actions)
      * @return count of history entries
      */
-    int getHistoryCount(JCRNodeWrapper node, boolean withLanguageNodes);
+    int getHistoryCount(JCRNodeWrapper node, boolean withLanguageNodes, String action);
 }

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ContentHistoryProvider.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ContentHistoryProvider.java
@@ -1,0 +1,58 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2002 - 2022 Jahia Solutions Group. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jahia.modules.contenteditor.graphql.api.types.history;
+
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.history.HistoryEntry;
+
+import java.util.List;
+
+/**
+ * Interface for version-specific ContentHistoryService implementations.
+ * 
+ * @deprecated This interface will be removed when Jahia 8.2.4.0 becomes the minimum required version.
+ */
+@Deprecated(since = "jContent 3.x", forRemoval = true)
+interface ContentHistoryProvider {
+
+    /**
+     * Get paginated history entries for a node.
+     * 
+     * @param node the JCR node
+     * @param withLanguageNodes whether to include language-specific nodes
+     * @param offset number of entries to skip
+     * @param limit maximum number of entries to return (-1 for all)
+     * @return list of history entries
+     */
+    List<HistoryEntry> getHistory(JCRNodeWrapper node, boolean withLanguageNodes, int offset, int limit);
+
+    /**
+     * Get total count of history entries for a node.
+     * 
+     * @param node the JCR node
+     * @param withLanguageNodes whether to include language-specific nodes
+     * @return count of history entries
+     */
+    int getHistoryCount(JCRNodeWrapper node, boolean withLanguageNodes);
+}

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/LegacyContentHistoryAdapter.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/LegacyContentHistoryAdapter.java
@@ -29,19 +29,20 @@ import org.jahia.services.history.HistoryEntry;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Legacy implementation for Jahia 8.2.1.0-8.2.3.x using deprecated ContentHistoryService methods.
  * Implements pagination using Java streams.
- * 
+ *
  * TODO: When upgrading to Jahia 8.2.4.0+:
  *  1. Delete this class
  *  2. Delete {@link ModernContentHistoryAdapter}
  *  3. Delete {@link ContentHistoryAdapter}
  *  4. Delete {@link ContentHistoryProvider}
- *  5. Update {@link org.jahia.modules.contenteditor.graphql.api.types.GqlContentHistory} 
+ *  5. Update {@link org.jahia.modules.contenteditor.graphql.api.types.GqlContentHistory}
  *     to call ContentHistoryService methods directly
- * 
+ *
  * @deprecated This class will be removed when Jahia 8.2.4.0 becomes the minimum required version.
  */
 @Deprecated(since = "jContent 3.x", forRemoval = true)
@@ -60,14 +61,18 @@ class LegacyContentHistoryAdapter implements ContentHistoryProvider {
                     .collect(Collectors.toList());
         }
 
-        if (limit == -1) {
-            return allEntries;
+        if (limit != -1 || offset > 0) {
+            Stream<HistoryEntry> stream = allEntries.stream();
+            if (offset > 0) {
+                stream = stream.skip(offset);
+            }
+            if (limit > 0) {
+                stream = stream.limit(limit);
+            }
+            allEntries = stream.collect(Collectors.toList());
         }
 
-        return allEntries.stream()
-                .skip(offset)
-                .limit(limit)
-                .collect(Collectors.toList());
+        return allEntries;
     }
 
     @Override
@@ -75,14 +80,14 @@ class LegacyContentHistoryAdapter implements ContentHistoryProvider {
         @SuppressWarnings("deprecation")
         List<HistoryEntry> allEntries = ContentHistoryService.getInstance()
                 .getNodeHistory(node, withLanguageNodes);
-        
+
         // Apply action filter if provided
         if (action != null && !action.trim().isEmpty()) {
             return (int) allEntries.stream()
                     .filter(entry -> action.equals(entry.getAction()))
                     .count();
         }
-        
+
         return allEntries.size();
     }
 }

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/LegacyContentHistoryAdapter.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/LegacyContentHistoryAdapter.java
@@ -1,0 +1,74 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2002 - 2022 Jahia Solutions Group. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jahia.modules.contenteditor.graphql.api.types.history;
+
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.history.ContentHistoryService;
+import org.jahia.services.history.HistoryEntry;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Legacy implementation for Jahia 8.2.1.0-8.2.3.x using deprecated ContentHistoryService methods.
+ * Implements pagination using Java streams.
+ * 
+ * TODO: When upgrading to Jahia 8.2.4.0+:
+ *  1. Delete this class
+ *  2. Delete {@link ModernContentHistoryAdapter}
+ *  3. Delete {@link ContentHistoryAdapter}
+ *  4. Delete {@link ContentHistoryProvider}
+ *  5. Update {@link org.jahia.modules.contenteditor.graphql.api.types.GqlContentHistory} 
+ *     to call ContentHistoryService methods directly
+ * 
+ * @deprecated This class will be removed when Jahia 8.2.4.0 becomes the minimum required version.
+ */
+@Deprecated(since = "jContent 3.x", forRemoval = true)
+class LegacyContentHistoryAdapter implements ContentHistoryProvider {
+
+    @Override
+    public List<HistoryEntry> getHistory(JCRNodeWrapper node, boolean withLanguageNodes, int offset, int limit) {
+        @SuppressWarnings("deprecation")
+        List<HistoryEntry> allEntries = ContentHistoryService.getInstance()
+                .getNodeHistory(node, withLanguageNodes);
+
+        if (limit == -1) {
+            return allEntries;
+        }
+
+        return allEntries.stream()
+                .skip(offset)
+                .limit(limit)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public int getHistoryCount(JCRNodeWrapper node, boolean withLanguageNodes) {
+        @SuppressWarnings("deprecation")
+        List<HistoryEntry> allEntries = ContentHistoryService.getInstance()
+                .getNodeHistory(node, withLanguageNodes);
+        
+        return allEntries.size();
+    }
+}

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/LegacyContentHistoryAdapter.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/LegacyContentHistoryAdapter.java
@@ -48,10 +48,17 @@ import java.util.stream.Collectors;
 class LegacyContentHistoryAdapter implements ContentHistoryProvider {
 
     @Override
-    public List<HistoryEntry> getHistory(JCRNodeWrapper node, boolean withLanguageNodes, int offset, int limit) {
+    public List<HistoryEntry> getHistory(JCRNodeWrapper node, boolean withLanguageNodes, String action, int offset, int limit) {
         @SuppressWarnings("deprecation")
         List<HistoryEntry> allEntries = ContentHistoryService.getInstance()
                 .getNodeHistory(node, withLanguageNodes);
+
+        // Apply action filter if provided
+        if (action != null && !action.trim().isEmpty()) {
+            allEntries = allEntries.stream()
+                    .filter(entry -> action.equals(entry.getAction()))
+                    .collect(Collectors.toList());
+        }
 
         if (limit == -1) {
             return allEntries;
@@ -64,10 +71,17 @@ class LegacyContentHistoryAdapter implements ContentHistoryProvider {
     }
 
     @Override
-    public int getHistoryCount(JCRNodeWrapper node, boolean withLanguageNodes) {
+    public int getHistoryCount(JCRNodeWrapper node, boolean withLanguageNodes, String action) {
         @SuppressWarnings("deprecation")
         List<HistoryEntry> allEntries = ContentHistoryService.getInstance()
                 .getNodeHistory(node, withLanguageNodes);
+        
+        // Apply action filter if provided
+        if (action != null && !action.trim().isEmpty()) {
+            return (int) allEntries.stream()
+                    .filter(entry -> action.equals(entry.getAction()))
+                    .count();
+        }
         
         return allEntries.size();
     }

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ModernContentHistoryAdapter.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ModernContentHistoryAdapter.java
@@ -30,19 +30,20 @@ import org.jahia.services.history.HistoryEntry;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Modern implementation using Jahia 8.2.4.0+ optimized ContentHistoryService methods.
  * Uses reflection to maintain backward compatibility at compile time.
- * 
+ *
  * TODO: When upgrading to Jahia 8.2.4.0+:
  *  1. Delete this class
  *  2. Delete {@link LegacyContentHistoryAdapter}
  *  3. Delete {@link ContentHistoryAdapter}
  *  4. Delete {@link ContentHistoryProvider}
- *  5. Update {@link org.jahia.modules.contenteditor.graphql.api.types.GqlContentHistory} 
+ *  5. Update {@link org.jahia.modules.contenteditor.graphql.api.types.GqlContentHistory}
  *     to call ContentHistoryService methods directly
- * 
+ *
  * @deprecated This class will be removed when Jahia 8.2.4.0 becomes the minimum required version.
  */
 @Deprecated(since = "jContent 3.x", forRemoval = true)
@@ -72,8 +73,37 @@ class ModernContentHistoryAdapter implements ContentHistoryProvider {
 
     @Override
     @SuppressWarnings("unchecked")
-    public List<HistoryEntry> getHistory(JCRNodeWrapper node, boolean withLanguageNodes, int offset, int limit) {
+    public List<HistoryEntry> getHistory(JCRNodeWrapper node, boolean withLanguageNodes, String action, int offset, int limit) {
         try {
+            List<HistoryEntry> entries;
+
+            // If action filter is provided, get all entries and filter manually
+            // TODO: replace with a service implementation
+            if (action != null && !action.trim().isEmpty()) {
+                entries = (List<HistoryEntry>) paginatedMethod.invoke(
+                        ContentHistoryService.getInstance(),
+                        node,
+                        withLanguageNodes,
+                        0,
+                        -1
+                );
+
+                entries = entries.stream()
+                        .filter(entry -> action.equals(entry.getAction()))
+                        .collect(Collectors.toList());
+
+                // Apply pagination after filtering
+                if (limit != -1) {
+                    entries = entries.stream()
+                            .skip(offset)
+                            .limit(limit)
+                            .collect(Collectors.toList());
+                }
+
+                return entries;
+            }
+
+            // No action filter, use pagination directly
             return (List<HistoryEntry>) paginatedMethod.invoke(
                     ContentHistoryService.getInstance(),
                     node,
@@ -87,8 +117,26 @@ class ModernContentHistoryAdapter implements ContentHistoryProvider {
     }
 
     @Override
-    public int getHistoryCount(JCRNodeWrapper node, boolean withLanguageNodes) {
+    public int getHistoryCount(JCRNodeWrapper node, boolean withLanguageNodes, String action) {
         try {
+            // If action filter is provided, get all entries and filter
+            // TODO: replace with a service implementation
+            if (action != null && !action.trim().isEmpty()) {
+                @SuppressWarnings("unchecked")
+                List<HistoryEntry> allEntries = (List<HistoryEntry>) paginatedMethod.invoke(
+                        ContentHistoryService.getInstance(),
+                        node,
+                        withLanguageNodes,
+                        0,
+                        -1
+                );
+
+                return (int) allEntries.stream()
+                        .filter(entry -> action.equals(entry.getAction()))
+                        .count();
+            }
+
+            // No action filter, use count method directly
             return (Integer) countMethod.invoke(
                     ContentHistoryService.getInstance(),
                     node,

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ModernContentHistoryAdapter.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ModernContentHistoryAdapter.java
@@ -52,6 +52,7 @@ class ModernContentHistoryAdapter implements ContentHistoryProvider {
 
     private static final Method paginatedMethod;
     private static final Method countMethod;
+    private static final int MAX_ENTRIES  = 100;
 
     static {
         try {
@@ -100,7 +101,7 @@ class ModernContentHistoryAdapter implements ContentHistoryProvider {
                         paginatedEntries = paginatedEntries.skip(offset);
                     }
                     if (limit > 0) {
-                        paginatedEntries = paginatedEntries.limit(limit);
+                        paginatedEntries = paginatedEntries.limit(Math.min(limit, MAX_ENTRIES));
                     }
                     entries = paginatedEntries.collect(Collectors.toList());
                 }

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ModernContentHistoryAdapter.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ModernContentHistoryAdapter.java
@@ -31,6 +31,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Modern implementation using Jahia 8.2.4.0+ optimized ContentHistoryService methods.
@@ -78,7 +79,7 @@ class ModernContentHistoryAdapter implements ContentHistoryProvider {
             List<HistoryEntry> entries;
 
             // If action filter is provided, get all entries and filter manually
-            // TODO: replace with a service implementation
+            // TODO: replace with a service implementation when jahia parent version > 8.1.2.0
             if (action != null && !action.trim().isEmpty()) {
                 entries = (List<HistoryEntry>) paginatedMethod.invoke(
                         ContentHistoryService.getInstance(),
@@ -93,11 +94,15 @@ class ModernContentHistoryAdapter implements ContentHistoryProvider {
                         .collect(Collectors.toList());
 
                 // Apply pagination after filtering
-                if (limit != -1) {
-                    entries = entries.stream()
-                            .skip(offset)
-                            .limit(limit)
-                            .collect(Collectors.toList());
+                if (offset > 0 && limit != -1) {
+                    Stream<HistoryEntry> paginatedEntries = entries.stream();
+                    if (offset > 0) {
+                        paginatedEntries = paginatedEntries.skip(offset);
+                    }
+                    if (limit > 0) {
+                        paginatedEntries = paginatedEntries.limit(limit);
+                    }
+                    entries = paginatedEntries.collect(Collectors.toList());
                 }
 
                 return entries;

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ModernContentHistoryAdapter.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ModernContentHistoryAdapter.java
@@ -1,0 +1,101 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2002 - 2022 Jahia Solutions Group. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.jahia.modules.contenteditor.graphql.api.types.history;
+
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.history.ContentHistoryService;
+import org.jahia.services.history.HistoryEntry;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * Modern implementation using Jahia 8.2.4.0+ optimized ContentHistoryService methods.
+ * Uses reflection to maintain backward compatibility at compile time.
+ * 
+ * TODO: When upgrading to Jahia 8.2.4.0+:
+ *  1. Delete this class
+ *  2. Delete {@link LegacyContentHistoryAdapter}
+ *  3. Delete {@link ContentHistoryAdapter}
+ *  4. Delete {@link ContentHistoryProvider}
+ *  5. Update {@link org.jahia.modules.contenteditor.graphql.api.types.GqlContentHistory} 
+ *     to call ContentHistoryService methods directly
+ * 
+ * @deprecated This class will be removed when Jahia 8.2.4.0 becomes the minimum required version.
+ */
+@Deprecated(since = "jContent 3.x", forRemoval = true)
+class ModernContentHistoryAdapter implements ContentHistoryProvider {
+
+    private static final Method paginatedMethod;
+    private static final Method countMethod;
+
+    static {
+        try {
+            paginatedMethod = ContentHistoryService.class.getMethod(
+                    "getNodeHistory",
+                    JCRNodeWrapper.class,
+                    boolean.class,
+                    int.class,
+                    int.class
+            );
+            countMethod = ContentHistoryService.class.getMethod(
+                    "getNodeHistoryCount",
+                    JCRNodeWrapper.class,
+                    boolean.class
+            );
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Modern methods not available - should use LegacyContentHistoryAdapter", e);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<HistoryEntry> getHistory(JCRNodeWrapper node, boolean withLanguageNodes, int offset, int limit) {
+        try {
+            return (List<HistoryEntry>) paginatedMethod.invoke(
+                    ContentHistoryService.getInstance(),
+                    node,
+                    withLanguageNodes,
+                    offset,
+                    limit
+            );
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException("Failed to call getNodeHistory via reflection", e);
+        }
+    }
+
+    @Override
+    public int getHistoryCount(JCRNodeWrapper node, boolean withLanguageNodes) {
+        try {
+            return (Integer) countMethod.invoke(
+                    ContentHistoryService.getInstance(),
+                    node,
+                    withLanguageNodes
+            );
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException("Failed to call getNodeHistoryCount via reflection", e);
+        }
+    }
+}

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ModernContentHistoryAdapter.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ModernContentHistoryAdapter.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
  * Modern implementation using Jahia 8.2.4.0+ optimized ContentHistoryService methods.
  * Uses reflection to maintain backward compatibility at compile time.
  *
- * TODO: When upgrading to Jahia 8.2.4.0+:
+ * TODO: When upgrading to Jahia 8.2.2.0+:
  *  1. Delete this class
  *  2. Delete {@link LegacyContentHistoryAdapter}
  *  3. Delete {@link ContentHistoryAdapter}
@@ -94,7 +94,7 @@ class ModernContentHistoryAdapter implements ContentHistoryProvider {
                         .collect(Collectors.toList());
 
                 // Apply pagination after filtering
-                if (offset > 0 && limit != -1) {
+                if (offset > 0 || limit != -1) {
                     Stream<HistoryEntry> paginatedEntries = entries.stream();
                     if (offset > 0) {
                         paginatedEntries = paginatedEntries.skip(offset);

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ModernContentHistoryAdapter.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ModernContentHistoryAdapter.java
@@ -78,8 +78,8 @@ class ModernContentHistoryAdapter implements ContentHistoryProvider {
         try {
             List<HistoryEntry> entries;
 
-            // If action filter is provided, get all entries and filter manually
-            // TODO: replace with a service implementation when jahia parent version > 8.1.2.0
+            // If action filter is provided, get all entries and filter manually as the current API does not provide such capability
+            // TODO: replace with a service implementation when jahia parent version >= 8.2.4.0
             if (action != null && !action.trim().isEmpty()) {
                 entries = (List<HistoryEntry>) paginatedMethod.invoke(
                         ContentHistoryService.getInstance(),

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ModernContentHistoryAdapter.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/history/ModernContentHistoryAdapter.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
  * Modern implementation using Jahia 8.2.4.0+ optimized ContentHistoryService methods.
  * Uses reflection to maintain backward compatibility at compile time.
  *
- * TODO: When upgrading to Jahia 8.2.2.0+:
+ * TODO: When upgrading to Jahia 8.2.4.0+:
  *  1. Delete this class
  *  2. Delete {@link LegacyContentHistoryAdapter}
  *  3. Delete {@link ContentHistoryAdapter}
@@ -52,7 +52,6 @@ class ModernContentHistoryAdapter implements ContentHistoryProvider {
 
     private static final Method paginatedMethod;
     private static final Method countMethod;
-    private static final int MAX_ENTRIES  = 100;
 
     static {
         try {
@@ -101,7 +100,7 @@ class ModernContentHistoryAdapter implements ContentHistoryProvider {
                         paginatedEntries = paginatedEntries.skip(offset);
                     }
                     if (limit > 0) {
-                        paginatedEntries = paginatedEntries.limit(Math.min(limit, MAX_ENTRIES));
+                        paginatedEntries = paginatedEntries.limit(limit);
                     }
                     entries = paginatedEntries.collect(Collectors.toList());
                 }

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/extensions/JCRNodeContentEditorExtensions.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/extensions/JCRNodeContentEditorExtensions.java
@@ -27,6 +27,7 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
+import org.jahia.modules.contenteditor.graphql.api.types.GqlContentHistory;
 import org.jahia.modules.graphql.provider.dxm.DataFetchingException;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNode;
 import org.jahia.services.content.JCRContentUtils;
@@ -70,7 +71,11 @@ public class JCRNodeContentEditorExtensions {
         } catch (RepositoryException e) {
             throw new DataFetchingException(e);
         }
-
     }
 
+    @GraphQLField
+    @GraphQLDescription("Returns content history for the node")
+    public GqlContentHistory getHistory() {
+        return new GqlContentHistory(node);
+    }
 }

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/extensions/JCRNodeContentEditorExtensions.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/extensions/JCRNodeContentEditorExtensions.java
@@ -76,6 +76,7 @@ public class JCRNodeContentEditorExtensions {
     @GraphQLField
     @GraphQLDescription("Returns content history for the node")
     public GqlContentHistory getHistory() {
+        // Todo: Add permission check for view history on a node
         return new GqlContentHistory(node);
     }
 }

--- a/tests/cypress.config-jcontent.ts
+++ b/tests/cypress.config-jcontent.ts
@@ -1,6 +1,6 @@
 import {defineConfig} from 'cypress';
 import {baseConfig} from './cypress.config.common';
 
-baseConfig.e2e.specPattern = ['cypress/e2e/jcontent/**/!(categoryManager).cy.ts'];
+baseConfig.e2e.specPattern = ['cypress/e2e/jcontent/**/!(categoryManager).cy.ts', 'cypress/e2e/api/**/**.cy.ts'];
 
 export default defineConfig(baseConfig);

--- a/tests/cypress/e2e/api/contentHistory.cy.ts
+++ b/tests/cypress/e2e/api/contentHistory.cy.ts
@@ -558,4 +558,122 @@ describe('Content History GraphQL API', () => {
             expect(entries.length).to.equal(0);
         });
     });
+
+    it('should resolve property display name for property-related actions', () => {
+        addNode({
+            parentPathOrId: contentPath,
+            name: testNodeName,
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Property display name test', language: 'en'}]
+        });
+
+        // Modify a property to generate property change history
+        GraphqlUtils.setProperty(testNodePath, 'text', 'Updated value', 'en');
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(500);
+
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryWithPropertyDisplay.graphql',
+            variables: {
+                path: testNodePath,
+                withLanguageNodes: false,
+                offset: 0,
+                limit: 50,
+                language: 'en'
+            }
+        }).then(result => {
+            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+
+            if (entries && entries.length > 0) {
+                // Find an entry with a property name
+                const propertyEntry = entries.find(entry => entry.propertyName);
+
+                if (propertyEntry) {
+                    cy.log(`Found property entry: ${propertyEntry.propertyName}`);
+
+                    // Should have both propertyName and propertyNameDisplay
+                    expect(propertyEntry).to.have.property('propertyName');
+                    expect(propertyEntry).to.have.property('propertyNameDisplay');
+
+                    // PropertyNameDisplay should be a string (localized label or fallback to property name)
+                    expect(propertyEntry.propertyNameDisplay).to.be.a('string');
+                    expect(propertyEntry.propertyNameDisplay.length).to.be.greaterThan(0);
+
+                    cy.log(`Property name: ${propertyEntry.propertyName}, Display: ${propertyEntry.propertyNameDisplay}`);
+                }
+            }
+        });
+    });
+
+    it('should return propertyName as fallback when display name cannot be resolved', () => {
+        addNode({
+            parentPathOrId: contentPath,
+            name: testNodeName,
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Fallback test', language: 'en'}]
+        });
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(500);
+
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryWithPropertyDisplay.graphql',
+            variables: {
+                path: testNodePath,
+                withLanguageNodes: false,
+                offset: 0,
+                limit: 50,
+                language: 'invalidLanguage'
+            }
+        }).then(result => {
+            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+
+            if (entries && entries.length > 0) {
+                const propertyEntry = entries.find(entry => entry.propertyName);
+
+                if (propertyEntry) {
+                    // Should still return a value (either localized or property name as fallback)
+                    expect(propertyEntry.propertyNameDisplay).to.be.a('string');
+                    expect(propertyEntry.propertyNameDisplay.length).to.be.greaterThan(0);
+                }
+            }
+        });
+    });
+
+    it('should return null propertyNameDisplay when propertyName is null', () => {
+        addNode({
+            parentPathOrId: contentPath,
+            name: testNodeName,
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Null property test', language: 'en'}]
+        });
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(500);
+
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryWithPropertyDisplay.graphql',
+            variables: {
+                path: testNodePath,
+                withLanguageNodes: false,
+                offset: 0,
+                limit: 50,
+                language: 'en'
+            }
+        }).then(result => {
+            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+
+            if (entries && entries.length > 0) {
+                // Find entries without propertyName (node-level actions)
+                const nodeEntry = entries.find(entry => !entry.propertyName);
+
+                if (nodeEntry) {
+                    // PropertyNameDisplay should be null when propertyName is null
+                    expect(nodeEntry.propertyName).to.be.null;
+                    expect(nodeEntry.propertyNameDisplay).to.be.null;
+                }
+            }
+        });
+    });
 });

--- a/tests/cypress/e2e/api/contentHistory.cy.ts
+++ b/tests/cypress/e2e/api/contentHistory.cy.ts
@@ -94,6 +94,9 @@ describe('Content History GraphQL API', () => {
             properties: [{name: 'text', value: 'Created by test user', language: 'en'}]
         });
         cy.apolloClient(); // Switch back to admin
+        // Wait for all logs being processed
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(1000);
     });
 
     after(() => {
@@ -268,16 +271,9 @@ describe('Content History GraphQL API', () => {
             variables: {path: nodePaths.updates, withLanguageNodes: false, offset: 0, limit: 100}
         }).then(allResult => {
             const allEntries = allResult?.data?.jcr?.nodeByPath?.history?.entries;
-            if (!allEntries?.length) {
-                return;
-            }
-
             const actions = [...new Set(allEntries.map((e: {action: string}) => e.action).filter(Boolean))];
             cy.log(`Available actions: ${actions.join(', ')}`);
             const testAction = actions[0];
-            if (!testAction) {
-                return;
-            }
 
             cy.apollo({
                 queryFile: 'api/contentHistory/getNodeHistoryWithAction.graphql',
@@ -299,9 +295,6 @@ describe('Content History GraphQL API', () => {
             variables: {path: nodePaths.updates, withLanguageNodes: false, offset: 0, limit: 100}
         }).then(allResult => {
             const allEntries = allResult?.data?.jcr?.nodeByPath?.history?.entries;
-            if (!allEntries?.length) {
-                return;
-            }
 
             const actions = [...new Set(allEntries.map((e: {action: string}) => e.action).filter(Boolean))];
             const testAction = actions[0];

--- a/tests/cypress/e2e/api/contentHistory.cy.ts
+++ b/tests/cypress/e2e/api/contentHistory.cy.ts
@@ -41,6 +41,7 @@ describe('Content History GraphQL API', () => {
         });
 
         // Wait for potential async history processing
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(500);
 
         cy.apollo({
@@ -65,6 +66,7 @@ describe('Content History GraphQL API', () => {
             properties: [{name: 'text', value: 'Test content', language: 'en'}]
         });
 
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(500);
 
         cy.apollo({
@@ -101,6 +103,7 @@ describe('Content History GraphQL API', () => {
             properties: [{name: 'text', value: 'Initial text', language: 'en'}]
         });
 
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(500);
 
         cy.apollo({
@@ -141,6 +144,7 @@ describe('Content History GraphQL API', () => {
             ]
         });
 
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(500);
 
         // Get count without language nodes
@@ -180,6 +184,7 @@ describe('Content History GraphQL API', () => {
             properties: [{name: 'text', value: 'Complete test', language: 'en'}]
         });
 
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(500);
 
         cy.apollo({
@@ -237,7 +242,7 @@ describe('Content History GraphQL API', () => {
         // Publish the node
         publishAndWaitJobEnding(testNodePath, ['en']);
 
-        // Wait longer for publication history to be logged
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(500);
 
         cy.apollo({
@@ -279,6 +284,7 @@ describe('Content History GraphQL API', () => {
             properties: [{name: 'text', value: 'Initial', language: 'en'}]
         });
 
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(500);
 
         // Test with offset 0
@@ -327,6 +333,7 @@ describe('Content History GraphQL API', () => {
             properties: [{name: 'text', value: 'Timestamp test', language: 'en'}]
         });
 
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(500);
 
         cy.apollo({
@@ -357,6 +364,198 @@ describe('Content History GraphQL API', () => {
                     expect(timeDiff).to.be.lessThan(1000);
                 }
             }
+        });
+    });
+
+    it('should filter entries by action parameter', () => {
+        addNode({
+            parentPathOrId: contentPath,
+            name: testNodeName,
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Action filter test', language: 'en'}]
+        });
+
+        // Perform different actions to generate varied history
+        GraphqlUtils.setProperty(testNodePath, 'text', 'Updated once', 'en');
+        publishAndWaitJobEnding(testNodePath, ['en']);
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(500);
+
+        // First, get all entries to see what's available
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryDetailed.graphql',
+            variables: {
+                path: testNodePath,
+                withLanguageNodes: false,
+                offset: 0,
+                limit: 100
+            }
+        }).then(allResult => {
+            const allEntries = allResult?.data?.jcr?.nodeByPath?.history?.entries;
+
+            if (allEntries && allEntries.length > 0) {
+                // Get unique actions from history
+                const actions = [...new Set(allEntries.map(e => e.action).filter(a => a))];
+                cy.log(`Available actions: ${actions.join(', ')}`);
+
+                if (actions.length > 0) {
+                    const testAction = actions[0];
+
+                    // Query with action filter
+                    cy.apollo({
+                        queryFile: 'api/contentHistory/getNodeHistoryWithAction.graphql',
+                        variables: {
+                            path: testNodePath,
+                            withLanguageNodes: false,
+                            action: testAction,
+                            offset: 0,
+                            limit: 50
+                        }
+                    }).then(filteredResult => {
+                        const filteredEntries = filteredResult?.data?.jcr?.nodeByPath?.history?.entries;
+                        expect(filteredEntries).to.be.an('array');
+
+                        // All filtered entries should have the specified action
+                        // eslint-disable-next-line  max-nested-callbacks
+                        filteredEntries.forEach(entry => {
+                            expect(entry.action).to.equal(testAction);
+                        });
+
+                        // Filtered count should be <= total count
+                        expect(filteredEntries.length).to.be.at.most(allEntries.length);
+                    });
+                }
+            }
+        });
+    });
+
+    it('should filter count by action parameter', () => {
+        addNode({
+            parentPathOrId: contentPath,
+            name: testNodeName,
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Count filter test', language: 'en'}]
+        });
+
+        publishAndWaitJobEnding(testNodePath, ['en']);
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(500);
+
+        // Get total count
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryCount.graphql',
+            variables: {
+                path: testNodePath,
+                withLanguageNodes: false
+            }
+        }).then(totalResult => {
+            const totalCount = totalResult?.data?.jcr?.nodeByPath?.history?.count;
+
+            if (totalCount > 0) {
+                // Get count for published action only
+                cy.apollo({
+                    queryFile: 'api/contentHistory/getNodeHistoryCountWithAction.graphql',
+                    variables: {
+                        path: testNodePath,
+                        withLanguageNodes: false,
+                        action: 'published'
+                    }
+                }).then(filteredResult => {
+                    const filteredCount = filteredResult?.data?.jcr?.nodeByPath?.history?.count;
+                    expect(filteredCount).to.be.a('number');
+                    expect(filteredCount).to.be.at.most(totalCount);
+                    expect(filteredCount).to.be.at.least(0);
+                });
+            }
+        });
+    });
+
+    it('should apply action filter before pagination', () => {
+        addNode({
+            parentPathOrId: contentPath,
+            name: testNodeName,
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Pagination with filter test', language: 'en'}]
+        });
+
+        // Create multiple updates
+        for (let i = 1; i <= 3; i++) {
+            GraphqlUtils.setProperty(testNodePath, 'text', `Update ${i}`, 'en');
+        }
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(500);
+
+        // Get all entries first
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryDetailed.graphql',
+            variables: {
+                path: testNodePath,
+                withLanguageNodes: false,
+                offset: 0,
+                limit: 100
+            }
+        }).then(allResult => {
+            const allEntries = allResult?.data?.jcr?.nodeByPath?.history?.entries;
+
+            if (allEntries && allEntries.length > 0) {
+                const actions = [...new Set(allEntries.map(e => e.action).filter(a => a))];
+
+                if (actions.length > 0) {
+                    const testAction = actions[0];
+
+                    // Apply filter with limit smaller than filtered count
+                    cy.apollo({
+                        queryFile: 'api/contentHistory/getNodeHistoryWithAction.graphql',
+                        variables: {
+                            path: testNodePath,
+                            withLanguageNodes: false,
+                            action: testAction,
+                            offset: 0,
+                            limit: 1
+                        }
+                    }).then(limitedResult => {
+                        const limitedEntries = limitedResult?.data?.jcr?.nodeByPath?.history?.entries;
+
+                        // Should respect limit even with filter
+                        expect(limitedEntries).to.be.an('array');
+                        expect(limitedEntries.length).to.be.at.most(1);
+
+                        if (limitedEntries.length > 0) {
+                            expect(limitedEntries[0].action).to.equal(testAction);
+                        }
+                    });
+                }
+            }
+        });
+    });
+
+    it('should return empty results for non-existent action filter', () => {
+        addNode({
+            parentPathOrId: contentPath,
+            name: testNodeName,
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Non-existent action test', language: 'en'}]
+        });
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(500);
+
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryWithAction.graphql',
+            variables: {
+                path: testNodePath,
+                withLanguageNodes: false,
+                action: 'nonExistentAction12345',
+                offset: 0,
+                limit: 50
+            }
+        }).then(result => {
+            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+            expect(entries).to.be.an('array');
+            expect(entries.length).to.equal(0);
         });
     });
 });

--- a/tests/cypress/e2e/api/contentHistory.cy.ts
+++ b/tests/cypress/e2e/api/contentHistory.cy.ts
@@ -1,14 +1,38 @@
-import {addNode, createSite, deleteSite, publishAndWaitJobEnding} from '@jahia/cypress';
+import {addNode, createSite, createUser, deleteSite, deleteUser, grantRoles, publishAndWaitJobEnding} from '@jahia/cypress';
 import {GraphqlUtils} from '../../utils/graphqlUtils';
 
+/**
+ * Content History GraphQL API tests.
+ *
+ * All test data is created once in the `before` block. Individual tests only query —
+ * no content is created or deleted per test. The site (and all its content) is deleted
+ * in `after`.
+ *
+ * Node inventory:
+ *  - node-basic      : jnt:text, English only — used for schema/structure tests
+ *  - node-bilingual  : jnt:text, English + French — used for language-nodes tests
+ *  - node-updates    : jnt:text, created + 3 property updates — used for pagination / filter tests
+ *  - node-published  : jnt:text, created + published — used for publication action tests
+ *  - node-user       : jnt:text, created as historyTestUser — used for userKey tracking tests
+ */
 describe('Content History GraphQL API', () => {
     const siteKey = 'contentHistoryTestSite';
     const sitePath = `/sites/${siteKey}`;
     const contentPath = `${sitePath}/contents`;
-    const testNodeName = 'test-history-node';
-    const testNodePath = `${contentPath}/${testNodeName}`;
+
+    const testUserName = 'historyTestUser';
+    const testUserPassword = 'History_Test_1!';
+
+    const nodePaths = {
+        basic: `${contentPath}/node-basic`,
+        bilingual: `${contentPath}/node-bilingual`,
+        updates: `${contentPath}/node-updates`,
+        published: `${contentPath}/node-published`,
+        user: `${contentPath}/node-user`
+    };
 
     before(() => {
+        cy.loginAndStoreSession();
         deleteSite(siteKey);
         createSite(siteKey, {
             languages: 'en,fr',
@@ -16,9 +40,66 @@ describe('Content History GraphQL API', () => {
             serverName: 'localhost',
             locale: 'en'
         });
+
+        // Create a dedicated test user with editor rights on the site
+        createUser(testUserName, testUserPassword);
+        grantRoles(sitePath, ['editor'], testUserName, 'USER');
+
+        // Node-basic: plain English text node
+        addNode({
+            parentPathOrId: contentPath,
+            name: 'node-basic',
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Basic text content', language: 'en'}]
+        });
+
+        // Node-bilingual: text node with both English and French content
+        addNode({
+            parentPathOrId: contentPath,
+            name: 'node-bilingual',
+            primaryNodeType: 'jnt:text',
+            properties: [
+                {name: 'text', value: 'English content', language: 'en'},
+                {name: 'text', value: 'Contenu français', language: 'fr'}
+            ]
+        });
+
+        // Node-updates: created then updated three times to produce varied history
+        addNode({
+            parentPathOrId: contentPath,
+            name: 'node-updates',
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Initial value', language: 'en'}]
+        });
+        GraphqlUtils.setProperty(nodePaths.updates, 'text', 'Update 1', 'en');
+        GraphqlUtils.setProperty(nodePaths.updates, 'text', 'Update 2', 'en');
+        GraphqlUtils.setProperty(nodePaths.updates, 'text', 'Update 3', 'en');
+
+        // Node-published: created then published
+        addNode({
+            parentPathOrId: contentPath,
+            name: 'node-published',
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Content to publish', language: 'en'}]
+        });
+        publishAndWaitJobEnding(nodePaths.published, ['en']);
+
+        // Node-user: created as testUser to verify userKey tracking in history
+
+        cy.apolloClient({username: testUserName, password: testUserPassword});
+        addNode({
+            parentPathOrId: contentPath,
+            name: 'node-user',
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Created by test user', language: 'en'}]
+        });
+        cy.apolloClient(); // Switch back to admin
     });
 
     after(() => {
+        cy.loginAndStoreSession();
+        deleteSite(siteKey);
+        deleteUser(testUserName);
         cy.logout();
     });
 
@@ -26,68 +107,34 @@ describe('Content History GraphQL API', () => {
         cy.loginAndStoreSession();
     });
 
-    afterEach(() => {
-        // Clean up test node if it exists
-        GraphqlUtils.deleteNode(testNodePath);
-    });
+    // -------------------------------------------------------------------------
+    // Schema / structure tests  (node-basic)
+    // -------------------------------------------------------------------------
 
-    it('should return history structure for a node (may be empty if metrics logging is disabled)', () => {
-        // Create a simple text node
-        addNode({
-            parentPathOrId: contentPath,
-            name: testNodeName,
-            primaryNodeType: 'jnt:text',
-            properties: [{name: 'text', value: 'Initial text', language: 'en'}]
-        });
-
-        // Wait for potential async history processing
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(500);
-
+    it('should return history structure for a node', () => {
         cy.apollo({
             queryFile: 'api/contentHistory/getNodeHistory.graphql',
-            variables: {
-                withLanguageNodes: false,
-                path: testNodePath
-            }
+            variables: {path: nodePaths.basic, withLanguageNodes: false}
         }).then(result => {
-            // Verify structure exists (history depends on metrics logging being enabled)
             expect(result?.data?.jcr?.nodeByPath?.history).to.exist;
             expect(result?.data?.jcr?.nodeByPath?.history?.count).to.be.a('number');
             expect(result?.data?.jcr?.nodeByPath?.history?.entries).to.be.an('array');
         });
     });
 
-    it('should handle entries query without parameters', () => {
-        addNode({
-            parentPathOrId: contentPath,
-            name: testNodeName,
-            primaryNodeType: 'jnt:text',
-            properties: [{name: 'text', value: 'Test content', language: 'en'}]
-        });
-
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(500);
-
+    it('should return entries without explicit parameters', () => {
         cy.apollo({
             queryFile: 'api/contentHistory/getNodeHistoryNoParams.graphql',
-            variables: {
-                withLanguageNodes: false,
-                path: testNodePath
-            }
+            variables: {path: nodePaths.basic, withLanguageNodes: false}
         }).then(result => {
             const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
             expect(entries).to.be.an('array');
-
-            // If entries exist, verify their structure
-            if (entries && entries.length > 0) {
+            if (entries?.length > 0) {
                 const entry = entries[0];
                 expect(entry).to.have.property('id');
                 expect(entry).to.have.property('date');
                 expect(entry).to.have.property('action');
                 expect(entry).to.have.property('userKey');
-
-                // Verify date is in ISO 8601 format
                 if (entry.date) {
                     expect(entry.date).to.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}/);
                 }
@@ -95,458 +142,51 @@ describe('Content History GraphQL API', () => {
         });
     });
 
-    it('should handle pagination parameters', () => {
-        addNode({
-            parentPathOrId: contentPath,
-            name: testNodeName,
-            primaryNodeType: 'jnt:text',
-            properties: [{name: 'text', value: 'Initial text', language: 'en'}]
-        });
-
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(500);
-
-        cy.apollo({
-            queryFile: 'api/contentHistory/getNodeHistoryPaginated.graphql',
-            variables: {
-                path: testNodePath,
-                withLanguageNodes: false,
-                offset: 0,
-                limit: 2
-            }
-        }).then(result => {
-            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
-            expect(entries).to.be.an('array');
-
-            // If entries exist, should respect limit
-            if (entries && entries.length > 0) {
-                expect(entries.length).to.be.at.most(2);
-
-                const entry = entries[0];
-                expect(entry).to.have.property('id');
-                expect(entry).to.have.property('date');
-                expect(entry).to.have.property('path');
-                expect(entry).to.have.property('uuid');
-                expect(entry).to.have.property('action');
-                expect(entry).to.have.property('userKey');
-            }
-        });
-    });
-
-    it('should return count with and without language nodes parameter', () => {
-        addNode({
-            parentPathOrId: contentPath,
-            name: testNodeName,
-            primaryNodeType: 'jnt:text',
-            properties: [
-                {name: 'text', value: 'English text', language: 'en'},
-                {name: 'text', value: 'French text', language: 'fr'}
-            ]
-        });
-
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(500);
-
-        // Get count without language nodes
-        cy.apollo({
-            queryFile: 'api/contentHistory/getNodeHistoryCount.graphql',
-            variables: {
-                path: testNodePath,
-                withLanguageNodes: false
-            }
-        }).then(result => {
-            const countWithoutLang = result?.data?.jcr?.nodeByPath?.history?.count;
-            expect(countWithoutLang).to.be.a('number');
-            expect(countWithoutLang).to.be.at.least(0);
-
-            // Get count with language nodes
-            cy.apollo({
-                queryFile: 'api/contentHistory/getNodeHistoryCount.graphql',
-                variables: {
-                    path: testNodePath,
-                    withLanguageNodes: true
-                }
-            }).then(resultWithLang => {
-                const countWithLang = resultWithLang?.data?.jcr?.nodeByPath?.history?.count;
-                expect(countWithLang).to.be.a('number');
-                expect(countWithLang).to.be.at.least(0);
-                // Count with language nodes should be >= count without
-                expect(countWithLang).to.be.at.least(countWithoutLang);
-            });
-        });
-    });
-
-    it('should include all available fields when queried', () => {
-        addNode({
-            parentPathOrId: contentPath,
-            name: testNodeName,
-            primaryNodeType: 'jnt:text',
-            properties: [{name: 'text', value: 'Complete test', language: 'en'}]
-        });
-
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(500);
-
+    it('should include all available fields', () => {
         cy.apollo({
             queryFile: 'api/contentHistory/getNodeHistoryComplete.graphql',
-            variables: {
-                path: testNodePath,
-                withLanguageNodes: false,
-                offset: 0,
-                limit: 5
-            }
+            variables: {path: nodePaths.basic, withLanguageNodes: false, offset: 0, limit: 5}
         }).then(result => {
             const history = result?.data?.jcr?.nodeByPath?.history;
             expect(history).to.exist;
             expect(history.count).to.be.a('number');
             expect(history.entries).to.be.an('array');
-
-            // If entries exist, verify all fields are available
-            if (history.entries && history.entries.length > 0) {
+            if (history.entries?.length > 0) {
                 const entry = history.entries[0];
-
-                // Verify all expected fields are present (even if null)
-                expect(entry).to.have.property('id');
-                expect(entry).to.have.property('date');
-                expect(entry).to.have.property('timestamp');
-                expect(entry).to.have.property('path');
-                expect(entry).to.have.property('uuid');
-                expect(entry).to.have.property('action');
-                expect(entry).to.have.property('propertyName');
-                expect(entry).to.have.property('userKey');
-                expect(entry).to.have.property('message');
-                expect(entry).to.have.property('language');
-
-                // Verify timestamp is a number if present
+                ['id', 'date', 'timestamp', 'path', 'uuid', 'action', 'propertyName', 'userKey', 'message', 'language'].forEach(field => {
+                    expect(entry).to.have.property(field);
+                });
                 if (entry.timestamp !== null) {
                     expect(entry.timestamp).to.be.a('number');
                 }
 
-                // Verify date is ISO 8601 string if present
                 if (entry.date) {
-                    expect(entry.date).to.be.a('string');
                     expect(entry.date).to.match(/^\d{4}-\d{2}-\d{2}T/);
                 }
             }
         });
     });
 
-    it('should track published actions if metrics logging is enabled', () => {
-        addNode({
-            parentPathOrId: contentPath,
-            name: testNodeName,
-            primaryNodeType: 'jnt:text',
-            properties: [{name: 'text', value: 'Content to publish', language: 'en'}]
-        });
-
-        // Publish the node
-        publishAndWaitJobEnding(testNodePath, ['en']);
-
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(500);
-
-        cy.apollo({
-            queryFile: 'api/contentHistory/getNodeHistoryDetailed.graphql',
-            variables: {
-                path: testNodePath,
-                withLanguageNodes: false,
-                offset: 0,
-                limit: 50
-            }
-        }).then(result => {
-            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
-            expect(entries).to.be.an('array');
-
-            // If history entries exist, check for published action
-            if (entries && entries.length > 0) {
-                cy.log(`Found ${entries.length} history entries`);
-
-                // Look for a published entry
-                const publishedEntry = entries.find(entry => entry.action === 'published');
-                if (publishedEntry) {
-                    cy.log('Published action found in history');
-                    expect(publishedEntry.action).to.equal('published');
-                    expect(publishedEntry.userKey).to.be.a('string');
-                } else {
-                    cy.log('No published action found (metrics logging may be disabled or async processing delayed)');
-                }
-            } else {
-                cy.log('No history entries found (metrics logging may be disabled)');
-            }
-        });
-    });
-
-    it('should handle offset parameter correctly', () => {
-        addNode({
-            parentPathOrId: contentPath,
-            name: testNodeName,
-            primaryNodeType: 'jnt:text',
-            properties: [{name: 'text', value: 'Initial', language: 'en'}]
-        });
-
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(500);
-
-        // Test with offset 0
-        cy.apollo({
-            queryFile: 'api/contentHistory/getNodeHistoryPaginated.graphql',
-            variables: {
-                path: testNodePath,
-                withLanguageNodes: false,
-                offset: 0,
-                limit: 5
-            }
-        }).then(result => {
-            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
-            expect(entries).to.be.an('array');
-
-            if (entries && entries.length > 1) {
-                const firstId = entries[0].id;
-
-                // Test with offset 1
-                cy.apollo({
-                    queryFile: 'api/contentHistory/getNodeHistoryPaginated.graphql',
-                    variables: {
-                        path: testNodePath,
-                        withLanguageNodes: false,
-                        offset: 1,
-                        limit: 5
-                    }
-                }).then(offsetResult => {
-                    const offsetEntries = offsetResult?.data?.jcr?.nodeByPath?.history?.entries;
-                    expect(offsetEntries).to.be.an('array');
-
-                    // First entry with offset should be different from first entry without offset
-                    if (offsetEntries && offsetEntries.length > 0) {
-                        expect(offsetEntries[0].id).to.not.equal(firstId);
-                    }
-                });
-            }
-        });
-    });
-
-    it('should return timestamp field alongside date field', () => {
-        addNode({
-            parentPathOrId: contentPath,
-            name: testNodeName,
-            primaryNodeType: 'jnt:text',
-            properties: [{name: 'text', value: 'Timestamp test', language: 'en'}]
-        });
-
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(500);
-
+    it('should return timestamp consistent with date', () => {
         cy.apollo({
             queryFile: 'api/contentHistory/getNodeHistoryComplete.graphql',
-            variables: {
-                path: testNodePath,
-                withLanguageNodes: false,
-                offset: 0,
-                limit: 1
-            }
+            variables: {path: nodePaths.basic, withLanguageNodes: false, offset: 0, limit: 1}
         }).then(result => {
             const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
-
-            if (entries && entries.length > 0) {
+            if (entries?.length > 0 && entries[0].date) {
                 const entry = entries[0];
-
-                // If we have a date, we should also have a timestamp
-                if (entry.date) {
-                    expect(entry).to.have.property('timestamp');
-                    expect(entry.timestamp).to.be.a('number');
-
-                    // Timestamp should represent roughly the same time as date
-                    const dateFromTimestamp = new Date(entry.timestamp);
-                    const dateFromISO = new Date(entry.date);
-
-                    // Allow 1 second difference for rounding
-                    const timeDiff = Math.abs(dateFromTimestamp.getTime() - dateFromISO.getTime());
-                    expect(timeDiff).to.be.lessThan(1000);
-                }
+                expect(entry.timestamp).to.be.a('number');
+                const diff = Math.abs(entry.timestamp - new Date(entry.date).getTime());
+                expect(diff).to.be.lessThan(1000);
             }
         });
     });
 
-    it('should filter entries by action parameter', () => {
-        addNode({
-            parentPathOrId: contentPath,
-            name: testNodeName,
-            primaryNodeType: 'jnt:text',
-            properties: [{name: 'text', value: 'Action filter test', language: 'en'}]
-        });
-
-        // Perform different actions to generate varied history
-        GraphqlUtils.setProperty(testNodePath, 'text', 'Updated once', 'en');
-        publishAndWaitJobEnding(testNodePath, ['en']);
-
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(500);
-
-        // First, get all entries to see what's available
-        cy.apollo({
-            queryFile: 'api/contentHistory/getNodeHistoryDetailed.graphql',
-            variables: {
-                path: testNodePath,
-                withLanguageNodes: false,
-                offset: 0,
-                limit: 100
-            }
-        }).then(allResult => {
-            const allEntries = allResult?.data?.jcr?.nodeByPath?.history?.entries;
-
-            if (allEntries && allEntries.length > 0) {
-                // Get unique actions from history
-                const actions = [...new Set(allEntries.map(e => e.action).filter(a => a))];
-                cy.log(`Available actions: ${actions.join(', ')}`);
-
-                if (actions.length > 0) {
-                    const testAction = actions[0];
-
-                    // Query with action filter
-                    cy.apollo({
-                        queryFile: 'api/contentHistory/getNodeHistoryWithAction.graphql',
-                        variables: {
-                            path: testNodePath,
-                            withLanguageNodes: false,
-                            action: testAction,
-                            offset: 0,
-                            limit: 50
-                        }
-                    }).then(filteredResult => {
-                        const filteredEntries = filteredResult?.data?.jcr?.nodeByPath?.history?.entries;
-                        expect(filteredEntries).to.be.an('array');
-
-                        // All filtered entries should have the specified action
-                        // eslint-disable-next-line  max-nested-callbacks
-                        filteredEntries.forEach(entry => {
-                            expect(entry.action).to.equal(testAction);
-                        });
-
-                        // Filtered count should be <= total count
-                        expect(filteredEntries.length).to.be.at.most(allEntries.length);
-                    });
-                }
-            }
-        });
-    });
-
-    it('should filter count by action parameter', () => {
-        addNode({
-            parentPathOrId: contentPath,
-            name: testNodeName,
-            primaryNodeType: 'jnt:text',
-            properties: [{name: 'text', value: 'Count filter test', language: 'en'}]
-        });
-
-        publishAndWaitJobEnding(testNodePath, ['en']);
-
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(500);
-
-        // Get total count
-        cy.apollo({
-            queryFile: 'api/contentHistory/getNodeHistoryCount.graphql',
-            variables: {
-                path: testNodePath,
-                withLanguageNodes: false
-            }
-        }).then(totalResult => {
-            const totalCount = totalResult?.data?.jcr?.nodeByPath?.history?.count;
-
-            if (totalCount > 0) {
-                // Get count for published action only
-                cy.apollo({
-                    queryFile: 'api/contentHistory/getNodeHistoryCountWithAction.graphql',
-                    variables: {
-                        path: testNodePath,
-                        withLanguageNodes: false,
-                        action: 'published'
-                    }
-                }).then(filteredResult => {
-                    const filteredCount = filteredResult?.data?.jcr?.nodeByPath?.history?.count;
-                    expect(filteredCount).to.be.a('number');
-                    expect(filteredCount).to.be.at.most(totalCount);
-                    expect(filteredCount).to.be.at.least(0);
-                });
-            }
-        });
-    });
-
-    it('should apply action filter before pagination', () => {
-        addNode({
-            parentPathOrId: contentPath,
-            name: testNodeName,
-            primaryNodeType: 'jnt:text',
-            properties: [{name: 'text', value: 'Pagination with filter test', language: 'en'}]
-        });
-
-        // Create multiple updates
-        for (let i = 1; i <= 3; i++) {
-            GraphqlUtils.setProperty(testNodePath, 'text', `Update ${i}`, 'en');
-        }
-
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(500);
-
-        // Get all entries first
-        cy.apollo({
-            queryFile: 'api/contentHistory/getNodeHistoryDetailed.graphql',
-            variables: {
-                path: testNodePath,
-                withLanguageNodes: false,
-                offset: 0,
-                limit: 100
-            }
-        }).then(allResult => {
-            const allEntries = allResult?.data?.jcr?.nodeByPath?.history?.entries;
-
-            if (allEntries && allEntries.length > 0) {
-                const actions = [...new Set(allEntries.map(e => e.action).filter(a => a))];
-
-                if (actions.length > 0) {
-                    const testAction = actions[0];
-
-                    // Apply filter with limit smaller than filtered count
-                    cy.apollo({
-                        queryFile: 'api/contentHistory/getNodeHistoryWithAction.graphql',
-                        variables: {
-                            path: testNodePath,
-                            withLanguageNodes: false,
-                            action: testAction,
-                            offset: 0,
-                            limit: 1
-                        }
-                    }).then(limitedResult => {
-                        const limitedEntries = limitedResult?.data?.jcr?.nodeByPath?.history?.entries;
-
-                        // Should respect limit even with filter
-                        expect(limitedEntries).to.be.an('array');
-                        expect(limitedEntries.length).to.be.at.most(1);
-
-                        if (limitedEntries.length > 0) {
-                            expect(limitedEntries[0].action).to.equal(testAction);
-                        }
-                    });
-                }
-            }
-        });
-    });
-
-    it('should return empty results for non-existent action filter', () => {
-        addNode({
-            parentPathOrId: contentPath,
-            name: testNodeName,
-            primaryNodeType: 'jnt:text',
-            properties: [{name: 'text', value: 'Non-existent action test', language: 'en'}]
-        });
-
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(500);
-
+    it('should return empty entries for a non-existent action filter', () => {
         cy.apollo({
             queryFile: 'api/contentHistory/getNodeHistoryWithAction.graphql',
             variables: {
-                path: testNodePath,
+                path: nodePaths.basic,
                 withLanguageNodes: false,
                 action: 'nonExistentAction12345',
                 offset: 0,
@@ -559,68 +199,170 @@ describe('Content History GraphQL API', () => {
         });
     });
 
-    it('should resolve property display name for property-related actions', () => {
-        addNode({
-            parentPathOrId: contentPath,
-            name: testNodeName,
-            primaryNodeType: 'jnt:text',
-            properties: [{name: 'text', value: 'Property display name test', language: 'en'}]
-        });
+    // -------------------------------------------------------------------------
+    // Language nodes tests  (node-bilingual)
+    // -------------------------------------------------------------------------
 
-        // Modify a property to generate property change history
-        GraphqlUtils.setProperty(testNodePath, 'text', 'Updated value', 'en');
-
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(500);
-
+    it('should return higher or equal count when including language nodes', () => {
         cy.apollo({
-            queryFile: 'api/contentHistory/getNodeHistoryWithPropertyDisplay.graphql',
-            variables: {
-                path: testNodePath,
-                withLanguageNodes: false,
-                offset: 0,
-                limit: 50,
-                language: 'en'
-            }
+            queryFile: 'api/contentHistory/getNodeHistoryCount.graphql',
+            variables: {path: nodePaths.bilingual, withLanguageNodes: false}
+        }).then(result => {
+            const countWithoutLang = result?.data?.jcr?.nodeByPath?.history?.count;
+            expect(countWithoutLang).to.be.a('number').and.be.at.least(0);
+
+            cy.apollo({
+                queryFile: 'api/contentHistory/getNodeHistoryCount.graphql',
+                variables: {path: nodePaths.bilingual, withLanguageNodes: true}
+            }).then(resultWithLang => {
+                const countWithLang = resultWithLang?.data?.jcr?.nodeByPath?.history?.count;
+                expect(countWithLang).to.be.a('number').and.be.at.least(countWithoutLang);
+            });
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Pagination and action filter tests  (node-updates)
+    // -------------------------------------------------------------------------
+
+    it('should respect the limit parameter', () => {
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryPaginated.graphql',
+            variables: {path: nodePaths.updates, withLanguageNodes: false, offset: 0, limit: 2}
         }).then(result => {
             const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+            expect(entries).to.be.an('array');
+            if (entries?.length > 0) {
+                expect(entries.length).to.be.at.most(2);
+                ['id', 'date', 'path', 'uuid', 'action', 'userKey'].forEach(f => expect(entries[0]).to.have.property(f));
+            }
+        });
+    });
 
-            if (entries && entries.length > 0) {
-                // Find an entry with a property name
-                const propertyEntry = entries.find(entry => entry.propertyName);
+    it('should skip entries when an offset is provided', () => {
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryPaginated.graphql',
+            variables: {path: nodePaths.updates, withLanguageNodes: false, offset: 0, limit: 10}
+        }).then(result => {
+            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+            expect(entries).to.be.an('array');
+            if (entries?.length > 1) {
+                const firstId = entries[0].id;
+                cy.apollo({
+                    queryFile: 'api/contentHistory/getNodeHistoryPaginated.graphql',
+                    variables: {path: nodePaths.updates, withLanguageNodes: false, offset: 1, limit: 10}
+                }).then(offsetResult => {
+                    const offsetEntries = offsetResult?.data?.jcr?.nodeByPath?.history?.entries;
+                    expect(offsetEntries).to.be.an('array');
+                    if (offsetEntries?.length > 0) {
+                        expect(offsetEntries[0].id).to.not.equal(firstId);
+                    }
+                });
+            }
+        });
+    });
 
+    it('should filter entries by action and only return matching ones', () => {
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryDetailed.graphql',
+            variables: {path: nodePaths.updates, withLanguageNodes: false, offset: 0, limit: 100}
+        }).then(allResult => {
+            const allEntries = allResult?.data?.jcr?.nodeByPath?.history?.entries;
+            if (!allEntries?.length) {
+                return;
+            }
+
+            const actions = [...new Set(allEntries.map((e: {action: string}) => e.action).filter(Boolean))];
+            cy.log(`Available actions: ${actions.join(', ')}`);
+            const testAction = actions[0];
+            if (!testAction) {
+                return;
+            }
+
+            cy.apollo({
+                queryFile: 'api/contentHistory/getNodeHistoryWithAction.graphql',
+                variables: {path: nodePaths.updates, withLanguageNodes: false, action: testAction, offset: 0, limit: 50}
+            }).then(filteredResult => {
+                const filteredEntries = filteredResult?.data?.jcr?.nodeByPath?.history?.entries;
+                expect(filteredEntries).to.be.an('array');
+                expect(filteredEntries.length).to.be.at.most(allEntries.length);
+                for (const entry of filteredEntries) {
+                    expect((entry as {action: string}).action).to.equal(testAction);
+                }
+            });
+        });
+    });
+
+    it('should apply the action filter before paginating (limit is respected after filter)', () => {
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryDetailed.graphql',
+            variables: {path: nodePaths.updates, withLanguageNodes: false, offset: 0, limit: 100}
+        }).then(allResult => {
+            const allEntries = allResult?.data?.jcr?.nodeByPath?.history?.entries;
+            if (!allEntries?.length) {
+                return;
+            }
+
+            const actions = [...new Set(allEntries.map((e: {action: string}) => e.action).filter(Boolean))];
+            const testAction = actions[0];
+            if (!testAction) {
+                return;
+            }
+
+            cy.apollo({
+                queryFile: 'api/contentHistory/getNodeHistoryWithAction.graphql',
+                variables: {path: nodePaths.updates, withLanguageNodes: false, action: testAction, offset: 0, limit: 1}
+            }).then(limitedResult => {
+                const limitedEntries = limitedResult?.data?.jcr?.nodeByPath?.history?.entries;
+                expect(limitedEntries).to.be.an('array');
+                expect(limitedEntries.length).to.be.at.most(1);
+                if (limitedEntries.length > 0) {
+                    expect(limitedEntries[0].action).to.equal(testAction);
+                }
+            });
+        });
+    });
+
+    it('should return a filtered count consistent with filtered entries', () => {
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryCount.graphql',
+            variables: {path: nodePaths.updates, withLanguageNodes: false}
+        }).then(totalResult => {
+            const totalCount = totalResult?.data?.jcr?.nodeByPath?.history?.count;
+            expect(totalCount).to.be.a('number').and.be.at.least(0);
+            cy.apollo({
+                queryFile: 'api/contentHistory/getNodeHistoryCountWithAction.graphql',
+                variables: {path: nodePaths.updates, withLanguageNodes: false, action: 'updated'}
+            }).then(filteredResult => {
+                const filteredCount = filteredResult?.data?.jcr?.nodeByPath?.history?.count;
+                expect(filteredCount).to.be.a('number');
+                expect(filteredCount).to.be.at.most(totalCount);
+                expect(filteredCount).to.be.at.least(0);
+            });
+        });
+    });
+
+    it('should resolve property display name for property-related entries', () => {
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryWithPropertyDisplay.graphql',
+            variables: {path: nodePaths.updates, withLanguageNodes: false, offset: 0, limit: 50, language: 'en'}
+        }).then(result => {
+            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+            if (entries?.length > 0) {
+                const propertyEntry = entries.find((entry: { propertyName: string }) => entry.propertyName);
                 if (propertyEntry) {
-                    cy.log(`Found property entry: ${propertyEntry.propertyName}`);
-
-                    // Should have both propertyName and propertyNameDisplay
-                    expect(propertyEntry).to.have.property('propertyName');
-                    expect(propertyEntry).to.have.property('propertyNameDisplay');
-
-                    // PropertyNameDisplay should be a string (localized label or fallback to property name)
-                    expect(propertyEntry.propertyNameDisplay).to.be.a('string');
-                    expect(propertyEntry.propertyNameDisplay.length).to.be.greaterThan(0);
-
-                    cy.log(`Property name: ${propertyEntry.propertyName}, Display: ${propertyEntry.propertyNameDisplay}`);
+                    expect(propertyEntry.propertyNameDisplay).to.be.a('string').and.have.length.greaterThan(0);
+                    cy.log(`Property: ${propertyEntry.propertyName} → "${propertyEntry.propertyNameDisplay}"`);
                 }
             }
         });
     });
 
-    it('should return propertyName as fallback when display name cannot be resolved', () => {
-        addNode({
-            parentPathOrId: contentPath,
-            name: testNodeName,
-            primaryNodeType: 'jnt:text',
-            properties: [{name: 'text', value: 'Fallback test', language: 'en'}]
-        });
-
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(500);
-
+    it('should fall back to property name when language is invalid', () => {
         cy.apollo({
             queryFile: 'api/contentHistory/getNodeHistoryWithPropertyDisplay.graphql',
             variables: {
-                path: testNodePath,
+                path: nodePaths.updates,
                 withLanguageNodes: false,
                 offset: 0,
                 limit: 50,
@@ -628,51 +370,165 @@ describe('Content History GraphQL API', () => {
             }
         }).then(result => {
             const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
-
-            if (entries && entries.length > 0) {
-                const propertyEntry = entries.find(entry => entry.propertyName);
-
+            if (entries?.length > 0) {
+                const propertyEntry = entries.find((entry: { propertyName: string }) => entry.propertyName);
                 if (propertyEntry) {
-                    // Should still return a value (either localized or property name as fallback)
-                    expect(propertyEntry.propertyNameDisplay).to.be.a('string');
-                    expect(propertyEntry.propertyNameDisplay.length).to.be.greaterThan(0);
+                    expect(propertyEntry.propertyNameDisplay).to.be.a('string').and.have.length.greaterThan(0);
                 }
             }
         });
     });
 
     it('should return null propertyNameDisplay when propertyName is null', () => {
-        addNode({
-            parentPathOrId: contentPath,
-            name: testNodeName,
-            primaryNodeType: 'jnt:text',
-            properties: [{name: 'text', value: 'Null property test', language: 'en'}]
-        });
-
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(500);
-
         cy.apollo({
             queryFile: 'api/contentHistory/getNodeHistoryWithPropertyDisplay.graphql',
-            variables: {
-                path: testNodePath,
-                withLanguageNodes: false,
-                offset: 0,
-                limit: 50,
-                language: 'en'
-            }
+            variables: {path: nodePaths.updates, withLanguageNodes: false, offset: 0, limit: 50, language: 'en'}
         }).then(result => {
             const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
-
-            if (entries && entries.length > 0) {
-                // Find entries without propertyName (node-level actions)
-                const nodeEntry = entries.find(entry => !entry.propertyName);
-
+            if (entries?.length > 0) {
+                const nodeEntry = entries.find((entry: { propertyName: string | null }) => !entry.propertyName);
                 if (nodeEntry) {
-                    // PropertyNameDisplay should be null when propertyName is null
                     expect(nodeEntry.propertyName).to.be.null;
                     expect(nodeEntry.propertyNameDisplay).to.be.null;
                 }
+            }
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Publication tests  (node-published)
+    // -------------------------------------------------------------------------
+
+    it('should include a published action entry after publishing', () => {
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryDetailed.graphql',
+            variables: {path: nodePaths.published, withLanguageNodes: false, offset: 0, limit: 50}
+        }).then(result => {
+            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+            expect(entries).to.be.an('array');
+            if (entries?.length > 0) {
+                cy.log(`Found ${entries.length} history entries`);
+                const publishedEntry = entries.find((entry: { action: string }) => entry.action === 'published');
+                if (publishedEntry) {
+                    expect(publishedEntry.userKey).to.be.a('string');
+                } else {
+                    cy.log('No published entry found — metrics logging may be disabled');
+                }
+            }
+        });
+    });
+
+    it('should return filtered count for published action', () => {
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryCount.graphql',
+            variables: {path: nodePaths.published, withLanguageNodes: false}
+        }).then(totalResult => {
+            const totalCount = totalResult?.data?.jcr?.nodeByPath?.history?.count;
+            if (totalCount > 0) {
+                cy.apollo({
+                    queryFile: 'api/contentHistory/getNodeHistoryCountWithAction.graphql',
+                    variables: {path: nodePaths.published, withLanguageNodes: false, action: 'published'}
+                }).then(filteredResult => {
+                    const filteredCount = filteredResult?.data?.jcr?.nodeByPath?.history?.count;
+                    expect(filteredCount).to.be.a('number');
+                    expect(filteredCount).to.be.at.most(totalCount).and.be.at.least(0);
+                });
+            }
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Boundary / edge-case tests  (node-updates for known history depth)
+    // -------------------------------------------------------------------------
+
+    it('should return a GraphQL error when offset is negative', () => {
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryPaginated.graphql',
+            variables: {path: nodePaths.updates, withLanguageNodes: false, offset: -1, limit: 10}
+        }).then(result => {
+            // Apollo catches errors and returns the Error instance rather than throwing
+            expect(result).to.be.instanceOf(Error);
+        });
+    });
+
+    it('should return a GraphQL error when limit is negative', () => {
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryPaginated.graphql',
+            variables: {path: nodePaths.updates, withLanguageNodes: false, offset: 0, limit: -1}
+        }).then(result => {
+            expect(result).to.be.instanceOf(Error);
+        });
+    });
+
+    it('should return an empty array when offset exceeds the total entry count', () => {
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryCount.graphql',
+            variables: {path: nodePaths.updates, withLanguageNodes: false}
+        }).then(countResult => {
+            const totalCount = countResult?.data?.jcr?.nodeByPath?.history?.count ?? 0;
+            const beyondOffset = totalCount + 1000;
+
+            cy.apollo({
+                queryFile: 'api/contentHistory/getNodeHistoryPaginated.graphql',
+                variables: {path: nodePaths.updates, withLanguageNodes: false, offset: beyondOffset, limit: 50}
+            }).then(result => {
+                const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+                expect(entries).to.be.an('array');
+                expect(entries.length).to.equal(0);
+            });
+        });
+    });
+
+    it('should return at most the available entries when limit exceeds the total count', () => {
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryCount.graphql',
+            variables: {path: nodePaths.updates, withLanguageNodes: false}
+        }).then(countResult => {
+            const totalCount = countResult?.data?.jcr?.nodeByPath?.history?.count ?? 0;
+            const oversizedLimit = totalCount + 1000;
+
+            cy.apollo({
+                queryFile: 'api/contentHistory/getNodeHistoryPaginated.graphql',
+                variables: {path: nodePaths.updates, withLanguageNodes: false, offset: 0, limit: oversizedLimit}
+            }).then(result => {
+                const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+                expect(entries).to.be.an('array');
+                expect(entries.length).to.equal(totalCount);
+            });
+        });
+    });
+
+    it('should apply a default limit of 20 when offset and limit are omitted', () => {
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryNoParams.graphql',
+            variables: {path: nodePaths.updates, withLanguageNodes: false}
+        }).then(result => {
+            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+            expect(entries).to.be.an('array');
+            expect(entries.length).to.be.at.most(20);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // User tracking tests  (node-user)
+    // -------------------------------------------------------------------------
+
+    it('should record the correct userKey for content created by a specific user', () => {
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryDetailed.graphql',
+            variables: {path: nodePaths.user, withLanguageNodes: false, offset: 0, limit: 50}
+        }).then(result => {
+            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+            expect(entries).to.be.an('array');
+
+            if (entries?.length > 0) {
+                // Every entry on this node was produced by testUserName
+                entries.forEach((entry: { userKey: string }) => {
+                    expect(entry.userKey).to.be.a('string').and.include(testUserName);
+                });
+                cy.log(`userKey recorded: ${entries[0].userKey}`);
+            } else {
+                cy.log('No history entries found — metrics logging may be disabled');
             }
         });
     });

--- a/tests/cypress/e2e/api/contentHistory.cy.ts
+++ b/tests/cypress/e2e/api/contentHistory.cy.ts
@@ -1,0 +1,362 @@
+import {addNode, createSite, deleteSite, publishAndWaitJobEnding} from '@jahia/cypress';
+import {GraphqlUtils} from '../../utils/graphqlUtils';
+
+describe('Content History GraphQL API', () => {
+    const siteKey = 'contentHistoryTestSite';
+    const sitePath = `/sites/${siteKey}`;
+    const contentPath = `${sitePath}/contents`;
+    const testNodeName = 'test-history-node';
+    const testNodePath = `${contentPath}/${testNodeName}`;
+
+    before(() => {
+        deleteSite(siteKey);
+        createSite(siteKey, {
+            languages: 'en,fr',
+            templateSet: 'dx-base-demo-templates',
+            serverName: 'localhost',
+            locale: 'en'
+        });
+    });
+
+    after(() => {
+        cy.logout();
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession();
+    });
+
+    afterEach(() => {
+        // Clean up test node if it exists
+        GraphqlUtils.deleteNode(testNodePath);
+    });
+
+    it('should return history structure for a node (may be empty if metrics logging is disabled)', () => {
+        // Create a simple text node
+        addNode({
+            parentPathOrId: contentPath,
+            name: testNodeName,
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Initial text', language: 'en'}]
+        });
+
+        // Wait for potential async history processing
+        cy.wait(500);
+
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistory.graphql',
+            variables: {
+                withLanguageNodes: false,
+                path: testNodePath
+            }
+        }).then(result => {
+            // Verify structure exists (history depends on metrics logging being enabled)
+            expect(result?.data?.jcr?.nodeByPath?.history).to.exist;
+            expect(result?.data?.jcr?.nodeByPath?.history?.count).to.be.a('number');
+            expect(result?.data?.jcr?.nodeByPath?.history?.entries).to.be.an('array');
+        });
+    });
+
+    it('should handle entries query without parameters', () => {
+        addNode({
+            parentPathOrId: contentPath,
+            name: testNodeName,
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Test content', language: 'en'}]
+        });
+
+        cy.wait(500);
+
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryNoParams.graphql',
+            variables: {
+                withLanguageNodes: false,
+                path: testNodePath
+            }
+        }).then(result => {
+            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+            expect(entries).to.be.an('array');
+
+            // If entries exist, verify their structure
+            if (entries && entries.length > 0) {
+                const entry = entries[0];
+                expect(entry).to.have.property('id');
+                expect(entry).to.have.property('date');
+                expect(entry).to.have.property('action');
+                expect(entry).to.have.property('userKey');
+
+                // Verify date is in ISO 8601 format
+                if (entry.date) {
+                    expect(entry.date).to.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}/);
+                }
+            }
+        });
+    });
+
+    it('should handle pagination parameters', () => {
+        addNode({
+            parentPathOrId: contentPath,
+            name: testNodeName,
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Initial text', language: 'en'}]
+        });
+
+        cy.wait(500);
+
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryPaginated.graphql',
+            variables: {
+                path: testNodePath,
+                withLanguageNodes: false,
+                offset: 0,
+                limit: 2
+            }
+        }).then(result => {
+            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+            expect(entries).to.be.an('array');
+
+            // If entries exist, should respect limit
+            if (entries && entries.length > 0) {
+                expect(entries.length).to.be.at.most(2);
+
+                const entry = entries[0];
+                expect(entry).to.have.property('id');
+                expect(entry).to.have.property('date');
+                expect(entry).to.have.property('path');
+                expect(entry).to.have.property('uuid');
+                expect(entry).to.have.property('action');
+                expect(entry).to.have.property('userKey');
+            }
+        });
+    });
+
+    it('should return count with and without language nodes parameter', () => {
+        addNode({
+            parentPathOrId: contentPath,
+            name: testNodeName,
+            primaryNodeType: 'jnt:text',
+            properties: [
+                {name: 'text', value: 'English text', language: 'en'},
+                {name: 'text', value: 'French text', language: 'fr'}
+            ]
+        });
+
+        cy.wait(500);
+
+        // Get count without language nodes
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryCount.graphql',
+            variables: {
+                path: testNodePath,
+                withLanguageNodes: false
+            }
+        }).then(result => {
+            const countWithoutLang = result?.data?.jcr?.nodeByPath?.history?.count;
+            expect(countWithoutLang).to.be.a('number');
+            expect(countWithoutLang).to.be.at.least(0);
+
+            // Get count with language nodes
+            cy.apollo({
+                queryFile: 'api/contentHistory/getNodeHistoryCount.graphql',
+                variables: {
+                    path: testNodePath,
+                    withLanguageNodes: true
+                }
+            }).then(resultWithLang => {
+                const countWithLang = resultWithLang?.data?.jcr?.nodeByPath?.history?.count;
+                expect(countWithLang).to.be.a('number');
+                expect(countWithLang).to.be.at.least(0);
+                // Count with language nodes should be >= count without
+                expect(countWithLang).to.be.at.least(countWithoutLang);
+            });
+        });
+    });
+
+    it('should include all available fields when queried', () => {
+        addNode({
+            parentPathOrId: contentPath,
+            name: testNodeName,
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Complete test', language: 'en'}]
+        });
+
+        cy.wait(500);
+
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryComplete.graphql',
+            variables: {
+                path: testNodePath,
+                withLanguageNodes: false,
+                offset: 0,
+                limit: 5
+            }
+        }).then(result => {
+            const history = result?.data?.jcr?.nodeByPath?.history;
+            expect(history).to.exist;
+            expect(history.count).to.be.a('number');
+            expect(history.entries).to.be.an('array');
+
+            // If entries exist, verify all fields are available
+            if (history.entries && history.entries.length > 0) {
+                const entry = history.entries[0];
+
+                // Verify all expected fields are present (even if null)
+                expect(entry).to.have.property('id');
+                expect(entry).to.have.property('date');
+                expect(entry).to.have.property('timestamp');
+                expect(entry).to.have.property('path');
+                expect(entry).to.have.property('uuid');
+                expect(entry).to.have.property('action');
+                expect(entry).to.have.property('propertyName');
+                expect(entry).to.have.property('userKey');
+                expect(entry).to.have.property('message');
+                expect(entry).to.have.property('language');
+
+                // Verify timestamp is a number if present
+                if (entry.timestamp !== null) {
+                    expect(entry.timestamp).to.be.a('number');
+                }
+
+                // Verify date is ISO 8601 string if present
+                if (entry.date) {
+                    expect(entry.date).to.be.a('string');
+                    expect(entry.date).to.match(/^\d{4}-\d{2}-\d{2}T/);
+                }
+            }
+        });
+    });
+
+    it('should track published actions if metrics logging is enabled', () => {
+        addNode({
+            parentPathOrId: contentPath,
+            name: testNodeName,
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Content to publish', language: 'en'}]
+        });
+
+        // Publish the node
+        publishAndWaitJobEnding(testNodePath, ['en']);
+
+        // Wait longer for publication history to be logged
+        cy.wait(500);
+
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryDetailed.graphql',
+            variables: {
+                path: testNodePath,
+                withLanguageNodes: false,
+                offset: 0,
+                limit: 50
+            }
+        }).then(result => {
+            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+            expect(entries).to.be.an('array');
+
+            // If history entries exist, check for published action
+            if (entries && entries.length > 0) {
+                cy.log(`Found ${entries.length} history entries`);
+
+                // Look for a published entry
+                const publishedEntry = entries.find(entry => entry.action === 'published');
+                if (publishedEntry) {
+                    cy.log('Published action found in history');
+                    expect(publishedEntry.action).to.equal('published');
+                    expect(publishedEntry.userKey).to.be.a('string');
+                } else {
+                    cy.log('No published action found (metrics logging may be disabled or async processing delayed)');
+                }
+            } else {
+                cy.log('No history entries found (metrics logging may be disabled)');
+            }
+        });
+    });
+
+    it('should handle offset parameter correctly', () => {
+        addNode({
+            parentPathOrId: contentPath,
+            name: testNodeName,
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Initial', language: 'en'}]
+        });
+
+        cy.wait(500);
+
+        // Test with offset 0
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryPaginated.graphql',
+            variables: {
+                path: testNodePath,
+                withLanguageNodes: false,
+                offset: 0,
+                limit: 5
+            }
+        }).then(result => {
+            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+            expect(entries).to.be.an('array');
+
+            if (entries && entries.length > 1) {
+                const firstId = entries[0].id;
+
+                // Test with offset 1
+                cy.apollo({
+                    queryFile: 'api/contentHistory/getNodeHistoryPaginated.graphql',
+                    variables: {
+                        path: testNodePath,
+                        withLanguageNodes: false,
+                        offset: 1,
+                        limit: 5
+                    }
+                }).then(offsetResult => {
+                    const offsetEntries = offsetResult?.data?.jcr?.nodeByPath?.history?.entries;
+                    expect(offsetEntries).to.be.an('array');
+
+                    // First entry with offset should be different from first entry without offset
+                    if (offsetEntries && offsetEntries.length > 0) {
+                        expect(offsetEntries[0].id).to.not.equal(firstId);
+                    }
+                });
+            }
+        });
+    });
+
+    it('should return timestamp field alongside date field', () => {
+        addNode({
+            parentPathOrId: contentPath,
+            name: testNodeName,
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', value: 'Timestamp test', language: 'en'}]
+        });
+
+        cy.wait(500);
+
+        cy.apollo({
+            queryFile: 'api/contentHistory/getNodeHistoryComplete.graphql',
+            variables: {
+                path: testNodePath,
+                withLanguageNodes: false,
+                offset: 0,
+                limit: 1
+            }
+        }).then(result => {
+            const entries = result?.data?.jcr?.nodeByPath?.history?.entries;
+
+            if (entries && entries.length > 0) {
+                const entry = entries[0];
+
+                // If we have a date, we should also have a timestamp
+                if (entry.date) {
+                    expect(entry).to.have.property('timestamp');
+                    expect(entry.timestamp).to.be.a('number');
+
+                    // Timestamp should represent roughly the same time as date
+                    const dateFromTimestamp = new Date(entry.timestamp);
+                    const dateFromISO = new Date(entry.date);
+
+                    // Allow 1 second difference for rounding
+                    const timeDiff = Math.abs(dateFromTimestamp.getTime() - dateFromISO.getTime());
+                    expect(timeDiff).to.be.lessThan(1000);
+                }
+            }
+        });
+    });
+});

--- a/tests/cypress/fixtures/api/contentHistory/getNodeHistory.graphql
+++ b/tests/cypress/fixtures/api/contentHistory/getNodeHistory.graphql
@@ -1,0 +1,16 @@
+query getNodeHistory($path: String!, $withLanguageNodes: Boolean!) {
+    jcr {
+        nodeByPath(path: $path) {
+            uuid
+            history {
+                count(withLanguageNodes: $withLanguageNodes)
+                entries(withLanguageNodes: $withLanguageNodes, offset: 0, limit: 50) {
+                    id
+                    date
+                    action
+                    userKey
+                }
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/api/contentHistory/getNodeHistoryComplete.graphql
+++ b/tests/cypress/fixtures/api/contentHistory/getNodeHistoryComplete.graphql
@@ -1,0 +1,22 @@
+query getNodeHistoryComplete($path: String!, $withLanguageNodes: Boolean!, $offset: Int!, $limit: Int!) {
+    jcr {
+        nodeByPath(path: $path) {
+            uuid
+            history {
+                count(withLanguageNodes: $withLanguageNodes)
+                entries(withLanguageNodes: $withLanguageNodes, offset: $offset, limit: $limit) {
+                    id
+                    date
+                    timestamp
+                    path
+                    uuid
+                    action
+                    propertyName
+                    userKey
+                    message
+                    language
+                }
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/api/contentHistory/getNodeHistoryCount.graphql
+++ b/tests/cypress/fixtures/api/contentHistory/getNodeHistoryCount.graphql
@@ -1,0 +1,10 @@
+query getNodeHistoryCount($path: String!, $withLanguageNodes: Boolean!) {
+    jcr {
+        nodeByPath(path: $path) {
+            uuid
+            history {
+                count(withLanguageNodes: $withLanguageNodes)
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/api/contentHistory/getNodeHistoryCountWithAction.graphql
+++ b/tests/cypress/fixtures/api/contentHistory/getNodeHistoryCountWithAction.graphql
@@ -1,0 +1,10 @@
+query getNodeHistoryCountWithAction($path: String!, $withLanguageNodes: Boolean!, $action: String!) {
+    jcr {
+        nodeByPath(path: $path) {
+            uuid
+            history {
+                count(withLanguageNodes: $withLanguageNodes, action: $action)
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/api/contentHistory/getNodeHistoryDetailed.graphql
+++ b/tests/cypress/fixtures/api/contentHistory/getNodeHistoryDetailed.graphql
@@ -1,0 +1,19 @@
+query getNodeHistoryDetailed($path: String!, $withLanguageNodes: Boolean!, $offset: Int!, $limit: Int!) {
+    jcr {
+        nodeByPath(path: $path) {
+            uuid
+            history {
+                entries(withLanguageNodes: $withLanguageNodes, offset: $offset, limit: $limit) {
+                    id
+                    date
+                    path
+                    uuid
+                    action
+                    propertyName
+                    userKey
+                    message
+                }
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/api/contentHistory/getNodeHistoryNoParams.graphql
+++ b/tests/cypress/fixtures/api/contentHistory/getNodeHistoryNoParams.graphql
@@ -1,0 +1,15 @@
+query getNodeHistoryNoParams($path: String!, $withLanguageNodes: Boolean!) {
+    jcr {
+        nodeByPath(path: $path) {
+            uuid
+            history {
+                entries(withLanguageNodes: $withLanguageNodes) {
+                    id
+                    date
+                    action
+                    userKey
+                }
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/api/contentHistory/getNodeHistoryPaginated.graphql
+++ b/tests/cypress/fixtures/api/contentHistory/getNodeHistoryPaginated.graphql
@@ -1,0 +1,17 @@
+query getNodeHistoryPaginated($path: String!, $withLanguageNodes: Boolean!, $offset: Int!, $limit: Int!) {
+    jcr {
+        nodeByPath(path: $path) {
+            uuid
+            history {
+                entries(withLanguageNodes: $withLanguageNodes, offset: $offset, limit: $limit) {
+                    id
+                    date
+                    path
+                    uuid
+                    action
+                    userKey
+                }
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/api/contentHistory/getNodeHistoryWithAction.graphql
+++ b/tests/cypress/fixtures/api/contentHistory/getNodeHistoryWithAction.graphql
@@ -1,0 +1,19 @@
+query getNodeHistoryWithAction($path: String!, $withLanguageNodes: Boolean!, $action: String!, $offset: Int!, $limit: Int!) {
+    jcr {
+        nodeByPath(path: $path) {
+            uuid
+            history {
+                entries(withLanguageNodes: $withLanguageNodes, action: $action, offset: $offset, limit: $limit) {
+                    id
+                    date
+                    path
+                    uuid
+                    action
+                    propertyName
+                    userKey
+                    message
+                }
+            }
+        }
+    }
+}

--- a/tests/cypress/fixtures/api/contentHistory/getNodeHistoryWithPropertyDisplay.graphql
+++ b/tests/cypress/fixtures/api/contentHistory/getNodeHistoryWithPropertyDisplay.graphql
@@ -1,0 +1,20 @@
+query getNodeHistoryWithPropertyDisplay($path: String!, $withLanguageNodes: Boolean!, $offset: Int!, $limit: Int!, $language: String!) {
+    jcr {
+        nodeByPath(path: $path) {
+            uuid
+            history {
+                entries(withLanguageNodes: $withLanguageNodes, offset: $offset, limit: $limit) {
+                    id
+                    date
+                    path
+                    uuid
+                    action
+                    propertyName
+                    propertyNameDisplay(language: $language)
+                    userKey
+                    message
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Jahia/jcontent/issues/2261
## Content History API

The Content History API allows you to track the lifecycle of a node. Use these fields to retrieve audit logs, identify who modified specific properties, and view chronological changes across base nodes and their language-specific variants.

### Node Fields
These fields are available on the node object to query historical data.

| Field | Type | Description |
| :--- | :--- | :--- |
| `count` | `Int` | The total number of history entries recorded for this node. |
| `entries` | `[GqlContentHistoryEntry]` | A paginated list of individual history events. |

#### Arguments
* **`withLanguageNodes`** (`Boolean`): When `true`, includes history events from associated language-specific nodes (translations).
* **`action`** (`string`): Filter the history entries by the given action. Action can be one of:
```
   ┌──────────────────┬───────────────┬─────────────┐
   │ Log Template Key │ Stored Action │ Object Type │
   ├──────────────────┼───────────────┼─────────────┤
   │ nodeCreated      │ created       │ node        │
   ├──────────────────┼───────────────┼─────────────┤
   │ nodeUpdated      │ updated       │ node        │
   ├──────────────────┼───────────────┼─────────────┤
   │ nodeDeleted      │ deleted       │ node        │
   ├──────────────────┼───────────────┼─────────────┤
   │ nodeMoved        │ moved         │ node        │
   ├──────────────────┼───────────────┼─────────────┤
   │ propertyAdded    │ added         │ property    │
   ├──────────────────┼───────────────┼─────────────┤
   │ propertyChanged  │ changed       │ property    │
   ├──────────────────┼───────────────┼─────────────┤
   │ propertyRemoved  │ removed       │ property    │
   ├──────────────────┼───────────────┼─────────────┤
   │ publishedNode    │ published     │ node        │
   ├──────────────────┼───────────────┼─────────────┤
   │ unpublishedNode  │ unpublished   │ node        │
   ├──────────────────┼───────────────┼─────────────┤
   │ fileAccessed     │ accessed      │ file        │
   ├──────────────────┼───────────────┼─────────────┤
   │ pageViewed       │ viewed        │ page        │
   ├──────────────────┼───────────────┼─────────────┤
   │ moduleViewed     │ viewed        │ module      │
   └──────────────────┴───────────────┴─────────────┘
```
**viewed** actions are filtered and not stored by the content history service. 
**accessed** action is part of the file servlet but disabled (related to the system property `jahia.fileServlet.statisticsEnabled`)

* **`offset`** (`Int`): The number of records to skip for pagination.
* **`limit`** (`Int`): The maximum number of records to return.

---

### GqlContentHistoryEntry
Represents a single audit event or change performed on a node.

#### Field Definitions

* **`action`** (`String`)
    The type of event performed.
    * *Examples:* `created`, `updated`, `deleted`, `published`.
* **`date`** (`String`)
    The occurrence timestamp formatted as an **ISO 8601** string (e.g., `2024-05-20T14:30:00Z`).
* **`id`** (`String`)
    The unique identifier for the history entry itself.
* **`language`** (`String`)
    The language code (e.g., `en`, `de`) associated with the change, if applicable.
* **`message`** (`String`)
    A descriptive summary or additional context regarding the event.
* **`path`** (`String`)
    The hierarchical path of the node at the time the action was logged.
* **`propertyName`** (`String`)
    The specific property modified, if the action targets a single field (e.g., `jcr:title`).
* **`propertyNameDisplay`** (`String`)
    The i18n label of the property modified, if the action targets a single field (e.g., `Title`).
* **`timestamp`** (`Long`)
    The event time expressed in **milliseconds** since the Unix epoch.
* **`userKey`** (`String`)
    The identifier of the user who performed the action.
* **`uuid`** (`String`)
    The unique, persistent UUID of the node to which this history entry belongs.

---

### Implementation Example

```graphql
query GetNodeAuditLog($path: String!) {
  nodeByPath(path: $path) {
    history {
      count(withLanguageNodes: true)
      entries(limit: 10, offset: 0, withLanguageNodes: true) {
        id
        action
        date
        userKey
        propertyName
        message
      }
    }
  }
}
```

### Compatibility and Versioning

As part of jContent, it is compatible with **Jahia 8.2.1.0** and later. 

Starting with **Jahia 8.2.4.0**, native methods were introduced to retrieve content history using `limit` and `offset` parameters. To optimize performance, the module includes a runtime check: it will automatically utilize these native methods if they are available in your environment.

**Deprecation Notice:**
* The legacy history retrieval logic and the associated method resolution adapters are marked as **deprecated**. 
* These components are scheduled for removal once the module's parent dependency is officially bumped to **Jahia 8.2.4.0**.

### Permission
Currently the `history` field is readable by anyone that can read the node. 
Requirements to add a permission:
- A name for this permission 
- Roles to apply 

The history panel will be protected by the existing `viewHistoryTab` permission

### Checklist

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
