### PR TITLE
fix: removed seo permission from visibility tab and hardeded components for nulls

### DIFF
--- a/.chachalog/_u2yAwRr.md
+++ b/.chachalog/_u2yAwRr.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": patch
+---
+
+Removed seo permission from visibility tab and hardeded components for nulls (#2289)

--- a/.chachalog/_u2yAwRr.md
+++ b/.chachalog/_u2yAwRr.md
@@ -3,4 +3,4 @@
 "@jahia/jcontent": patch
 ---
 
-Removed seo permission from visibility tab and hardeded components for nulls (#2289)
+Visibility tab is now correctly gated by `viewVisibilityTab` instead of `viewSeoTab`; existing roles that had `viewSeoTab` are auto-granted `viewVisibilityTab` via a startup patch so they keep their access (#2289)

--- a/src/javascript/ContentEditor/editorTabs/AdvancedOptions/Visibility/Channels/Channels.jsx
+++ b/src/javascript/ContentEditor/editorTabs/AdvancedOptions/Visibility/Channels/Channels.jsx
@@ -25,8 +25,12 @@ const filterRegularFieldSets = fieldSets => {
 export const Channels = () => {
     const {sections} = useContentEditorSectionContext();
 
-    const section = sections.filter(s => s.name === 'visibility');
-    const fieldSets = filterRegularFieldSets(section[0].fieldSets);
+    const section = sections.find(s => s.name === 'visibility');
+    if (!section) {
+        return null;
+    }
+
+    const fieldSets = filterRegularFieldSets(section.fieldSets);
 
     if (fieldSets.length === 0) {
         return null;

--- a/src/javascript/ContentEditor/editorTabs/AdvancedOptions/Visibility/DateTime/DateTime.jsx
+++ b/src/javascript/ContentEditor/editorTabs/AdvancedOptions/Visibility/DateTime/DateTime.jsx
@@ -58,9 +58,14 @@ function render(props, t) {
 export const DateTime = ({rules, refresh}) => {
     const {t} = useTranslation('jcontent');
     const {sections} = useContentEditorSectionContext();
-    const section = sections.filter(s => s.name === 'visibility');
-    const fieldSets = filterRegularFieldSets(section[0].fieldSets);
+    const section = sections.find(s => s.name === 'visibility');
     const [activatedSection, setActivatedSection] = useState(rules > 0);
+
+    if (!section) {
+        return null;
+    }
+
+    const fieldSets = filterRegularFieldSets(section.fieldSets);
 
     if (fieldSets.length === 0) {
         return null;

--- a/src/javascript/ContentEditor/editorTabs/AdvancedOptions/Visibility/Languages/Languages.jsx
+++ b/src/javascript/ContentEditor/editorTabs/AdvancedOptions/Visibility/Languages/Languages.jsx
@@ -55,8 +55,7 @@ export const Languages = ({invalidLanguages}) => {
         uiLanguage: uiLanguage
     });
     const [activatedSection, setActivatedSection] = useState(invalidLanguages !== undefined && invalidLanguages.length > 0);
-    const section = sections.filter(s => s.name === 'visibility');
-    const fieldSets = filterRegularFieldSets(section[0].fieldSets);
+    const section = sections.find(s => s.name === 'visibility');
     const handleChange = () => {
         setActivatedSection(!activatedSection);
     };
@@ -64,6 +63,12 @@ export const Languages = ({invalidLanguages}) => {
     if (error || loading) {
         return null;
     }
+
+    if (!section) {
+        return null;
+    }
+
+    const fieldSets = filterRegularFieldSets(section.fieldSets);
 
     if (fieldSets.length === 0) {
         return null;

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/nt_base.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/nt_base.json
@@ -82,8 +82,7 @@
     {
       "name": "visibility",
       "labelKey": "label.engineTab.visibility",
-      "rank": 8.0,
-      "requiredPermission": "viewSeoTab"
+      "rank": 8.0
     },
     {
       "name": "permissions",

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/nt_base.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/nt_base.json
@@ -82,7 +82,8 @@
     {
       "name": "visibility",
       "labelKey": "label.engineTab.visibility",
-      "rank": 8.0
+      "rank": 8.0,
+      "requiredPermission": "viewVisibilityTab"
     },
     {
       "name": "permissions",

--- a/src/main/resources/META-INF/patches/groovy/03-grantViewVisibilityTabPermission.started.groovy
+++ b/src/main/resources/META-INF/patches/groovy/03-grantViewVisibilityTabPermission.started.groovy
@@ -1,0 +1,74 @@
+import org.jahia.services.content.JCRCallback
+import org.jahia.services.content.JCRSessionWrapper
+import org.jahia.services.content.JCRTemplate
+
+import javax.jcr.NodeIterator
+import javax.jcr.RepositoryException
+
+SOURCE_PERMISSION = "viewSeoTab"
+TARGET_PERMISSION = "viewVisibilityTab"
+PROP = "j:permissionNames"
+ROLES_ROOT = "/roles"
+
+def hasPermission(node, String propName, String value) {
+    if (!node.hasProperty(propName)) {
+        return false
+    }
+    return node.getProperty(propName).getValues().any { it.getString() == value }
+}
+
+def ensureValueInMultiProp(node, String propName, String valueToAdd) {
+    if (node.hasProperty(propName)) {
+        def values = node.getProperty(propName).getValues()
+        if (values.any { it.getString() == valueToAdd }) {
+            return false
+        }
+        node.getProperty(propName).addValue(valueToAdd)
+    } else {
+        node.setProperty(propName, [valueToAdd] as String[])
+    }
+    return true
+}
+
+def visit(node, Closure work) {
+    work(node)
+    NodeIterator it = node.getNodes()
+    while (it.hasNext()) {
+        visit(it.nextNode(), work)
+    }
+}
+
+def grantViewVisibilityWhereSeoExists() {
+    JCRTemplate.getInstance().doExecuteWithSystemSession(new JCRCallback<Void>() {
+
+        @Override
+        Void doInJCR(JCRSessionWrapper session) throws RepositoryException {
+            if (!session.nodeExists(ROLES_ROOT)) {
+                log.warn("${ROLES_ROOT} not found — skipping ${TARGET_PERMISSION} migration")
+                return null
+            }
+            log.info("Granting ${TARGET_PERMISSION} to every role node that has ${SOURCE_PERMISSION}...")
+            int changed = 0
+            visit(session.getNode(ROLES_ROOT)) { node ->
+                try {
+                    if (hasPermission(node, PROP, SOURCE_PERMISSION)
+                            && ensureValueInMultiProp(node, PROP, TARGET_PERMISSION)) {
+                        log.info("Added ${TARGET_PERMISSION} to ${node.getPath()}")
+                        changed++
+                    }
+                } catch (RepositoryException e) {
+                    log.error("Error processing node: ${node.getPath()}", e)
+                }
+            }
+            if (changed > 0) {
+                session.save()
+                log.info("${TARGET_PERMISSION} migration applied to ${changed} node(s).")
+            } else {
+                log.info("No nodes needed updating — ${TARGET_PERMISSION} already aligned with ${SOURCE_PERMISSION}.")
+            }
+            return null
+        }
+    })
+}
+
+grantViewVisibilityWhereSeoExists()


### PR DESCRIPTION
### Description
This PR removes the SEO permission from the visibility tab and adds null checks to a few components.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
