### PR TITLE
fix: Update permission scripts to ensure permissions added to right nodes

### DIFF
--- a/.chachalog/-uMt2QI8.md
+++ b/.chachalog/-uMt2QI8.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Update permission scripts to ensure jContentAccordions is added to right nodes (#2291)

--- a/src/main/resources/META-INF/patches/groovy/01-permissions.started.groovy
+++ b/src/main/resources/META-INF/patches/groovy/01-permissions.started.groovy
@@ -5,27 +5,39 @@ import org.jahia.services.content.JCRTemplate
 import javax.jcr.RepositoryException
 
 def updateAccordionPermissions() {
-    JCRTemplate.getInstance().doExecuteWithSystemSession (new JCRCallback<Void>(){
+    JCRTemplate.getInstance().doExecuteWithSystemSession(new JCRCallback<Void>() {
 
         @Override
         Void doInJCR(JCRSessionWrapper jcrSessionWrapper) throws RepositoryException {
-            log.info("Updating permissions for jContentAccordions...");
-            def roleNames = List.of("editor", "reviewer", "translator");
-            roleNames.stream().forEach(roleName -> {
+            log.info("Updating permissions for jContentAccordions...")
+            def roleNames = List.of("editor", "reviewer", "translator")
+            roleNames.forEach(roleName -> {
                 try {
-                    def role = jcrSessionWrapper.getNode("/roles/" + roleName);
-                    if (role != null) {
-                        log.info("Adding jContentAccordions permission to role: " + roleName);
-                        role.getProperty("j:permissionNames").addValue("jContentAccordions");
+                    def rolePath = "/roles/" + roleName
+                    if (!jcrSessionWrapper.nodeExists(rolePath)) {
+                        log.warn("Role node not found: " + rolePath)
+                        return
+                    }
+                    def role = jcrSessionWrapper.getNode(rolePath)
+                    if (!role.hasNode("currentSite-access")) {
+                        log.warn("currentSite-access child not found under role: " + roleName)
+                        return
+                    }
+                    def siteAccess = role.getNode("currentSite-access")
+                    log.info("Adding jContentAccordions permission to role: " + roleName + " (currentSite-access)")
+                    if (siteAccess.hasProperty("j:permissionNames")) {
+                        siteAccess.getProperty("j:permissionNames").addValue("jContentAccordions")
+                    } else {
+                        siteAccess.setProperty("j:permissionNames", ["jContentAccordions"] as String[])
                     }
                 } catch (RepositoryException e) {
-                    log.error("Error updating permissions for role: " + roleName, e);
+                    log.error("Error updating permissions for role: " + roleName, e)
                 }
-            });
-            jcrSessionWrapper.save();
-            return null;
+            })
+            jcrSessionWrapper.save()
+            return null
         }
-    });
+    })
 }
 
-updateAccordionPermissions();
+updateAccordionPermissions()

--- a/src/main/resources/META-INF/patches/groovy/03-permissionsAccordionsAccessFix.started.groovy
+++ b/src/main/resources/META-INF/patches/groovy/03-permissionsAccordionsAccessFix.started.groovy
@@ -1,0 +1,99 @@
+import org.jahia.services.content.JCRCallback
+import org.jahia.services.content.JCRSessionWrapper
+import org.jahia.services.content.JCRTemplate
+
+import javax.jcr.RepositoryException
+import javax.jcr.Value
+
+PERMISSION = "jContentAccordions"
+PROP = "j:permissionNames"
+CHILD = "currentSite-access"
+
+/**
+ * Remove a value from a multi-valued property if present.
+ * Does nothing if the property is missing or the value isn't there.
+ * Returns true if a change was made.
+ */
+boolean removeValueFromMultiProp(node, String propName, String valueToRemove) {
+    if (!node.hasProperty(propName)) {
+        return false
+    }
+    Value[] current = node.getProperty(propName).getValues()
+    String[] kept = current.findAll { it.getString() != valueToRemove }*.getString() as String[]
+    if (kept.length < current.length) {
+        node.setProperty(propName, kept)
+        return true
+    }
+
+    return false
+}
+
+/**
+ * Ensure a value exists in a multi-valued property. Returns true if added.
+ */
+def ensureValueInMultiProp(node, String propName, String valueToAdd) {
+    if (node.hasProperty(propName)) {
+        def values = node.getProperty(propName).getValues()
+        if (values.any { it.getString() == valueToAdd }) {
+            return false
+        }
+        node.getProperty(propName).addValue(valueToAdd)
+    } else {
+        node.setProperty(propName, [valueToAdd] as String[])
+    }
+    return true
+}
+
+def fixAccordionPermissionLocation() {
+    JCRTemplate.getInstance().doExecuteWithSystemSession(new JCRCallback<Void>() {
+
+        @Override
+        Void doInJCR(JCRSessionWrapper session) throws RepositoryException {
+            log.info("Fixing misplaced ${PERMISSION} permission on roles...")
+            def roleNames = List.of("editor", "reviewer", "translator")
+            boolean anyChange = false
+
+            roleNames.forEach(roleName -> {
+                try {
+                    def rolePath = "/roles/" + roleName
+                    if (!session.nodeExists(rolePath)) {
+                        log.warn("Role node not found: " + rolePath)
+                        return
+                    }
+                    def role = session.getNode(rolePath)
+
+                    // 1. Remove from the role node itself (wrong location)
+                    if (removeValueFromMultiProp(role, PROP, PERMISSION)) {
+                        log.info("Removed misplaced ${PERMISSION} from role node: ${roleName}")
+                        anyChange = true
+                    }
+
+                    // 2. Ensure it's on currentSite-access (correct location)
+                    if (!role.hasNode(CHILD)) {
+                        log.warn("${CHILD} child not found under role: " + roleName + " — cannot relocate permission")
+                        return
+                    }
+                    def siteAccess = role.getNode(CHILD)
+                    if (ensureValueInMultiProp(siteAccess, PROP, PERMISSION)) {
+                        log.info("Added ${PERMISSION} to ${roleName}/${CHILD}")
+                        anyChange = true
+                    } else {
+                        log.info("${PERMISSION} already present on ${roleName}/${CHILD} — no change")
+                    }
+                } catch (RepositoryException e) {
+                    log.error("Error fixing permissions for role: " + roleName, e)
+                }
+            })
+
+            if (anyChange) {
+                session.save()
+                log.info("Permission relocation patch applied.")
+            } else {
+                log.info("No changes required — permissions already in correct location.")
+            }
+            return null
+        }
+    })
+}
+
+fixAccordionPermissionLocation()


### PR DESCRIPTION
### Description
Update permission scripts to ensure permissions are added to right nodes. `jContentAccordions` was placed under role node but needed to be under `currentSite-access`. Original migration script is modified and additional script is added to remove permissions directly from under the role node.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
