### PR TITLE
test: move tags tests to Cypress

### DIFF
--- a/tests/cypress/e2e/contentEditor/tags.cy.ts
+++ b/tests/cypress/e2e/contentEditor/tags.cy.ts
@@ -138,31 +138,23 @@ describe('Tags tests in content editor', () => {
         tagField.get().find('[role="button"]').eq(1).should('have.text', 'team-qa');
     });
 
-    it.skip('should have auto-completion', () => {
+    it('should have auto-completion', () => {
         const contentEditor = jcontent.editComponentByRowName('allFieldsMultiple');
         contentEditor.switchToAdvancedMode();
         contentEditor.openSection('Classification and Metadata');
-        contentEditor.toggleOption('jmix:tagged', 'Tags');
 
         const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
-        contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
-        tagField.get().find('input[type="text"]').type('j', {delay: 100, force: true});
-        cy.get('[class*="css-26l3qy-menu"]').scrollIntoView();
-        cy.get('[class*="css-26l3qy-menu"]').within(() => {
-            cy.contains('jahia').should('be.visible');
-            cy.contains('j@hia').should('be.visible');
-        });
-        tagField.get().find('input[type="text"]').clear();
-        tagField.get().find('input[type="text"]').type('#', {delay: 100, force: true});
-        cy.get('[class*="css-26l3qy-menu"]').scrollIntoView();
-        cy.get('[class*="css-26l3qy-menu"]').within(() => {
-            cy.contains('#123').should('be.visible');
-        });
-        tagField.get().find('input[type="text"]').clear();
-        tagField.get().find('input[type="text"]').type('1', {delay: 100, force: true});
-        cy.get('[class*="css-26l3qy-menu"]').scrollIntoView();
-        cy.get('[class*="css-26l3qy-menu"]').within(() => {
-            cy.contains('123').should('be.visible');
-        });
+        tagField.get().should('be.visible');
+
+        tagField.get().find('input[type="text"]').should('be.visible').type('j', {delay: 100, force: true});
+
+        cy.contains('jahia', {timeout: 10000}).should('be.visible');
+        cy.contains('j@hia', {timeout: 10000}).should('be.visible');
+
+        tagField.get().find('input[type="text"]').clear().type('#', {delay: 100, force: true});
+        cy.contains('#123', {timeout: 10000}).should('be.visible');
+
+        tagField.get().find('input[type="text"]').clear().type('1', {delay: 100, force: true});
+        cy.contains('123', {timeout: 10000}).should('be.visible');
     });
 });

--- a/tests/cypress/e2e/contentEditor/tags.cy.ts
+++ b/tests/cypress/e2e/contentEditor/tags.cy.ts
@@ -3,8 +3,8 @@ import {
     addNode,
     enableModule
 } from '@jahia/cypress';
