### PR TITLE
fix: Handle template redirection correctly

### DIFF
--- a/.chachalog/VGkEM-Go.md
+++ b/.chachalog/VGkEM-Go.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Handle template redirection corectly (#2279)

--- a/.chachalog/VGkEM-Go.md
+++ b/.chachalog/VGkEM-Go.md
@@ -3,4 +3,4 @@
 "@jahia/jcontent": minor
 ---
 
-Handle template redirection corectly (#2279)
+Fix redirection issue in page builder when system name contains . (#2279)

--- a/src/javascript/JContent/redux/JContent.redux.js
+++ b/src/javascript/JContent/redux/JContent.redux.js
@@ -26,10 +26,6 @@ const apps = {
             const accordion = registry.get('accordionItem', mode);
             const viewMode = localStorage.getItem('jcontent-previous-tableView-viewMode-' + site + '-' + mode) || accordion?.tableConfig?.defaultViewMode || 'flatList';
             let template = '';
-            if (viewMode === JContentConstants.tableView.viewMode.PAGE_BUILDER && path.lastIndexOf('.') > 0) {
-                template = path.substring(path.lastIndexOf('.') + 1);
-                path = path.substring(0, path.lastIndexOf('.'));
-            }
 
             if (params.template) {
                 template = params.template;

--- a/tests/cypress/e2e/jcontent/navigation.cy.ts
+++ b/tests/cypress/e2e/jcontent/navigation.cy.ts
@@ -140,20 +140,22 @@ describe('Content navigation', () => {
     // Template extraction was originally restricted to PageBuilder in https://github.com/Jahia/jcontent/pull/1739
     // It was removed since the issue is no longer reproducible. This test was added to catch any regression.
     it('can navigate to a page with ".something" suffix when ".something" does not match a template', () => {
+        const timeout = {timeout: 3000};
         const jc = JContent.visit('mySite1', 'en', 'pages/home/notemplate.my');
-        cy.get('h1', {timeout: 3000}).should('contain', 'page with non-template');
+        cy.get('h1', timeout).should('contain', 'page with non-template');
 
         jc.getAccordionItem('pages').getTreeItem('home').click();
 
-        cy.get('h1', {timeout: 3000}).should('contain', 'Home');
+        cy.get('h1', timeout).should('contain', 'Home');
 
         jc.getAccordionItem('pages').getTreeItem('notemplate.my').click();
 
-        cy.get('h1', {timeout: 3000}).should('contain', 'page with non-template');
+        cy.get('h1', timeout).should('contain', 'page with non-template');
     });
 
     // This tests this issue: https://github.com/Jahia/jira-archives/issues/15703
     it('can navigate with a link that contains a template suffix', () => {
+        const timeout = {timeout: 3000};
         const jc = JContent.visit('mySite1', 'en', 'pages/home/notemplate.my');
         const pb = jc.switchToPageBuilder();
         const module = pb.getModule('/sites/mySite1/home/notemplate.my/landing', false);
@@ -166,7 +168,7 @@ describe('Content navigation', () => {
         contentEditor.create();
 
         // The link will end like this: ...pressEntry.pressdetail.html so successful navigation confirms that the template part is handled correctly
-        pb.iframe().get().find('a').contains('pressEntry').click();
-        cy.get('h1', {timeout: 3000}).should('contain', 'pressEntry');
+        pb.iframe().get().find('a', timeout).contains('pressEntry', timeout).click();
+        cy.get('h1', timeout).should('contain', 'pressEntry');
     });
 });

--- a/tests/cypress/e2e/jcontent/navigation.cy.ts
+++ b/tests/cypress/e2e/jcontent/navigation.cy.ts
@@ -168,6 +168,10 @@ describe('Content navigation', () => {
         contentEditor.create();
 
         // The link will end like this: ...pressEntry.pressdetail.html so successful navigation confirms that the template part is handled correctly
+        cy.waitUntil(() =>
+            pb.iframe().get().find('a').contains('pressEntry').then($el => $el.length > 0),
+        {interval: 500, ...timeout}
+        );
         pb.iframe().get().find('a', timeout).contains('pressEntry', timeout).click();
         cy.get('h1', timeout).should('contain', 'pressEntry');
     });

--- a/tests/cypress/e2e/jcontent/navigation.cy.ts
+++ b/tests/cypress/e2e/jcontent/navigation.cy.ts
@@ -167,6 +167,7 @@ describe('Content navigation', () => {
         contentEditor.getRichTextField('jnt:press_body').type('random text');
         contentEditor.create();
 
+        cy.wait(5000);
         cy.frameLoaded('[data-sel-role="page-builder-frame-active"]');
 
         // The link will end like this: ...pressEntry.pressdetail.html so successful navigation confirms that the template part is handled correctly

--- a/tests/cypress/e2e/jcontent/navigation.cy.ts
+++ b/tests/cypress/e2e/jcontent/navigation.cy.ts
@@ -139,7 +139,7 @@ describe('Content navigation', () => {
 
     // Template extraction was originally restricted to PageBuilder in https://github.com/Jahia/jcontent/pull/1739
     // It was removed since the issue is no longer reproducible. This test was added to catch any regression.
-    it('can navigate to a page with ".something" postfix when ".something" does not match a template', () => {
+    it('can navigate to a page with ".something" suffix when ".something" does not match a template', () => {
         const jc = JContent.visit('mySite1', 'en', 'pages/home/notemplate.my');
         cy.get('h1', {timeout: 3000}).should('contain', 'page with non-template');
 
@@ -153,7 +153,7 @@ describe('Content navigation', () => {
     });
 
     // This tests this issue: https://github.com/Jahia/jira-archives/issues/15703
-    it('can navigate with a link that contains a template postfix', () => {
+    it('can navigate with a link that contains a template suffix', () => {
         const jc = JContent.visit('mySite1', 'en', 'pages/home/notemplate.my');
         const pb = jc.switchToPageBuilder();
         const module = pb.getModule('/sites/mySite1/home/notemplate.my/landing', false);

--- a/tests/cypress/e2e/jcontent/navigation.cy.ts
+++ b/tests/cypress/e2e/jcontent/navigation.cy.ts
@@ -14,6 +14,7 @@ describe('Content navigation', () => {
         });
         enableModule('jcontent-test-module', 'mySite1');
         enableModule('events', 'mySite1');
+        enableModule('press', 'mySite1');
         addNode({parentPathOrId: '/sites/mySite1/contents', primaryNodeType: 'jnt:event', name: 'test-event'});
         addNode({
             name: specialCharsName,
@@ -21,6 +22,15 @@ describe('Content navigation', () => {
             primaryNodeType: 'jnt:page',
             properties: [
                 {name: 'jcr:title', value: 'special chars page', language: 'en'},
+                {name: 'j:templateName', value: '2-column'}
+            ]
+        });
+        addNode({
+            name: 'notemplate.my',
+            parentPathOrId: '/sites/mySite1/home',
+            primaryNodeType: 'jnt:page',
+            properties: [
+                {name: 'jcr:title', value: 'page with non-template', language: 'en'},
                 {name: 'j:templateName', value: '2-column'}
             ]
         });
@@ -125,5 +135,38 @@ describe('Content navigation', () => {
         const cardRow = jc.getGrid().getCardByName('bootstrap');
         cardRow.get().dblclick();
         cy.get('h1').contains('bootstrap');
+    });
+
+    // Template extraction was originally restricted to PageBuilder in https://github.com/Jahia/jcontent/pull/1739
+    // It was removed since the issue is no longer reproducible. This test was added to catch any regression.
+    it('can navigate to a page with ".something" postfix when ".something" does not match a template', () => {
+        const jc = JContent.visit('mySite1', 'en', 'pages/home/notemplate.my');
+        cy.get('h1', {timeout: 3000}).should('contain', 'page with non-template');
+
+        jc.getAccordionItem('pages').getTreeItem('home').click();
+
+        cy.get('h1', {timeout: 3000}).should('contain', 'Home');
+
+        jc.getAccordionItem('pages').getTreeItem('notemplate.my').click();
+
+        cy.get('h1', {timeout: 3000}).should('contain', 'page with non-template');
+    });
+
+    // This tests this issue: https://github.com/Jahia/jira-archives/issues/15703
+    it('can navigate with a link that contains a template postfix', () => {
+        const jc = JContent.visit('mySite1', 'en', 'pages/home/notemplate.my');
+        const pb = jc.switchToPageBuilder();
+        const module = pb.getModule('/sites/mySite1/home/notemplate.my/landing', false);
+        module.getHeader(false).get().click();
+        module.getCreateButtons().getInsertionButtonByIndex(1).click();
+
+        const contentEditor = jc.getCreateContent().getContentTypeSelector().searchForContentType('jnt:press').selectContentType('jnt:press').create();
+        contentEditor.getSmallTextField('jnt:press_jcr:title').addNewValue('pressEntry');
+        contentEditor.getRichTextField('jnt:press_body').type('random text');
+        contentEditor.create();
+
+        // The link will end like this: ...pressEntry.pressdetail.html so successful navigation confirms that the template part is handled correctly
+        pb.iframe().get().find('a').contains('pressEntry').click();
+        cy.get('h1', {timeout: 3000}).should('contain', 'pressEntry');
     });
 });

--- a/tests/cypress/e2e/jcontent/navigation.cy.ts
+++ b/tests/cypress/e2e/jcontent/navigation.cy.ts
@@ -155,7 +155,7 @@ describe('Content navigation', () => {
 
     // This tests this issue: https://github.com/Jahia/jira-archives/issues/15703
     it('can navigate with a link that contains a template suffix', () => {
-        const timeout = {timeout: 3000};
+        const timeout = {timeout: 10000};
         const jc = JContent.visit('mySite1', 'en', 'pages/home/notemplate.my');
         const pb = jc.switchToPageBuilder();
         const module = pb.getModule('/sites/mySite1/home/notemplate.my/landing', false);
@@ -166,6 +166,8 @@ describe('Content navigation', () => {
         contentEditor.getSmallTextField('jnt:press_jcr:title').addNewValue('pressEntry');
         contentEditor.getRichTextField('jnt:press_body').type('random text');
         contentEditor.create();
+
+        cy.frameLoaded('[data-sel-role="page-builder-frame-active"]');
 
         // The link will end like this: ...pressEntry.pressdetail.html so successful navigation confirms that the template part is handled correctly
         cy.waitUntil(() =>

--- a/tests/cypress/e2e/jcontent/navigation.cy.ts
+++ b/tests/cypress/e2e/jcontent/navigation.cy.ts
@@ -156,8 +156,8 @@ describe('Content navigation', () => {
     // This tests this issue: https://github.com/Jahia/jira-archives/issues/15703
     it('can navigate with a link that contains a template suffix', () => {
         const timeout = {timeout: 10000};
-        const jc = JContent.visit('mySite1', 'en', 'pages/home/notemplate.my');
-        const pb = jc.switchToPageBuilder();
+        let jc = JContent.visit('mySite1', 'en', 'pages/home/notemplate.my');
+        let pb = jc.switchToPageBuilder();
         const module = pb.getModule('/sites/mySite1/home/notemplate.my/landing', false);
         module.getHeader(false).get().click();
         module.getCreateButtons().getInsertionButtonByIndex(1).click();
@@ -167,8 +167,11 @@ describe('Content navigation', () => {
         contentEditor.getRichTextField('jnt:press_body').type('random text');
         contentEditor.create();
 
-        cy.wait(5000);
-        cy.frameLoaded('[data-sel-role="page-builder-frame-active"]');
+        // On CI it fails to grab that pressEntry link, even though it exists, because there is a delay, the iframe and
+        // the rest of the structure exists, but I think it gets the wrong instance of the iframe, the one without the link.
+        // Only hardcoded wait worked, to avoid it I navigate to the page again.
+        jc = JContent.visit('mySite1', 'en', 'pages/home/notemplate.my');
+        pb = jc.switchToPageBuilder();
 
         // The link will end like this: ...pressEntry.pressdetail.html so successful navigation confirms that the template part is handled correctly
         cy.waitUntil(() =>


### PR DESCRIPTION
### Description
Do not resolve template from path. This changes the work done here: https://github.com/Jahia/jira-archives/issues/15703 and here https://github.com/Jahia/jcontent/pull/1739. Template resolves correctly now and is passed via params.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
