### PR TITLE
feat: changed jnt:query to multiline and monospaced font.

### DIFF
--- a/.chachalog/pupB34Yp.md
+++ b/.chachalog/pupB34Yp.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Changed jnt:query input to multiline and monospaced font. (#2294)

--- a/src/javascript/ContentEditor/SelectorTypes/TextAreaField/TextAreaField.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/TextAreaField/TextAreaField.jsx
@@ -2,13 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {TextArea} from '~/ContentEditor/DesignSystem/TextArea';
 import {FieldPropTypes} from '~/ContentEditor/ContentEditor.proptypes';
+import styles from './TextAreaField.scss';
+
+const findOption = (field, name) => field.selectorOptions?.find(option => option.name === name);
 
 export const TextAreaField = ({id, value, field, onChange, onBlur}) => {
+    const rowsOption = findOption(field, 'rows');
+    const rows = rowsOption ? parseInt(rowsOption.value, 10) : undefined;
+    const monospace = findOption(field, 'monospace')?.value === 'true';
+
     return (
         <TextArea id={id}
                   name={id}
                   aria-labelledby={`${field.name}-label`}
                   value={value || ''}
+                  rows={rows}
+                  className={monospace ? styles.monospace : undefined}
                   readOnly={field.readOnly}
                   onChange={evt => onChange(evt?.target?.value)}
                   onBlur={onBlur}

--- a/src/javascript/ContentEditor/SelectorTypes/TextAreaField/TextAreaField.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/TextAreaField/TextAreaField.jsx
@@ -8,7 +8,7 @@ const findOption = (field, name) => field.selectorOptions?.find(option => option
 
 export const TextAreaField = ({id, value, field, onChange, onBlur}) => {
     const rowsOption = findOption(field, 'rows');
-    const rows = rowsOption ? parseInt(rowsOption.value, 10) : undefined;
+    const rows = rowsOption ? Number.parseInt(rowsOption.value, 10) : undefined;
     const monospace = findOption(field, 'monospace')?.value === 'true';
 
     return (

--- a/src/javascript/ContentEditor/SelectorTypes/TextAreaField/TextAreaField.scss
+++ b/src/javascript/ContentEditor/SelectorTypes/TextAreaField/TextAreaField.scss
@@ -1,0 +1,3 @@
+.monospace {
+    font-family: var(--font-family-monospace, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
+}

--- a/src/javascript/ContentEditor/SelectorTypes/TextAreaField/TextAreaField.spec.js
+++ b/src/javascript/ContentEditor/SelectorTypes/TextAreaField/TextAreaField.spec.js
@@ -49,4 +49,30 @@ describe('TextArea component', () => {
         expect(props.onChange.mock.calls.length).toBe(1);
         expect(props.onChange).toHaveBeenCalledWith('text');
     });
+
+    it('should pass rows from selectorOptions', () => {
+        props.field.selectorOptions = [{name: 'rows', value: '10'}];
+        const cmp = shallow(<TextAreaField {...props}/>);
+
+        expect(cmp.props().rows).toBe(10);
+    });
+
+    it('should leave rows undefined when no selectorOption is set', () => {
+        const cmp = shallow(<TextAreaField {...props}/>);
+
+        expect(cmp.props().rows).toBeUndefined();
+    });
+
+    it('should apply monospace className when selectorOption is true', () => {
+        props.field.selectorOptions = [{name: 'monospace', value: 'true'}];
+        const cmp = shallow(<TextAreaField {...props}/>);
+
+        expect(cmp.props().className).toBeTruthy();
+    });
+
+    it('should not apply monospace className when selectorOption is missing', () => {
+        const cmp = shallow(<TextAreaField {...props}/>);
+
+        expect(cmp.props().className).toBeUndefined();
+    });
 });

--- a/src/javascript/ContentEditor/SelectorTypes/TextAreaField/TextAreaField.spec.js
+++ b/src/javascript/ContentEditor/SelectorTypes/TextAreaField/TextAreaField.spec.js
@@ -57,10 +57,10 @@ describe('TextArea component', () => {
         expect(cmp.props().rows).toBe(10);
     });
 
-    it('should leave rows undefined when no selectorOption is set', () => {
+    it('should fall back to default rows when no selectorOption is set', () => {
         const cmp = shallow(<TextAreaField {...props}/>);
 
-        expect(cmp.props().rows).toBeUndefined();
+        expect(cmp.props().rows).toBe(5);
     });
 
     it('should apply monospace className when selectorOption is true', () => {

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_query.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_query.json
@@ -1,0 +1,24 @@
+{
+  "nodeType": "jnt:query",
+  "priority": 2.0,
+  "sections": [
+    {
+      "name": "content",
+      "fieldSets": [
+        {
+          "name": "jnt:query",
+          "fields": [
+            {
+              "name": "query",
+              "selectorType": "TextArea",
+              "selectorOptionsMap": {
+                "rows": "6",
+                "monospace": "true"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description
This PR adds a JSON override to use textareas for queries, and some styling improvements.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
