### PR TITLE
test: open/closing dropdown for choicelist can remove items instead

### DIFF
--- a/tests/cypress/page-object/fields/choiceListField.ts
+++ b/tests/cypress/page-object/fields/choiceListField.ts
@@ -110,7 +110,7 @@ export class ChoiceListField extends Field {
         dropdown.then($el => {
             // Only click if menu is not visible
             if ($el.find('.moonstone-menu').length === 0) {
-                dropdown.click();
+                dropdown.click('right');
             }
         });
         // Wait for the menu to be visible
@@ -124,7 +124,7 @@ export class ChoiceListField extends Field {
         dropdown.then($el => {
             // Only click if menu is visible
             if ($el.find('.moonstone-menu').length > 0) {
-                dropdown.click();
+                dropdown.click('right');
             }
         });
         // Wait for the menu to be hidden


### PR DESCRIPTION
### Description

Found an issue in the cypress test `selectorTypes/choicelistInitializers` with the change in choicelist tags when open/closing dropdowns:

Before:

<img width="516" height="133" alt="image" src="https://github.com/user-attachments/assets/4102c4d9-1e5a-472e-86ba-3ba2db734cf1" />

After:

<img width="527" height="143" alt="image" src="https://github.com/user-attachments/assets/c3e08ebd-e868-4d07-a039-ed3521745b77" />

It's now long enough that clicking on the dropdown to open/close actually removes one of the selection instead. Adjust dropdown click to the rightmost instead of the default center to be safe.

