### PR TITLE
fix: Allow to have target attribute in the tooltip link

### DIFF
--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/Sanitizer.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/Sanitizer.java
@@ -13,7 +13,7 @@ public class Sanitizer {
         .allowCommonInlineFormattingElements()
         .allowUrlProtocols("http", "https")
         .allowElements("a")
-        .allowAttributes("href").onElements("a")
+        .allowAttributes("href", "target").onElements("a")
         .toFactory();
 
     public static final PolicyFactory COMMON_FORMATTING = Sanitizers.FORMATTING;


### PR DESCRIPTION
### Description
Allow to have target attribute in the tooltip link so customers can open the link in a new tab.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