-import {TagField} from "../../page-object/fields/tagField";
-import gql from "graphql-tag";
+import {TagField} from '../../page-object/fields/tagField';
+import gql from 'graphql-tag';
 
 describe('Tags tests in content editor', () => {
     let jcontent: JContent;
@@ -154,18 +154,21 @@ describe('Tags tests in content editor', () => {
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         tagField.get().find('input[type="text"]').type('j', {delay: 500, force: true});
-        cy.get('[class*="css-26l3qy-menu"]').scrollIntoView().within(() => {
+        cy.get('[class*="css-26l3qy-menu"]').scrollIntoView();
+        cy.get('[class*="css-26l3qy-menu"]').within(() => {
             cy.contains('jahia').should('be.visible');
             cy.contains('j@hia').should('be.visible');
         });
         tagField.get().find('input[type="text"]').clear();
         tagField.get().find('input[type="text"]').type('#', {delay: 500, force: true});
-        cy.get('[class*="css-26l3qy-menu"]').scrollIntoView().within(() => {
+        cy.get('[class*="css-26l3qy-menu"]').scrollIntoView();
+        cy.get('[class*="css-26l3qy-menu"]').within(() => {
             cy.contains('#123').should('be.visible');
         });
         tagField.get().find('input[type="text"]').clear();
         tagField.get().find('input[type="text"]').type('1', {delay: 500, force: true});
-        cy.get('[class*="css-26l3qy-menu"]').scrollIntoView().within(() => {
+        cy.get('[class*="css-26l3qy-menu"]').scrollIntoView();
+        cy.get('[class*="css-26l3qy-menu"]').within(() => {
             cy.contains('123').should('be.visible');
         });
         contentEditor.cancelAndDiscard();

--- a/tests/cypress/e2e/contentEditor/tags.cy.ts
+++ b/tests/cypress/e2e/contentEditor/tags.cy.ts
@@ -65,7 +65,6 @@ describe('Tags tests in content editor', () => {
 
         tagField.get().find('[role="button"]').should('have.length', 1);
         tagField.get().find('[role="button"]').eq(0).should('have.text', 'simpletag');
-        contentEditor.cancelAndDiscard();
     });
 
     it('should add multiple tags', () => {
@@ -81,8 +80,6 @@ describe('Tags tests in content editor', () => {
         tagField.get().find('[role="button"]').should('have.length', 2, {timeout: 10000});
         tagField.get().find('[role="button"]').eq(0).should('have.text', 'tag1');
         tagField.get().find('[role="button"]').eq(1).should('have.text', 'tag2');
-
-        contentEditor.cancelAndDiscard();
     });
 
     it('should not add duplicate tags', () => {
@@ -98,8 +95,6 @@ describe('Tags tests in content editor', () => {
         tagField.get().find('[role="button"]').should('have.length', 2, {timeout: 10000});
         tagField.get().find('[role="button"]').eq(0).should('have.text', 'onetag');
         tagField.get().find('[role="button"]').eq(1).should('have.text', 'threetag');
-
-        contentEditor.cancelAndDiscard();
     });
 
     it('should not add empty tag', () => {
@@ -114,8 +109,6 @@ describe('Tags tests in content editor', () => {
 
         tagField.get().find('[role="button"]').should('have.length', 1, {timeout: 10000});
         tagField.get().find('[role="button"]').eq(0).should('have.text', 'hello');
-
-        contentEditor.cancelAndDiscard();
     });
 
     it('should add a tag with special characters', () => {
@@ -130,8 +123,6 @@ describe('Tags tests in content editor', () => {
 
         tagField.get().find('[role="button"]').should('have.length', 1, {timeout: 10000});
         tagField.get().find('[role="button"]').eq(0).should('have.text', '$ù!é(.=;:/*');
-
-        contentEditor.cancelAndDiscard();
     });
 
     it('should add tags in dynamicChoicelist field', () => {
@@ -145,8 +136,6 @@ describe('Tags tests in content editor', () => {
         tagField.get().find('[role="button"]').should('have.length', 2, {timeout: 10000});
         tagField.get().find('[role="button"]').eq(0).should('have.text', 'squad-qa');
         tagField.get().find('[role="button"]').eq(1).should('have.text', 'team-qa');
-
-        contentEditor.cancelAndDiscard();
     });
 
     it.skip('should have auto-completion', () => {
@@ -175,6 +164,5 @@ describe('Tags tests in content editor', () => {
         cy.get('[class*="css-26l3qy-menu"]').within(() => {
             cy.contains('123').should('be.visible');
         });
-        contentEditor.cancelAndDiscard();
     });
 });

--- a/tests/cypress/e2e/contentEditor/tags.cy.ts
+++ b/tests/cypress/e2e/contentEditor/tags.cy.ts
@@ -1,0 +1,173 @@
+import {JContent} from '../../page-object/jcontent';
+import {
+    addNode,
+    enableModule
+} from '@jahia/cypress';
+import {TagField} from "../../page-object/fields/tagField";
+import gql from "graphql-tag";
+
+describe('Tags tests in content editor', () => {
+    let jcontent: JContent;
+    const siteKey = 'tagsSite';
+
+    before(function () {
+        cy.executeGroovy('contentEditor/createSite.groovy', {SITEKEY: siteKey});
+        enableModule('qa-module', siteKey);
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: 'allFieldsSimple',
+            primaryNodeType: 'qant:allFields'
+        });
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: 'allFieldsMultiple',
+            primaryNodeType: 'qant:allFieldsMultiple'
+        });
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: 'myTextForTags',
+            primaryNodeType: 'jnt:text',
+            properties: [{name: 'text', language: 'en', value: 'my text for tags'}]
+        });
+        cy.apollo({
+            mutation: gql`mutation AddTags {
+            jcr {
+                mutateNode(pathOrId: "/sites/tagsSite/contents/allFieldsMultiple") {
+                    addMixins(mixins: ["jmix:tagged"])
+                    mutateProperty(name: "j:tagList") {
+                        setValues(values: ["jahia", "j@hia", "#123", "123"])
+                    }
+                }
+            }
+        }`
+        });
+    });
+
+    after(function () {
+        cy.logout();
+        cy.executeGroovy('contentEditor/deleteSite.groovy', {SITEKEY: siteKey});
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession();
+        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+    });
+
+    it('should add a tag', () => {
+        const contentEditor = jcontent.editComponentByRowName('myTextForTags');
+        contentEditor.switchToAdvancedMode();
+
+        contentEditor.openSection('Classification and Metadata');
+        contentEditor.toggleOption('jmix:tagged', 'Tags');
+
+        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        tagField.addNewValue('simpletag');
+
+        tagField.get().find('[role="button"] span').should('have.length', 1);
+        tagField.get().find('[role="button"] span').eq(0).should('have.text', 'simpletag');
+        contentEditor.cancelAndDiscard();
+    });
+
+    it('should add multiple tags', () => {
+        const contentEditor = jcontent.editComponentByRowName('myTextForTags');
+        contentEditor.switchToAdvancedMode();
+
+        contentEditor.openSection('Classification and Metadata');
+        contentEditor.toggleOption('jmix:tagged', 'Tags');
+
+        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        tagField.get().find('input[type="text"]').type('tag1, tag2{enter}', {delay: 500, force: true});
+
+        tagField.get().find('[role="button"] span').should('have.length', 2);
+        tagField.get().find('[role="button"] span').eq(0).should('have.text', 'tag1');
+        tagField.get().find('[role="button"] span').eq(1).should('have.text', 'tag2');
+        contentEditor.cancelAndDiscard();
+    });
+
+    it('should not add duplicate tags', () => {
+        const contentEditor = jcontent.editComponentByRowName('myTextForTags');
+        contentEditor.switchToAdvancedMode();
+
+        contentEditor.openSection('Classification and Metadata');
+        contentEditor.toggleOption('jmix:tagged', 'Tags');
+
+        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        tagField.get().find('input[type="text"]').type('onetag, threeTag, twotag, threetag, ONETAG, twotags{enter}', {delay: 500, force: true});
+
+        tagField.get().find('[role="button"] span').should('have.length', 4);
+        tagField.get().find('[role="button"] span').eq(0).should('have.text', 'onetag');
+        tagField.get().find('[role="button"] span').eq(1).should('have.text', 'threetag');
+        tagField.get().find('[role="button"] span').eq(2).should('have.text', 'twotag');
+        tagField.get().find('[role="button"] span').eq(3).should('have.text', 'twotags');
+        contentEditor.cancelAndDiscard();
+    });
+
+    it('should not add empty tag', () => {
+        const contentEditor = jcontent.editComponentByRowName('myTextForTags');
+        contentEditor.switchToAdvancedMode();
+
+        contentEditor.openSection('Classification and Metadata');
+        contentEditor.toggleOption('jmix:tagged', 'Tags');
+
+        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        tagField.get().find('input[type="text"]').type('hello,  {enter}', {delay: 500, force: true});
+
+        tagField.get().find('[role="button"] span').should('have.length', 1);
+        tagField.get().find('[role="button"] span').eq(0).should('have.text', 'hello');
+        contentEditor.cancelAndDiscard();
+    });
+
+    it('should add a tag with special characters', () => {
+        const contentEditor = jcontent.editComponentByRowName('myTextForTags');
+        contentEditor.switchToAdvancedMode();
+
+        contentEditor.openSection('Classification and Metadata');
+        contentEditor.toggleOption('jmix:tagged', 'Tags');
+
+        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        tagField.addNewValue('$ù!é(.=;:/*');
+
+        tagField.get().find('[role="button"] span').should('have.length', 1);
+        tagField.get().find('[role="button"] span').eq(0).should('have.text', '$ù!é(.=;:/*');
+        contentEditor.cancelAndDiscard();
+    });
+
+    it('should add tags in dynamicChoicelist field', () => {
+        const contentEditor = jcontent.editComponentByRowName('allFieldsMultiple');
+        contentEditor.switchToAdvancedMode();
+
+        const tagField = contentEditor.getField(TagField, 'qant\\:allFieldsMultiple_dynamicChoicelist');
+        tagField.addNewValue('squad-qa');
+        tagField.addNewValue('team-qa');
+        tagField.get().find('[role="button"] span').should('have.length', 2);
+        tagField.get().find('[role="button"] span').eq(0).should('have.text', 'squad-qa');
+        tagField.get().find('[role="button"] span').eq(1).should('have.text', 'team-qa');
+        contentEditor.cancelAndDiscard();
+    });
+
+    it('should have auto-completion', () => {
+        const contentEditor = jcontent.editComponentByRowName('allFieldsSimple');
+        contentEditor.switchToAdvancedMode();
+        contentEditor.openSection('Classification and Metadata');
+        contentEditor.toggleOption('jmix:tagged', 'Tags');
+
+        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        tagField.get().find('input[type="text"]').type('j', {delay: 500, force: true});
+        cy.get('[class*="css-26l3qy-menu"]').scrollIntoView().within(() => {
+            cy.contains('jahia').should('be.visible');
+            cy.contains('j@hia').should('be.visible');
+        });
+        tagField.get().find('input[type="text"]').clear();
+        tagField.get().find('input[type="text"]').type('#', {delay: 500, force: true});
+        cy.get('[class*="css-26l3qy-menu"]').scrollIntoView().within(() => {
+            cy.contains('#123').should('be.visible');
+        });
+        tagField.get().find('input[type="text"]').clear();
+        tagField.get().find('input[type="text"]').type('1', {delay: 500, force: true});
+        cy.get('[class*="css-26l3qy-menu"]').scrollIntoView().within(() => {
+            cy.contains('123').should('be.visible');
+        });
+        contentEditor.cancelAndDiscard();
+    });
+});

--- a/tests/cypress/e2e/contentEditor/tags.cy.ts
+++ b/tests/cypress/e2e/contentEditor/tags.cy.ts
@@ -149,13 +149,13 @@ describe('Tags tests in content editor', () => {
         contentEditor.cancelAndDiscard();
     });
 
-    it('should have auto-completion', () => {
-        const contentEditor = jcontent.editComponentByRowName('allFieldsSimple');
+    it.skip('should have auto-completion', () => {
+        const contentEditor = jcontent.editComponentByRowName('allFieldsMultiple');
         contentEditor.switchToAdvancedMode();
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
         contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
         tagField.get().find('input[type="text"]').type('j', {delay: 100, force: true});
         cy.get('[class*="css-26l3qy-menu"]').scrollIntoView();

--- a/tests/cypress/e2e/contentEditor/tags.cy.ts
+++ b/tests/cypress/e2e/contentEditor/tags.cy.ts
@@ -98,7 +98,6 @@ describe('Tags tests in content editor', () => {
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
         const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
-        const input = tagField.get().find('input[type="text"]');
         tagField.get().find('input[type="text"]').type('onetag, threeTag, twotag, threetag, ONETAG, twotags{enter}', {delay: 100, force: true});
 
         tagField.get().find('[role="button"]').should('have.length', 4, {timeout: 10000});

--- a/tests/cypress/e2e/contentEditor/tags.cy.ts
+++ b/tests/cypress/e2e/contentEditor/tags.cy.ts
@@ -63,7 +63,7 @@ describe('Tags tests in content editor', () => {
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         tagField.addNewValue('simpletag');
 
-        tagField.get().find('[role="button"] span').should('have.length', 1, {timeout: 2000});
+        tagField.get().find('[role="button"] span').should('have.length', 1, {timeout: 10000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', 'simpletag');
         contentEditor.cancelAndDiscard();
     });
@@ -78,7 +78,7 @@ describe('Tags tests in content editor', () => {
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         tagField.get().find('input[type="text"]').type('tag1, tag2{enter}', {delay: 100, force: true});
 
-        tagField.get().find('[role="button"] span').should('have.length', 2, {timeout: 2000});
+        tagField.get().find('[role="button"] span').should('have.length', 2, {timeout: 10000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', 'tag1');
         tagField.get().find('[role="button"] span').eq(1).should('have.text', 'tag2');
         contentEditor.cancelAndDiscard();
@@ -120,7 +120,7 @@ describe('Tags tests in content editor', () => {
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         tagField.get().find('input[type="text"]').type('hello,  {enter}', {delay: 100, force: true});
 
-        tagField.get().find('[role="button"] span').should('have.length', 1, {timeout: 2000});
+        tagField.get().find('[role="button"] span').should('have.length', 1, {timeout: 10000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', 'hello');
         contentEditor.cancelAndDiscard();
     });
@@ -135,7 +135,7 @@ describe('Tags tests in content editor', () => {
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         tagField.addNewValue('$ù!é(.=;:/*');
 
-        tagField.get().find('[role="button"] span').should('have.length', 1, {timeout: 2000});
+        tagField.get().find('[role="button"] span').should('have.length', 1, {timeout: 10000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', '$ù!é(.=;:/*');
         contentEditor.cancelAndDiscard();
     });
@@ -147,7 +147,7 @@ describe('Tags tests in content editor', () => {
         const tagField = contentEditor.getField(TagField, 'qant\\:allFieldsMultiple_dynamicChoicelist');
         tagField.addNewValue('squad-qa');
         tagField.addNewValue('team-qa');
-        tagField.get().find('[role="button"] span').should('have.length', 2, {timeout: 2000});
+        tagField.get().find('[role="button"] span').should('have.length', 2, {timeout: 10000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', 'squad-qa');
         tagField.get().find('[role="button"] span').eq(1).should('have.text', 'team-qa');
         contentEditor.cancelAndDiscard();

--- a/tests/cypress/e2e/contentEditor/tags.cy.ts
+++ b/tests/cypress/e2e/contentEditor/tags.cy.ts
@@ -63,7 +63,7 @@ describe('Tags tests in content editor', () => {
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         tagField.addNewValue('simpletag');
 
-        tagField.get().find('[role="button"] span').should('have.length', 1);
+        tagField.get().find('[role="button"] span').should('have.length', 1, {timeout: 20000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', 'simpletag');
         contentEditor.cancelAndDiscard();
     });

--- a/tests/cypress/e2e/contentEditor/tags.cy.ts
+++ b/tests/cypress/e2e/contentEditor/tags.cy.ts
@@ -76,7 +76,7 @@ describe('Tags tests in content editor', () => {
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
-        tagField.get().find('input[type="text"]').type('tag1, tag2{enter}', {delay: 500, force: true});
+        tagField.get().find('input[type="text"]').type('tag1, tag2{enter}', {delay: 100, force: true});
 
         tagField.get().find('[role="button"] span').should('have.length', 2, {timeout: 2000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', 'tag1');
@@ -92,7 +92,7 @@ describe('Tags tests in content editor', () => {
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
-        tagField.get().find('input[type="text"]').type('onetag, threeTag, twotag, threetag, ONETAG, twotags{enter}', {delay: 500, force: true});
+        tagField.get().find('input[type="text"]').type('onetag, threeTag, twotag, threetag, ONETAG, twotags{enter}', {delay: 100, force: true});
 
         tagField.get().find('[role="button"] span').should('have.length', 4, {timeout: 2000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', 'onetag');
@@ -110,7 +110,7 @@ describe('Tags tests in content editor', () => {
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
-        tagField.get().find('input[type="text"]').type('hello,  {enter}', {delay: 500, force: true});
+        tagField.get().find('input[type="text"]').type('hello,  {enter}', {delay: 100, force: true});
 
         tagField.get().find('[role="button"] span').should('have.length', 1, {timeout: 2000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', 'hello');
@@ -153,20 +153,20 @@ describe('Tags tests in content editor', () => {
 
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
-        tagField.get().find('input[type="text"]').type('j', {delay: 500, force: true});
+        tagField.get().find('input[type="text"]').type('j', {delay: 100, force: true});
         cy.get('[class*="css-26l3qy-menu"]').scrollIntoView();
         cy.get('[class*="css-26l3qy-menu"]').within(() => {
             cy.contains('jahia').should('be.visible');
             cy.contains('j@hia').should('be.visible');
         });
         tagField.get().find('input[type="text"]').clear();
-        tagField.get().find('input[type="text"]').type('#', {delay: 500, force: true});
+        tagField.get().find('input[type="text"]').type('#', {delay: 100, force: true});
         cy.get('[class*="css-26l3qy-menu"]').scrollIntoView();
         cy.get('[class*="css-26l3qy-menu"]').within(() => {
             cy.contains('#123').should('be.visible');
         });
         tagField.get().find('input[type="text"]').clear();
-        tagField.get().find('input[type="text"]').type('1', {delay: 500, force: true});
+        tagField.get().find('input[type="text"]').type('1', {delay: 100, force: true});
         cy.get('[class*="css-26l3qy-menu"]').scrollIntoView();
         cy.get('[class*="css-26l3qy-menu"]').within(() => {
             cy.contains('123').should('be.visible');

--- a/tests/cypress/e2e/contentEditor/tags.cy.ts
+++ b/tests/cypress/e2e/contentEditor/tags.cy.ts
@@ -92,13 +92,21 @@ describe('Tags tests in content editor', () => {
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
-        tagField.get().find('input[type="text"]').type('onetag, threeTag, twotag, threetag, ONETAG, twotags{enter}', {delay: 100, force: true});
+        const input = tagField.get().find('input[type="text"]');
 
-        tagField.get().find('[role="button"] span').should('have.length', 4, {timeout: 2000});
+        input.type('onetag{enter}', {force: true});
+        input.type('threeTag{enter}', {force: true});
+        input.type('twotag{enter}', {force: true});
+        input.type('threetag{enter}', {force: true});
+        input.type('ONETAG{enter}', {force: true});
+        input.type('twotags{enter}', {force: true});
+
+        tagField.get().find('[role="button"] span').should('have.length', 4, {timeout: 10000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', 'onetag');
         tagField.get().find('[role="button"] span').eq(1).should('have.text', 'threetag');
         tagField.get().find('[role="button"] span').eq(2).should('have.text', 'twotag');
         tagField.get().find('[role="button"] span').eq(3).should('have.text', 'twotags');
+
         contentEditor.cancelAndDiscard();
     });
 

--- a/tests/cypress/e2e/contentEditor/tags.cy.ts
+++ b/tests/cypress/e2e/contentEditor/tags.cy.ts
@@ -159,27 +159,39 @@ describe('Tags tests in content editor', () => {
         tagField.get().should('be.visible');
 
         tagField.type('j');
+
         cy.get('[id^="react-select-"][id*="-option-"]', {timeout: 10000})
             .contains('jahia')
-            .scrollIntoView()
+            .scrollIntoView();
+        cy.get('[id^="react-select-"][id*="-option-"]', {timeout: 10000})
+            .contains('jahia')
             .should('be.visible');
+
         cy.get('[id^="react-select-"][id*="-option-"]', {timeout: 10000})
             .contains('j@hia')
-            .scrollIntoView()
+            .scrollIntoView();
+        cy.get('[id^="react-select-"][id*="-option-"]', {timeout: 10000})
+            .contains('j@hia')
             .should('be.visible');
 
         tagField.clear();
         tagField.type('#');
+
         cy.get('[id^="react-select-"][id*="-option-"]', {timeout: 10000})
             .contains('#123')
-            .scrollIntoView()
+            .scrollIntoView();
+        cy.get('[id^="react-select-"][id*="-option-"]', {timeout: 10000})
+            .contains('#123')
             .should('be.visible');
 
         tagField.clear();
         tagField.type('1');
+
         cy.get('[id^="react-select-"][id*="-option-"]', {timeout: 10000})
             .contains('123')
-            .scrollIntoView()
+            .scrollIntoView();
+        cy.get('[id^="react-select-"][id*="-option-"]', {timeout: 10000})
+            .contains('123')
             .should('be.visible');
 
         contentEditor.cancelAndDiscard();

--- a/tests/cypress/e2e/contentEditor/tags.cy.ts
+++ b/tests/cypress/e2e/contentEditor/tags.cy.ts
@@ -63,7 +63,7 @@ describe('Tags tests in content editor', () => {
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         tagField.addNewValue('simpletag');
 
-        tagField.get().find('[role="button"] span').should('have.length', 1, {timeout: 20000});
+        tagField.get().find('[role="button"] span').should('have.length', 1, {timeout: 2000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', 'simpletag');
         contentEditor.cancelAndDiscard();
     });
@@ -78,7 +78,7 @@ describe('Tags tests in content editor', () => {
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         tagField.get().find('input[type="text"]').type('tag1, tag2{enter}', {delay: 500, force: true});
 
-        tagField.get().find('[role="button"] span').should('have.length', 2);
+        tagField.get().find('[role="button"] span').should('have.length', 2, {timeout: 2000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', 'tag1');
         tagField.get().find('[role="button"] span').eq(1).should('have.text', 'tag2');
         contentEditor.cancelAndDiscard();
@@ -94,7 +94,7 @@ describe('Tags tests in content editor', () => {
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         tagField.get().find('input[type="text"]').type('onetag, threeTag, twotag, threetag, ONETAG, twotags{enter}', {delay: 500, force: true});
 
-        tagField.get().find('[role="button"] span').should('have.length', 4);
+        tagField.get().find('[role="button"] span').should('have.length', 4, {timeout: 2000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', 'onetag');
         tagField.get().find('[role="button"] span').eq(1).should('have.text', 'threetag');
         tagField.get().find('[role="button"] span').eq(2).should('have.text', 'twotag');
@@ -112,7 +112,7 @@ describe('Tags tests in content editor', () => {
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         tagField.get().find('input[type="text"]').type('hello,  {enter}', {delay: 500, force: true});
 
-        tagField.get().find('[role="button"] span').should('have.length', 1);
+        tagField.get().find('[role="button"] span').should('have.length', 1, {timeout: 2000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', 'hello');
         contentEditor.cancelAndDiscard();
     });
@@ -127,7 +127,7 @@ describe('Tags tests in content editor', () => {
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         tagField.addNewValue('$ù!é(.=;:/*');
 
-        tagField.get().find('[role="button"] span').should('have.length', 1);
+        tagField.get().find('[role="button"] span').should('have.length', 1, {timeout: 2000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', '$ù!é(.=;:/*');
         contentEditor.cancelAndDiscard();
     });
@@ -139,7 +139,7 @@ describe('Tags tests in content editor', () => {
         const tagField = contentEditor.getField(TagField, 'qant\\:allFieldsMultiple_dynamicChoicelist');
         tagField.addNewValue('squad-qa');
         tagField.addNewValue('team-qa');
-        tagField.get().find('[role="button"] span').should('have.length', 2);
+        tagField.get().find('[role="button"] span').should('have.length', 2, {timeout: 2000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', 'squad-qa');
         tagField.get().find('[role="button"] span').eq(1).should('have.text', 'team-qa');
         contentEditor.cancelAndDiscard();

--- a/tests/cypress/e2e/contentEditor/tags.cy.ts
+++ b/tests/cypress/e2e/contentEditor/tags.cy.ts
@@ -61,10 +61,16 @@ describe('Tags tests in content editor', () => {
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
         const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
-        tagField.addNewValue('simpletag');
+        const input = tagField.get().find('input[type="text"]');
+
+        input.should('be.visible').and('not.be.disabled');
+        input.click({force: true});
+        input.clear({force: true});
+        input.type('simpletag{enter}', {delay: 100, force: true});
 
         tagField.get().find('[role="button"] span').should('have.length', 1, {timeout: 10000});
         tagField.get().find('[role="button"] span').eq(0).should('have.text', 'simpletag');
+
         contentEditor.cancelAndDiscard();
     });
 

--- a/tests/cypress/e2e/contentEditor/tags.cy.ts
+++ b/tests/cypress/e2e/contentEditor/tags.cy.ts
@@ -60,7 +60,7 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
         const input = tagField.get().find('input[type="text"]');
 
         input.should('be.visible').and('not.be.disabled');
@@ -68,8 +68,8 @@ describe('Tags tests in content editor', () => {
         input.clear({force: true});
         input.type('simpletag{enter}', {delay: 100, force: true});
 
-        tagField.get().find('[role="button"] span').should('have.length', 1, {timeout: 10000});
-        tagField.get().find('[role="button"] span').eq(0).should('have.text', 'simpletag');
+        tagField.get().find('[role="button"]').should('have.length', 1, {timeout: 10000});
+        tagField.get().find('[role="button"]').eq(0).should('have.text', 'simpletag');
 
         contentEditor.cancelAndDiscard();
     });
@@ -81,12 +81,12 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
         tagField.get().find('input[type="text"]').type('tag1, tag2{enter}', {delay: 100, force: true});
 
-        tagField.get().find('[role="button"] span').should('have.length', 2, {timeout: 10000});
-        tagField.get().find('[role="button"] span').eq(0).should('have.text', 'tag1');
-        tagField.get().find('[role="button"] span').eq(1).should('have.text', 'tag2');
+        tagField.get().find('[role="button"]').should('have.length', 2, {timeout: 10000});
+        tagField.get().find('[role="button"]').eq(0).should('have.text', 'tag1');
+        tagField.get().find('[role="button"]').eq(1).should('have.text', 'tag2');
         contentEditor.cancelAndDiscard();
     });
 
@@ -97,21 +97,15 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
         const input = tagField.get().find('input[type="text"]');
+        tagField.get().find('input[type="text"]').type('onetag, threeTag, twotag, threetag, ONETAG, twotags{enter}', {delay: 100, force: true});
 
-        input.type('onetag{enter}', {force: true});
-        input.type('threeTag{enter}', {force: true});
-        input.type('twotag{enter}', {force: true});
-        input.type('threetag{enter}', {force: true});
-        input.type('ONETAG{enter}', {force: true});
-        input.type('twotags{enter}', {force: true});
-
-        tagField.get().find('[role="button"] span').should('have.length', 4, {timeout: 10000});
-        tagField.get().find('[role="button"] span').eq(0).should('have.text', 'onetag');
-        tagField.get().find('[role="button"] span').eq(1).should('have.text', 'threetag');
-        tagField.get().find('[role="button"] span').eq(2).should('have.text', 'twotag');
-        tagField.get().find('[role="button"] span').eq(3).should('have.text', 'twotags');
+        tagField.get().find('[role="button"]').should('have.length', 4, {timeout: 10000});
+        tagField.get().find('[role="button"]').eq(0).should('have.text', 'onetag');
+        tagField.get().find('[role="button"]').eq(1).should('have.text', 'threetag');
+        tagField.get().find('[role="button"]').eq(2).should('have.text', 'twotag');
+        tagField.get().find('[role="button"]').eq(3).should('have.text', 'twotags');
 
         contentEditor.cancelAndDiscard();
     });
@@ -123,11 +117,11 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
         tagField.get().find('input[type="text"]').type('hello,  {enter}', {delay: 100, force: true});
 
-        tagField.get().find('[role="button"] span').should('have.length', 1, {timeout: 10000});
-        tagField.get().find('[role="button"] span').eq(0).should('have.text', 'hello');
+        tagField.get().find('[role="button"]').should('have.length', 1, {timeout: 10000});
+        tagField.get().find('[role="button"]').eq(0).should('have.text', 'hello');
         contentEditor.cancelAndDiscard();
     });
 
@@ -138,11 +132,11 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
         tagField.addNewValue('$ù!é(.=;:/*');
 
-        tagField.get().find('[role="button"] span').should('have.length', 1, {timeout: 10000});
-        tagField.get().find('[role="button"] span').eq(0).should('have.text', '$ù!é(.=;:/*');
+        tagField.get().find('[role="button"]').should('have.length', 1, {timeout: 10000});
+        tagField.get().find('[role="button"]').eq(0).should('have.text', '$ù!é(.=;:/*');
         contentEditor.cancelAndDiscard();
     });
 
@@ -150,12 +144,12 @@ describe('Tags tests in content editor', () => {
         const contentEditor = jcontent.editComponentByRowName('allFieldsMultiple');
         contentEditor.switchToAdvancedMode();
 
-        const tagField = contentEditor.getField(TagField, 'qant\\:allFieldsMultiple_dynamicChoicelist');
+        const tagField = contentEditor.getField(TagField, 'qant:allFieldsMultiple_dynamicChoicelist');
         tagField.addNewValue('squad-qa');
         tagField.addNewValue('team-qa');
-        tagField.get().find('[role="button"] span').should('have.length', 2, {timeout: 10000});
-        tagField.get().find('[role="button"] span').eq(0).should('have.text', 'squad-qa');
-        tagField.get().find('[role="button"] span').eq(1).should('have.text', 'team-qa');
+        tagField.get().find('[role="button"]').should('have.length', 2, {timeout: 10000});
+        tagField.get().find('[role="button"]').eq(0).should('have.text', 'squad-qa');
+        tagField.get().find('[role="button"]').eq(1).should('have.text', 'team-qa');
         contentEditor.cancelAndDiscard();
     });
 
@@ -165,8 +159,8 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
-        contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
+        contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
         tagField.get().find('input[type="text"]').type('j', {delay: 100, force: true});
         cy.get('[class*="css-26l3qy-menu"]').scrollIntoView();
         cy.get('[class*="css-26l3qy-menu"]').within(() => {

--- a/tests/cypress/e2e/contentEditor/tags.cy.ts
+++ b/tests/cypress/e2e/contentEditor/tags.cy.ts
@@ -60,17 +60,11 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
-        const input = tagField.get().find('input[type="text"]');
+        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        tagField.addNewValue('simpletag');
 
-        input.should('be.visible').and('not.be.disabled');
-        input.click({force: true});
-        input.clear({force: true});
-        input.type('simpletag{enter}', {delay: 100, force: true});
-
-        tagField.get().find('[role="button"]').should('have.length', 1, {timeout: 10000});
+        tagField.get().find('[role="button"]').should('have.length', 1);
         tagField.get().find('[role="button"]').eq(0).should('have.text', 'simpletag');
-
         contentEditor.cancelAndDiscard();
     });
 
@@ -81,12 +75,13 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
+        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         tagField.get().find('input[type="text"]').type('tag1, tag2{enter}', {delay: 100, force: true});
 
         tagField.get().find('[role="button"]').should('have.length', 2, {timeout: 10000});
         tagField.get().find('[role="button"]').eq(0).should('have.text', 'tag1');
         tagField.get().find('[role="button"]').eq(1).should('have.text', 'tag2');
+
         contentEditor.cancelAndDiscard();
     });
 
@@ -97,14 +92,12 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
-        tagField.get().find('input[type="text"]').type('onetag, threeTag, twotag, threetag, ONETAG, twotags{enter}', {delay: 100, force: true});
+        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        tagField.get().find('input[type="text"]').type('onetag, threeTag, threetag, ONETAG{enter}', {delay: 100, force: true});
 
-        tagField.get().find('[role="button"]').should('have.length', 4, {timeout: 10000});
+        tagField.get().find('[role="button"]').should('have.length', 2, {timeout: 10000});
         tagField.get().find('[role="button"]').eq(0).should('have.text', 'onetag');
         tagField.get().find('[role="button"]').eq(1).should('have.text', 'threetag');
-        tagField.get().find('[role="button"]').eq(2).should('have.text', 'twotag');
-        tagField.get().find('[role="button"]').eq(3).should('have.text', 'twotags');
 
         contentEditor.cancelAndDiscard();
     });
@@ -116,11 +109,12 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
+        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         tagField.get().find('input[type="text"]').type('hello,  {enter}', {delay: 100, force: true});
 
         tagField.get().find('[role="button"]').should('have.length', 1, {timeout: 10000});
         tagField.get().find('[role="button"]').eq(0).should('have.text', 'hello');
+
         contentEditor.cancelAndDiscard();
     });
 
@@ -131,11 +125,12 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
+        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         tagField.addNewValue('$ù!é(.=;:/*');
 
         tagField.get().find('[role="button"]').should('have.length', 1, {timeout: 10000});
         tagField.get().find('[role="button"]').eq(0).should('have.text', '$ù!é(.=;:/*');
+
         contentEditor.cancelAndDiscard();
     });
 
@@ -143,12 +138,14 @@ describe('Tags tests in content editor', () => {
         const contentEditor = jcontent.editComponentByRowName('allFieldsMultiple');
         contentEditor.switchToAdvancedMode();
 
-        const tagField = contentEditor.getField(TagField, 'qant:allFieldsMultiple_dynamicChoicelist');
+        const tagField = contentEditor.getField(TagField, 'qant\\:allFieldsMultiple_dynamicChoicelist');
         tagField.addNewValue('squad-qa');
         tagField.addNewValue('team-qa');
+
         tagField.get().find('[role="button"]').should('have.length', 2, {timeout: 10000});
         tagField.get().find('[role="button"]').eq(0).should('have.text', 'squad-qa');
         tagField.get().find('[role="button"]').eq(1).should('have.text', 'team-qa');
+
         contentEditor.cancelAndDiscard();
     });
 
@@ -158,7 +155,7 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
+        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
         contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
         tagField.get().find('input[type="text"]').type('j', {delay: 100, force: true});
         cy.get('[class*="css-26l3qy-menu"]').scrollIntoView();

--- a/tests/cypress/e2e/contentEditor/tags.cy.ts
+++ b/tests/cypress/e2e/contentEditor/tags.cy.ts
@@ -60,11 +60,12 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
         tagField.addNewValue('simpletag');
 
-        tagField.get().find('[role="button"]').should('have.length', 1);
-        tagField.get().find('[role="button"]').eq(0).should('have.text', 'simpletag');
+        tagField.getTags().should('have.length', 1);
+        tagField.assertTagText('simpletag', 0);
+        contentEditor.cancelAndDiscard();
     });
 
     it('should add multiple tags', () => {
@@ -74,12 +75,14 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
-        tagField.get().find('input[type="text"]').type('tag1, tag2{enter}', {delay: 100, force: true});
+        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
+        tagField.type('tag1, tag2{enter}');
 
-        tagField.get().find('[role="button"]').should('have.length', 2, {timeout: 10000});
-        tagField.get().find('[role="button"]').eq(0).should('have.text', 'tag1');
-        tagField.get().find('[role="button"]').eq(1).should('have.text', 'tag2');
+        tagField.getTags().should('have.length', 2, {timeout: 10000});
+        tagField.assertTagText('tag1', 0);
+        tagField.assertTagText('tag2', 1);
+
+        contentEditor.cancelAndDiscard();
     });
 
     it('should not add duplicate tags', () => {
@@ -89,12 +92,14 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
-        tagField.get().find('input[type="text"]').type('onetag, threeTag, threetag, ONETAG{enter}', {delay: 100, force: true});
+        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
+        tagField.type('onetag, threeTag, threetag, ONETAG{enter}');
 
-        tagField.get().find('[role="button"]').should('have.length', 2, {timeout: 10000});
-        tagField.get().find('[role="button"]').eq(0).should('have.text', 'onetag');
-        tagField.get().find('[role="button"]').eq(1).should('have.text', 'threetag');
+        tagField.getTags().should('have.length', 2, {timeout: 10000});
+        tagField.assertTagText('onetag', 0);
+        tagField.assertTagText('threetag', 1);
+
+        contentEditor.cancelAndDiscard();
     });
 
     it('should not add empty tag', () => {
@@ -104,11 +109,13 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
-        tagField.get().find('input[type="text"]').type('hello,  {enter}', {delay: 100, force: true});
+        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
+        tagField.type('hello,  {enter}');
 
-        tagField.get().find('[role="button"]').should('have.length', 1, {timeout: 10000});
-        tagField.get().find('[role="button"]').eq(0).should('have.text', 'hello');
+        tagField.getTags().should('have.length', 1, {timeout: 10000});
+        tagField.assertTagText('hello', 0);
+
+        contentEditor.cancelAndDiscard();
     });
 
     it('should add a tag with special characters', () => {
@@ -118,43 +125,63 @@ describe('Tags tests in content editor', () => {
         contentEditor.openSection('Classification and Metadata');
         contentEditor.toggleOption('jmix:tagged', 'Tags');
 
-        const tagField = contentEditor.getField(TagField, 'jmix\\:tagged_j\\:tagList');
+        const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
         tagField.addNewValue('$ù!é(.=;:/*');
 
-        tagField.get().find('[role="button"]').should('have.length', 1, {timeout: 10000});
-        tagField.get().find('[role="button"]').eq(0).should('have.text', '$ù!é(.=;:/*');
+        tagField.getTags().should('have.length', 1, {timeout: 10000});
+        tagField.assertTagText('$ù!é(.=;:/*', 0);
+
+        contentEditor.cancelAndDiscard();
     });
 
     it('should add tags in dynamicChoicelist field', () => {
         const contentEditor = jcontent.editComponentByRowName('allFieldsMultiple');
         contentEditor.switchToAdvancedMode();
 
-        const tagField = contentEditor.getField(TagField, 'qant\\:allFieldsMultiple_dynamicChoicelist');
+        const tagField = contentEditor.getField(TagField, 'qant:allFieldsMultiple_dynamicChoicelist');
         tagField.addNewValue('squad-qa');
         tagField.addNewValue('team-qa');
 
-        tagField.get().find('[role="button"]').should('have.length', 2, {timeout: 10000});
-        tagField.get().find('[role="button"]').eq(0).should('have.text', 'squad-qa');
-        tagField.get().find('[role="button"]').eq(1).should('have.text', 'team-qa');
+        tagField.getTags().should('have.length', 2, {timeout: 10000});
+        tagField.assertTagText('squad-qa', 0);
+        tagField.assertTagText('team-qa', 1);
+
+        contentEditor.cancelAndDiscard();
     });
 
     it('should have auto-completion', () => {
-        const contentEditor = jcontent.editComponentByRowName('allFieldsMultiple');
+        const contentEditor = jcontent.editComponentByRowName('allFieldsSimple');
         contentEditor.switchToAdvancedMode();
         contentEditor.openSection('Classification and Metadata');
+        contentEditor.toggleOption('jmix:tagged', 'Tags');
 
         const tagField = contentEditor.getField(TagField, 'jmix:tagged_j:tagList');
         tagField.get().should('be.visible');
 
-        tagField.get().find('input[type="text"]').should('be.visible').type('j', {delay: 100, force: true});
+        tagField.type('j');
+        cy.get('[id^="react-select-"][id*="-option-"]', {timeout: 10000})
+            .contains('jahia')
+            .scrollIntoView()
+            .should('be.visible');
+        cy.get('[id^="react-select-"][id*="-option-"]', {timeout: 10000})
+            .contains('j@hia')
+            .scrollIntoView()
+            .should('be.visible');
 
-        cy.contains('jahia', {timeout: 10000}).should('be.visible');
-        cy.contains('j@hia', {timeout: 10000}).should('be.visible');
+        tagField.clear();
+        tagField.type('#');
+        cy.get('[id^="react-select-"][id*="-option-"]', {timeout: 10000})
+            .contains('#123')
+            .scrollIntoView()
+            .should('be.visible');
 
-        tagField.get().find('input[type="text"]').clear().type('#', {delay: 100, force: true});
-        cy.contains('#123', {timeout: 10000}).should('be.visible');
+        tagField.clear();
+        tagField.type('1');
+        cy.get('[id^="react-select-"][id*="-option-"]', {timeout: 10000})
+            .contains('123')
+            .scrollIntoView()
+            .should('be.visible');
 
-        tagField.get().find('input[type="text"]').clear().type('1', {delay: 100, force: true});
-        cy.contains('123', {timeout: 10000}).should('be.visible');
+        contentEditor.cancelAndDiscard();
     });
 });

--- a/tests/cypress/page-object/contentEditor.ts
+++ b/tests/cypress/page-object/contentEditor.ts
@@ -124,7 +124,7 @@ export class ContentEditor extends BasePage {
 
     cancelAndDiscard() {
         getComponentByRole(Button, 'backButton').click();
-        getComponentByRole(Button, 'close-dialog-discard').click();
+        getComponentByRole(Button, 'close-dialog-discard').get().should('be.visible').click();
     }
 
     addAnotherContent() {

--- a/tests/cypress/page-object/fields/tagField.ts
+++ b/tests/cypress/page-object/fields/tagField.ts
@@ -2,7 +2,7 @@ import {Field} from './field';
 
 export class TagField extends Field {
     addNewValue(text: string): void {
-        this.get().find(`#${this.fieldName}`).type(`${text}{enter}`, {delay: 100});
-        this.get().find(`#${this.fieldName} [role="button"]`).contains(text).should('be.visible');
+        this.get().find('input[type="text"]').type(`${text}{enter}`, {delay: 300, force: true});
+        this.get().find('[role="button"]').contains(text).should('be.visible');
     }
 }

--- a/tests/cypress/page-object/fields/tagField.ts
+++ b/tests/cypress/page-object/fields/tagField.ts
@@ -2,7 +2,7 @@ import {Field} from './field';
 
 export class TagField extends Field {
     addNewValue(text: string): void {
-        this.get().find(`#${this.fieldName}`).type(`${text}{enter}`, {delay: 500});
+        this.get().find(`#${this.fieldName}`).type(`${text}{enter}`, {delay: 100});
         this.get().find(`#${this.fieldName} [role="button"]`).contains(text).should('be.visible');
     }
 }

--- a/tests/cypress/page-object/fields/tagField.ts
+++ b/tests/cypress/page-object/fields/tagField.ts
@@ -1,8 +1,24 @@
 import {Field} from './field';
 
 export class TagField extends Field {
+    type(text: string, options = {delay: 100, force: true}) {
+        return this.get().find('input[type="text"]').type(text, options);
+    }
+
+    clear() {
+        return this.get().find('input[type="text"]').clear();
+    }
+
     addNewValue(text: string): void {
-        this.get().find('input[type="text"]').type(`${text}{enter}`, {delay: 300, force: true});
-        this.get().find('[role="button"]').contains(text).should('be.visible');
+        this.type(`${text}{enter}`);
+        this.getTags().contains(text).should('be.visible');
+    }
+
+    getTags() {
+        return this.get().find('[role="button"]');
+    }
+
+    assertTagText(text: string, index: number): void {
+        this.getTags().eq(index).should('have.text', text);
     }
 }


### PR DESCRIPTION
### Description
Move Selenium tags tests to Cypress.
It includes: 
- testDynamicChoicelist
- testTagAutocompletion
- added other testcases in bonus.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
