### PR TITLE
chore: Increase workflow timeout to 140 minutes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
           - cypress.config-pageBuilder.ts
           - cypress.config-pickers.ts
           - cypress.config-categoryManager.ts
-    timeout-minutes: 120
+    timeout-minutes: 140
     steps:
       - uses: jahia/jahia-modules-action/helper@v2
       - uses: KengoTODA/actions-setup-docker-compose@main

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -93,7 +93,7 @@ jobs:
           - cypress.config-pageBuilder.ts
           - cypress.config-pickers.ts
           - cypress.config-categoryManager.ts
-    timeout-minutes: 120
+    timeout-minutes: 140
     steps:
       - uses: jahia/jahia-modules-action/helper@v2
       - uses: KengoTODA/actions-setup-docker-compose@main

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -27,7 +27,7 @@ jobs:
     needs: update-signature
     runs-on: ubuntu-latest
     env:
-      NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }} 
+      NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }}
     container:
       image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
       credentials:
@@ -57,7 +57,7 @@ jobs:
     name: Integration Tests ${{ matrix.config_file }}
     needs: build
     runs-on: self-hosted
-    timeout-minutes: 75
+    timeout-minutes: 140
     strategy:
       fail-fast: false
       matrix:
@@ -130,7 +130,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     env:
-      NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }} 
+      NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }}
     container:
       image: ghcr.io/jahia/jahia-docker-mvn-cache:11-jdk-noble-mvn-loaded
       credentials:

--- a/.github/workflows/weekly-cluster.yml
+++ b/.github/workflows/weekly-cluster.yml
@@ -21,7 +21,7 @@ jobs:
           - cypress.config-pageBuilder.ts
           - cypress.config-pickers.ts
           - cypress.config-categoryManager.ts
-    timeout-minutes: 120
+    timeout-minutes: 140
     steps:
       - uses: jahia/jahia-modules-action/helper@v2
       - uses: KengoTODA/actions-setup-docker-compose@main


### PR DESCRIPTION
### Description
Increase workflow timeout to 140 minutes as we've run into issues with the current setting a few times. Normally, the tests should pass much faster but it looks like github infrastructure and execution speeds might affect it as well. From the looks of it, extra 20 minutes should be enough.
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
