### PR TITLE
fix: keep dynamic fieldsets in editForm response to restore addMixin mechanism

### DIFF
--- a/.chachalog/J1w1ve8_.md
+++ b/.chachalog/J1w1ve8_.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Fixed `addMixin` choicelist property so it correctly applies mixins that have no visible fields when saving content. (#2281)

--- a/.github/workflows/weekly-cluster.yml
+++ b/.github/workflows/weekly-cluster.yml
@@ -43,6 +43,7 @@ jobs:
           tests_profile: ${{ matrix.config_file }}
           should_use_build_artifacts: false
           should_skip_artifacts: true
+          docker_compose_file: 'docker-compose-cluster.yml'
           should_skip_notifications: false
           should_skip_testrail: false
           github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
@@ -217,7 +217,7 @@ public class EditorFormServiceImpl implements EditorFormService {
                         .filter(Field::isVisible)
                         .collect(Collectors.toList()));
 
-                    fieldSet.setVisible(fieldSet.isVisible() && (fieldSet.isHasEnableSwitch() || fieldSet.getFields().stream().anyMatch(Field::isVisible)));
+                    fieldSet.setVisible(fieldSet.isVisible() && (fieldSet.isDynamic() || fieldSet.getFields().stream().anyMatch(Field::isVisible)));
                 }
 
                 // Remove empty fieldSets - only keep empty dynamic field set which do not have matching mixin in another section

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
@@ -217,14 +217,21 @@ public class EditorFormServiceImpl implements EditorFormService {
                         .filter(Field::isVisible)
                         .collect(Collectors.toList()));
 
-                    fieldSet.setVisible(fieldSet.isVisible() && (fieldSet.isDynamic() || fieldSet.getFields().stream().anyMatch(Field::isVisible)));
+                    fieldSet.setVisible(fieldSet.isVisible() && (fieldSet.isHasEnableSwitch() || fieldSet.getFields().stream().anyMatch(Field::isVisible)));
                 }
 
-                // Remove empty fieldSets - only keep empty dynamic field set which do not have matching mixin in another section
-                // (if the dynamic mixin is present in multiple sections, keep only the non-empty ones)
+                /*
+                 * Keep fieldSets that passes one of the following criteria:
+                 *  - Always present
+                 *  - Dynamic and unique to this section
+                 *    - Dynamic single-occurrence fieldsets are always kept — this includes jmix:templateMixin fieldsets
+                 *      with no visible fields that are needed for addMixin tracking even though visible=false
+                 *  - Visible and non-empty.
+                 */
                 section.setFieldSets(section.getFieldSets().stream()
-                    .filter(fs -> fs.isAlwaysPresent() != null && fs.isAlwaysPresent() || fs.isVisible())
-                    .filter(fs -> (fs.isDynamic() && fieldSetsMap.get(fs.getName()).size() == 1) || !fs.getFields().isEmpty() || (fs.isAlwaysPresent() != null && fs.isAlwaysPresent()))
+                    .filter(fs -> (fs.isAlwaysPresent() != null && fs.isAlwaysPresent())
+                        || (fs.isDynamic() && fieldSetsMap.get(fs.getName()).size() == 1)
+                        || (fs.isVisible() && !fs.getFields().isEmpty()))
                     .collect(Collectors.toList()));
 
                 section.setVisible(section.isVisible() && section.getFieldSets().stream().anyMatch(FieldSet::isVisible));

--- a/tests/cypress.config.common.ts
+++ b/tests/cypress.config.common.ts
@@ -34,16 +34,21 @@ export const baseConfig = {
                 }
             });
 
