### PR TITLE
test: Test that editor can see primary nav item

### DIFF
--- a/tests/cypress/e2e/jcontent/accordions.cy.ts
+++ b/tests/cypress/e2e/jcontent/accordions.cy.ts
@@ -1,26 +1,34 @@
-import {createSite, deleteSite, enableModule} from '@jahia/cypress';
+import {createSite, createUser, deleteSite, deleteUser, enableModule, grantRoles} from '@jahia/cypress';
 import gql from 'graphql-tag';
 import {JContent} from '../../page-object';
 
 describe('Test accordions', () => {
+    const siteKey = 'accordionTest';
+    const editor = {username: 'accordionEditor', password: 'password'};
+
     before(function () {
-        createSite('accordionTest', {
+        createSite(siteKey, {
             templateSet: 'dx-base-demo-templates',
             serverName: 'localhost',
             locale: 'en'
         });
-        enableModule('jcontent-test-module', 'accordionTest');
+        enableModule('jcontent-test-module', siteKey);
+
+        createUser(editor.username, editor.password);
+        grantRoles(`/sites/${siteKey}/home`, ['editor'], editor.username, 'USER');
     });
 
     after(function () {
-        deleteSite('accordionTest');
+        deleteSite(siteKey);
+        deleteUser(editor.username);
+        cy.logout();
     });
 
     it('Check consistencies of RegExp validation pattern', () => {
         cy.apollo({mutation: gql`
             mutation {
                 jcr {
-                    mutateNode(pathOrId: "/sites/accordionTest/home") {
+                    mutateNode(pathOrId: "/sites/${siteKey}/home") {
                         addChild(name: "test", primaryNodeType: "cent:visibleInTree") {
                             uuid
                         }
@@ -49,5 +57,11 @@ describe('Test accordions', () => {
             jc.getAccordionItem('pages').getTreeItem('home').expand();
             jc.getAccordionItem('testmoduleApps_Example').click();
         });
+    });
+
+    it('Displays accordion for user with editor permission on home page', () => {
+        cy.login(editor.username, editor.password);
+        JContent.visit(siteKey, 'en', 'pages/home');
+        cy.get('li[data-registry-key="primary-nav-item:jcontent"]').should('be.visible');
     });
 });


### PR DESCRIPTION
### Description
Test that editor can see primary nav item if the editor permission is added to home page. It tests that the jContentAccordions permission is added to currentSite-access and not directly under the role's node.
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
