### PR TITLE
chore: Update jcontent-test-js-template groupId

### DIFF
--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -14,7 +14,7 @@
     - 'mvn:org.jahia.modules/jahia-ui-root'
     - 'mvn:org.jahia.test/jcontent-test-module'
     - 'mvn:org.jahia.test/jcontent-test-template'
-    - 'mvn:org.jahia.test/jcontent-test-js-template'
+    - 'mvn:org.jahia.modules.javascript/jcontent-test-js-template'
   autoStart: true
   uninstallPreviousVersion: true
 - include: 'provisioning.yml'


### PR DESCRIPTION
### Description
jcontent-test-js-template is not found on nexus, as it uses the groupId org.jahia.test.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