-            // Clean up videos for passing tests
-            on('after:spec', (spec, results) => {
-                if (results?.video) {
-                    const failures = results.tests.some(test =>
-                        test.attempts.some(attempt => attempt.state === 'failed')
-                    );
-                    if (!failures) {
-                        // Delete video asynchronously to avoid blocking
-                        fs.promises.unlink(results.video).catch(() => {});
-                    }
+            // Clean up videos for passing tests after compression has finished
+            on('after:run', results => {
+                if (results && 'runs' in results) {
+                    const deletions = results.runs.flatMap(run => {
+                        if (run.video && run.stats.failures === 0) {
+                            const compressedPath = run.video.replace(/\.mp4$/, '-compressed.mp4');
+                            return [
+                                fs.promises.unlink(run.video).catch(() => {}),
+                                fs.promises.unlink(compressedPath).catch(() => {})
+                            ];
+                        }
+
+                        return [];
+                    });
+                    return Promise.all(deletions);
                 }
             });
 

--- a/tests/cypress/e2e/selectorTypes/choicelistInitializers.cy.ts
+++ b/tests/cypress/e2e/selectorTypes/choicelistInitializers.cy.ts
@@ -40,6 +40,11 @@ describe('ChoiceList initializers tests', () => {
             name: 'choicelistMultiple',
             primaryNodeType: 'qant:choicelist'
         });
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: 'emptyTemplateMixinTest',
+            primaryNodeType: 'cent:emptyTemplateMixinTest'
+        });
     });
 
     beforeEach(() => {
@@ -180,5 +185,42 @@ describe('ChoiceList initializers tests', () => {
             .and('include', 'img2.png');
         contentEditor.getField(ChoiceListField, 'qant:choicelist_imageList').selectValue('img2');
         contentEditor.getChoiceListField('qant:choicelist_imageList').assertSelected('Image 2');
+    });
+
+    // Regression test for jahia-private#4940:
+    // addMixin choicelist must apply jmix:templateMixin even when the mixin has no visible properties.
+    // Before the fix, such fieldsets were stripped from the GraphQL response, causing the mixin to
+    // never appear in getMixinsToMutate() and silently failing on save.
+    it('should apply jmix:templateMixin with no visible fields via addMixin choicelist (regression #4940)', () => {
+        const nodePath = `/sites/${siteKey}/contents/emptyTemplateMixinTest`;
+
+        // Select mixin1 and save — the mixin has no visible fields so the fieldset has visible=false
+        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+        const contentEditor = jcontent.editComponentByRowName('emptyTemplateMixinTest');
+        contentEditor.getField(ChoiceListField, 'cent:emptyTemplateMixinTest_type').selectValue('mixin1');
+        contentEditor.save();
+
+        cy.apollo({
+            queryFile: 'jcontent/getMixinTypes.graphql',
+            variables: {path: nodePath}
+        }).should(resp => {
+            const mixinNames = resp?.data?.jcr.nodeByPath.mixinTypes.map((m: {name: string}) => m.name);
+            expect(mixinNames).to.include('cemix:emptyTemplateMixin1');
+        });
+
+        // Switch to mixin2 — mixin1 should be removed and mixin2 added
+        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+        const contentEditor2 = jcontent.editComponentByRowName('emptyTemplateMixinTest');
+        contentEditor2.getField(ChoiceListField, 'cent:emptyTemplateMixinTest_type').selectValue('mixin2');
+        contentEditor2.save();
+
+        cy.apollo({
+            queryFile: 'jcontent/getMixinTypes.graphql',
+            variables: {path: nodePath}
+        }).should(resp => {
+            const mixinNames = resp?.data?.jcr.nodeByPath.mixinTypes.map((m: {name: string}) => m.name);
+            expect(mixinNames).to.include('cemix:emptyTemplateMixin2');
+            expect(mixinNames).to.not.include('cemix:emptyTemplateMixin1');
+        });
     });
 });

--- a/tests/cypress/page-object/contentEditor.ts
+++ b/tests/cypress/page-object/contentEditor.ts
@@ -125,6 +125,7 @@ export class ContentEditor extends BasePage {
     cancelAndDiscard() {
         getComponentByRole(Button, 'backButton').click();
         getComponentByRole(Button, 'close-dialog-discard').click();
+        getComponentByRole(Button, 'backButton').get().should('not.exist', {timeout: 5000});
     }
 
     addAnotherContent() {

--- a/tests/docker-compose-cluster.yml
+++ b/tests/docker-compose-cluster.yml
@@ -54,6 +54,82 @@ services:
         depends_on:
             - mariadb
 
+    jahia-browsing-a:
+        image: '${JAHIA_IMAGE}'
+        container_name: jahia-browsing-a
+        restart: 'no'
+        profiles:
+            - cluster
+        deploy:
+            resources:
+                limits:
+                    memory: 4gb
+        depends_on:
+            - mariadb
+            - jahia
+        networks:
+            - stack
+        ports:
+            - '8081:8080'
+            - '8102:8101'
+        environment:
+            jahia_cfg_karaf_remoteShellHost: 0.0.0.0
+            DB_VENDOR: mariadb
+            DB_HOST: mariadb
+            DB_NAME: jahia
+            DB_USER: jahia
+            DB_PASS: jahia
+            JAHIA_LICENSE: ${JAHIA_LICENSE}
+            SUPER_USER_PASSWORD: ${JAHIA_PASSWORD}
+            CLUSTER_ENABLED: ${JAHIA_CLUSTER_ENABLED}
+            PROCESSING_SERVER: 'false'
+            PROCESSING_HOST: jahia
+            MAX_RAM_PERCENTAGE: 80
+            JAHIA_PROPERTIES: ${JAHIA_PROPERTIES}
+            CATALINA_OPTS: ${CATALINA_OPTS}
+            RESTORE_MODULE_STATES: 'false'
+            NEXUS_USERNAME: ${NEXUS_USERNAME}
+            NEXUS_PASSWORD: ${NEXUS_PASSWORD}
+            TZ: ${TIMEZONE}
+
+    jahia-browsing-b:
+        image: '${JAHIA_IMAGE}'
+        profiles:
+            - cluster
+        container_name: jahia-browsing-b
+        restart: 'no'
+        deploy:
+            resources:
+                limits:
+                    memory: 4gb
+        depends_on:
+            - mariadb
+            - jahia
+        networks:
+            - stack
+        ports:
+            - '8082:8080'
+            - '8103:8101'
+        environment:
+            jahia_cfg_karaf_remoteShellHost: 0.0.0.0
+            DB_VENDOR: mariadb
+            DB_HOST: mariadb
+            DB_NAME: jahia
+            DB_USER: jahia
+            DB_PASS: jahia
+            JAHIA_LICENSE: ${JAHIA_LICENSE}
+            SUPER_USER_PASSWORD: ${JAHIA_PASSWORD}
+            CLUSTER_ENABLED: ${JAHIA_CLUSTER_ENABLED}
+            PROCESSING_SERVER: 'false'
+            PROCESSING_HOST: jahia
+            MAX_RAM_PERCENTAGE: 80
+            JAHIA_PROPERTIES: ${JAHIA_PROPERTIES}
+            CATALINA_OPTS: ${CATALINA_OPTS}
+            RESTORE_MODULE_STATES: 'false'
+            TZ: ${TIMEZONE}
+            NEXUS_USERNAME: ${NEXUS_USERNAME}
+            NEXUS_PASSWORD: ${NEXUS_PASSWORD}
+
     cypress:
         profiles: ["test"]
         image: '${TESTS_IMAGE}'

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -193,3 +193,14 @@
 - double2 (double)
 - double3 (double)
 - longReq (long) mandatory
+
+// Regression test types for jahia-private#4940:
+// jmix:templateMixin with NO visible properties must still be applied via addMixin choicelist
+[cent:emptyTemplateMixinTest] > jnt:content, jmix:basicContent, jmix:editorialContent
+ - type (string, choicelist) < 'mixin1', 'mixin2'
+
+[cemix:emptyTemplateMixin1] > jmix:templateMixin mixin
+ extends = cent:emptyTemplateMixinTest
+
+[cemix:emptyTemplateMixin2] > jmix:templateMixin mixin
+ extends = cent:emptyTemplateMixinTest

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/jahia-content-editor-forms/forms/cent_emptyTemplateMixinTest.json
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/jahia-content-editor-forms/forms/cent_emptyTemplateMixinTest.json
@@ -1,0 +1,31 @@
+{
+  "nodeType": "cent:emptyTemplateMixinTest",
+  "priority": 1.0,
+  "sections": [
+    {
+      "name": "content",
+      "fieldSets": [
+        {
+          "name": "cent:emptyTemplateMixinTest",
+          "fields": [
+            {
+              "name": "type",
+              "valueConstraints": [
+                {
+                  "displayValue": "Mixin 1",
+                  "value": {"type": "String", "value": "mixin1"},
+                  "propertyList": [{"name": "addMixin", "value": "cemix:emptyTemplateMixin1"}]
+                },
+                {
+                  "displayValue": "Mixin 2",
+                  "value": {"type": "String", "value": "mixin2"},
+                  "propertyList": [{"name": "addMixin", "value": "cemix:emptyTemplateMixin2"}]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Empty `jmix:templateMixin` fieldsets (`hasEnableSwitch=false`) were filtered out of the GraphQL response by the visibility logic introduced in BACKLOG-21449 (commit `1871f272`, PR #999).
- As a result, the frontend's `getDynamicFieldSets()` had no knowledge of these fieldsets, and `getMixinsToMutate()` never included them at save time — silently breaking the `addMixin` choicelist mechanism.
- This regression only affects mixins that extend `jmix:templateMixin` and have no visible properties (all hidden or none declared).

## Root cause

`EditorFormServiceImpl` line 220 (before fix):
```java
fieldSet.setVisible(fieldSet.isVisible() && (fieldSet.isHasEnableSwitch() || fieldSet.getFields().stream().anyMatch(Field::isVisible)));
```
For a `jmix:templateMixin` mixin with no visible fields: `hasEnableSwitch=false` + `fields.isEmpty()=true` → `visible=false` → filtered out → frontend never sees it.

## Fix

Replace `isHasEnableSwitch()` with `isDynamic()` in the visibility condition:
```java
fieldSet.setVisible(fieldSet.isVisible() && (fieldSet.isDynamic() || fieldSet.getFields().stream().anyMatch(Field::isVisible)));
```

A dynamic fieldset must always be included in the response — even when empty — because it may be activated programmatically via `addMixin`. The frontend's display filter (`filterFieldSets`) already handles not rendering inactive dynamic fieldsets, so there is no visual regression.

Non-dynamic empty fieldsets continue to be filtered out as before.

## Verification

- Worked correctly on Jahia 8.1.6.2 (predates [BACKLOG-21449](https://github.com/Jahia/jcontent/pull/999/changes/86824acb191f824c33c0d5589307d644d09e6b68))
- Broken on all versions after commit `1871f272` when using `jmix:templateMixin` mixins with no visible fields and the `addMixin` choicelist mechanism

Closes https://github.com/Jahia/jahia-private/issues/4940