### PR TITLE
fix: Correctly resolve insertion point buttons.

### DIFF
--- a/.chachalog/oJYoQQPW.md
+++ b/.chachalog/oJYoQQPW.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Correctly resolve insertion point buttons. Make sure that all available types are taken into account. (#2313)

--- a/src/javascript/ContentEditor/actions/jcontent/createContent/createContent.utils.js
+++ b/src/javascript/ContentEditor/actions/jcontent/createContent/createContent.utils.js
@@ -123,7 +123,12 @@ export function transformNodeTypesToActionsPB(nodeTypes, hasBypassChildrenLimit,
             }));
     }
 
-    return actions;
+    return actions || [{
+        key: 'allTypes',
+        nodeTypeIcon: defaultIcon,
+        nodeTypes: nodeTypes.length > 0 ? nodeTypes.map(n => n.name) : ['jmix:droppableContent'],
+        tooltipLabel: 'jcontent:label.contentEditor.CMMActions.createNewContent.tooltipGeneric',
+        tooltipParams: {parent: parentName}}];
 }
 
 export function childrenLimitReachedOrExceeded(node, templateLimit) {

--- a/src/javascript/ContentEditor/actions/jcontent/createContent/createContentActionPB.jsx
+++ b/src/javascript/ContentEditor/actions/jcontent/createContent/createContentActionPB.jsx
@@ -46,7 +46,8 @@ export const CreateContentPB = ({
         let resolvedNodeTypesForAction = [];
         // NodeTypes come from placeholder's nodetypes attribute, as each action is created for such placeholder we want to match what that button can create
         if (resNode.acceptedNodeTypes.size > 0) {
-            if (nodeTypes?.length > 0) {
+            // If nodetypes is defined, it will be used as the source of truth for calculating available note types
+            if (nodeTypes) {
                 resolvedNodeTypesForAction = nodeTypes
                     .map(nt => resNode.acceptedNodeTypes.get(nt))
                     .filter(nt => nt !== undefined);

--- a/src/javascript/ContentEditor/actions/jcontent/createContent/createContentActionPB.jsx
+++ b/src/javascript/ContentEditor/actions/jcontent/createContent/createContentActionPB.jsx
@@ -113,7 +113,7 @@ CreateContentPB.propTypes = {
     onVisibilityChanged: PropTypes.func,
     labelProps: PropTypes.object,
     nodeData: PropTypes.object,
-    nodeTypes: PropTypes.object
+    nodeTypes: PropTypes.arrayOf(PropTypes.string)
 };
 
 export const createContentActionPB = {

--- a/src/javascript/ContentEditor/actions/jcontent/createContent/createContentActionPB.jsx
+++ b/src/javascript/ContentEditor/actions/jcontent/createContent/createContentActionPB.jsx
@@ -81,11 +81,7 @@ export const CreateContentPB = ({
         api.create({uuid: resNode.uuid, lang: language, nodeTypes, name, isFullscreen, createCallback: onCreate, onClosedCallback: onClosed});
     };
 
-    return (actions || [{
-        key: 'allTypes',
-        nodeTypeIcon: otherProps.defaultIcon,
-        tooltipLabel: 'jcontent:label.contentEditor.CMMActions.createNewContent.tooltipGeneric',
-        tooltipParams: {parent: resNode.name}}]).map(result => (
+    return actions.map(result => (
             <Render
             key={result.key}
             dataSelRole="createContent"
@@ -93,7 +89,6 @@ export const CreateContentPB = ({
             buttonIcon={result.nodeTypeIcon || otherProps.defaultIcon}
             tooltipLabel={result.tooltipLabel}
             tooltipParams={result.tooltipParams}
-            nodeTypes={['jmix:droppableContent']}
             {...otherProps}
             path={path}
             uilang={uilang}

--- a/src/javascript/ContentEditor/actions/jcontent/createContent/createContentActionPB.jsx
+++ b/src/javascript/ContentEditor/actions/jcontent/createContent/createContentActionPB.jsx
@@ -44,7 +44,7 @@ export const CreateContentPB = ({
 
         // Note: acceptedNodeTypes is based on the DOM if we were able to find it, allowedChildNodeTypes is the info from JCR
         let resolvedNodeTypesForAction = [];
-        // nodeTypes come from placeholder's nodetypes attribute, as each action is created for such placeholder we want to match what that button can create
+        // NodeTypes come from placeholder's nodetypes attribute, as each action is created for such placeholder we want to match what that button can create
         if (resNode.acceptedNodeTypes.size > 0) {
             if (nodeTypes?.length > 0) {
                 resolvedNodeTypesForAction = nodeTypes
@@ -54,6 +54,7 @@ export const CreateContentPB = ({
                 resolvedNodeTypesForAction = [...resNode.acceptedNodeTypes.values()];
             }
         }
+
         const resolvedNodeTypes = resolvedNodeTypesForAction.length > 0 ? resolvedNodeTypesForAction : resNode.allowedChildNodeTypes;
         const actions = transformNodeTypesToActionsPB(resolvedNodeTypes, false, resNode?.name, otherProps.defaultIcon);
 
@@ -82,7 +83,7 @@ export const CreateContentPB = ({
     };
 
     return actions.map(result => (
-            <Render
+        <Render
             key={result.key}
             dataSelRole="createContent"
             enabled={!isDisabled && !resNode?.lockOwner}

--- a/src/javascript/ContentEditor/actions/jcontent/createContent/createContentActionPB.jsx
+++ b/src/javascript/ContentEditor/actions/jcontent/createContent/createContentActionPB.jsx
@@ -64,7 +64,7 @@ export const CreateContentPB = ({
             actions,
             missingNodes: false
         };
-    }, [Loading, resNode, path, otherProps.defaultIcon]);
+    }, [Loading, resNode, path, otherProps.defaultIcon, nodeTypes]);
 
     useEffect(() => {
         onVisibilityChanged?.(isVisible);
@@ -112,7 +112,8 @@ CreateContentPB.propTypes = {
     loading: PropTypes.func,
     onVisibilityChanged: PropTypes.func,
     labelProps: PropTypes.object,
-    nodeData: PropTypes.object
+    nodeData: PropTypes.object,
+    nodeTypes: PropTypes.object
 };
 
 export const createContentActionPB = {

--- a/src/javascript/ContentEditor/actions/jcontent/createContent/createContentActionPB.jsx
+++ b/src/javascript/ContentEditor/actions/jcontent/createContent/createContentActionPB.jsx
@@ -17,6 +17,7 @@ export const CreateContentPB = ({
     isDisabled,
     onVisibilityChanged,
     nodeData,
+    nodeTypes,
     render: Render,
     loading: Loading,
     labelProps,
@@ -42,8 +43,19 @@ export const CreateContentPB = ({
         }
 
         // Note: acceptedNodeTypes is based on the DOM if we were able to find it, allowedChildNodeTypes is the info from JCR
-        const nodeTypes = resNode.acceptedNodeTypes.length > 0 ? resNode.acceptedNodeTypes : resNode.allowedChildNodeTypes;
-        const actions = transformNodeTypesToActionsPB(nodeTypes, false, resNode?.name, otherProps.defaultIcon);
+        let resolvedNodeTypesForAction = [];
+        // nodeTypes come from placeholder's nodetypes attribute, as each action is created for such placeholder we want to match what that button can create
+        if (resNode.acceptedNodeTypes.size > 0) {
+            if (nodeTypes?.length > 0) {
+                resolvedNodeTypesForAction = nodeTypes
+                    .map(nt => resNode.acceptedNodeTypes.get(nt))
+                    .filter(nt => nt !== undefined);
+            } else {
+                resolvedNodeTypesForAction = [...resNode.acceptedNodeTypes.values()];
+            }
+        }
+        const resolvedNodeTypes = resolvedNodeTypesForAction.length > 0 ? resolvedNodeTypesForAction : resNode.allowedChildNodeTypes;
+        const actions = transformNodeTypesToActionsPB(resolvedNodeTypes, false, resNode?.name, otherProps.defaultIcon);
 
         return {
             loading: false,

--- a/src/javascript/JContent/EditFrame/Boxes/dataHooks/useButtonsData.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/dataHooks/useButtonsData.jsx
@@ -3,12 +3,12 @@ import {useNodeChecks} from '@jahia/data-helper';
 import {getNodeTypeInfo} from '~/ContentEditor/actions/jcontent/createContent/createContent.gql-queries';
 
 export const useButtonsData = ({createButtons, language, uilang}) => {
-    const paths = [];
+    const paths = new Set();
     const nodeTypes = new Set();
 
     createButtons.forEach(b => {
         if (b?.node) {
-            paths.push(b.node.path);
+            paths.add(b.node.path);
             b.attributes?.nodeTypes?.forEach(nt => nodeTypes.add(nt));
         }
     });
@@ -17,7 +17,7 @@ export const useButtonsData = ({createButtons, language, uilang}) => {
 
     // This data will be used to drive createContentPB actions
     const res = useNodeChecks({
-        paths,
+        paths: Array.from(paths),
         language
     }, {
         mapResults: true, // This creates a map of {path: node result}
@@ -58,8 +58,17 @@ export const useButtonsData = ({createButtons, language, uilang}) => {
     createButtons.forEach(b => {
         const node = output.nodes[b?.node?.path];
         if (node) {
-            // Map list of node type names to the full info objects
-            node.acceptedNodeTypes = b.attributes?.nodeTypes?.map(nt => nodeTypeInfoMap.get(nt)).filter(nt => nt !== undefined) || [];
+            // There can be multiple placeholders or a single one with multiple or single nodetype defined.
+            // Each node keeps a set of acceptable node types, display configuration will be resolved at Create button/action level with the help of nodetypes attribute.
+            const resolved = b.attributes?.nodeTypes
+                ?.map(nt => nodeTypeInfoMap.get(nt))
+                .filter(nt => nt !== undefined) || [];
+
+            if (!node.acceptedNodeTypes) {
+                node.acceptedNodeTypes = new Map();
+            }
+
+            resolved.forEach(nt => node.acceptedNodeTypes.set(nt.name, nt));
         }
     });
 

--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -108,7 +108,7 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
     const parent = element.dataset.jahiaParent && element.ownerDocument.getElementById(element.dataset.jahiaParent);
     const parentPath = parent.getAttribute('path');
     const [currentOffset, setCurrentOffset] = useState(getBoundingBox(element));
-    const {nodeName, nodePath} = getElemAttributes({element, parent, isInsertionPoint});
+    const {nodeName, nodePath, nodeTypes} = getElemAttributes({element, parent, isInsertionPoint});
     const [actionVisibility, setActionVisibility] = useState({
         createContent: false,
         paste: false,
@@ -196,6 +196,7 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
     const createAction = useMemo(() => (
         <DisplayAction
             actionKey="createContentPB"
+            nodeTypes={nodeTypes}
             path={parentPath}
             name={nodePath}
             isDisabled={isDisabled}

--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -170,7 +170,7 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
     const insertionStyle = {};
     if (isInsertionPoint && !isEmpty) {
         insertionStyle.height = 0;
-        insertionStyle.zIndex = 25001;
+        insertionStyle.zIndex = 1000000;
 
         if (isVertical) {
             const btnWidth = 42;
@@ -205,7 +205,7 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
             onVisibilityChanged={onCreateVisibilityChanged}
             onCreate={onAction(({name}) => reorderNodes([name], nodeName))}
         />
-    ), [parentPath, nodePath, isDisabled, nodeData, btnRenderer, onCreateVisibilityChanged, onAction, reorderNodes, nodeName]);
+    ), [parentPath, nodePath, isDisabled, nodeData, btnRenderer, onCreateVisibilityChanged, onAction, reorderNodes, nodeName, nodeTypes]);
 
     return !anyDragging && (
         <div ref={drop}

--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -50,8 +50,7 @@ export const getElemAttributes = ({element, parent}) => {
 
     let nodeTypes;
     let parentAreaType;
-    if (parent.getAttribute('nodetypes') &&
-        (parent.getAttribute('type') === 'area' || parent.getAttribute('type') === 'absoluteArea')) {
+    if (parent.getAttribute('nodetypes') && (parent.getAttribute('type') === 'area' || parent.getAttribute('type') === 'absoluteArea' || isContainer)) {
         nodeTypes = parent.getAttribute('nodetypes').split(' ');
         parentAreaType = parent.getAttribute('type');
     }

--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -39,18 +39,41 @@ function reposition(element, currentOffset, setCurrentOffset) {
     }
 }
 
+/**
+ * There are several types of placeholders and several ways in which node types can be resolved.
+ *
+ * Definition of multiple children of types a and b
+ * <div id="moduleABC" jahiatype="module" nodetypes="a b">
+ *      <div type="placeholder" path="*"/>
+ * </div>
+ *
+ * Definition of a single named child a and multiple children of type b
+ * <div id="moduleABC" jahiatype="module" nodetypes="b">
+ *     <div type="placeholder" path="childName" nodetypes="a"/>
+ *     <div type="placeholder" path="*"/>
+ * </div>
+ *
+ * If named child is added the placehoder will be replaced by <div type="existingNode" />. This is true for all named children.
+ *
+ * Definition of multiple named children of type a and b (it could also be just one child). Note that the parent no longer has nodetypes.
+ * <div id="moduleABC" jahiatype="module">
+ *     <div type="placeholder" path="childName" nodetypes="a"/>
+ *     <div type="placeholder" path="childName" nodetypes="b"/>
+ * </div>
+ */
 export const getElemAttributes = ({element, parent}) => {
     // Need to check here if insertionPoint is an original create button or not,
     // otherwise it breaks create button for specific child nodes.
     const isInsertionPoint = element.getAttribute('type') !== 'placeholder';
-    const isContainer = element.getAttribute('path') === '*';
+    const isMultipleChildPlaceholder = element.getAttribute('path') === '*';
 
-    const nodePath = (isInsertionPoint || isContainer) ? null : element.getAttribute('path');
+    const nodePath = (isInsertionPoint || isMultipleChildPlaceholder) ? null : element.getAttribute('path');
     const nodeName = element.getAttribute('path').split('/').pop();
 
-    let nodeTypes;
+    // Nodetypes should not be undefined here because if nothing is found nothing should be used
+    let nodeTypes = [];
     let parentAreaType;
-    if (parent.getAttribute('nodetypes') && (parent.getAttribute('type') === 'area' || parent.getAttribute('type') === 'absoluteArea' || isContainer)) {
+    if (parent.getAttribute('nodetypes')) {
         nodeTypes = parent.getAttribute('nodetypes').split(' ');
         parentAreaType = parent.getAttribute('type');
     }

--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -170,7 +170,7 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
     const insertionStyle = {};
     if (isInsertionPoint && !isEmpty) {
         insertionStyle.height = 0;
-        insertionStyle.zIndex = 1000000;
+        insertionStyle.zIndex = 25001;
 
         if (isVertical) {
             const btnWidth = 42;

--- a/src/javascript/JContent/EditFrame/InsertionPoints.jsx
+++ b/src/javascript/JContent/EditFrame/InsertionPoints.jsx
@@ -6,14 +6,21 @@ import {useSelector} from 'react-redux';
 import {usePasteData} from '~/JContent/EditFrame/Boxes/dataHooks/usePasteData';
 
 const getNodeTypes = e => {
+    const types = new Set();
+
+    const ownNt = e.getAttribute('nodetypes');
+    if (ownNt) {
+        ownNt.split(' ').forEach(t => types.add(t));
+    }
+
     if (e.dataset.jahiaParent) {
-        const nt = e.ownerDocument.getElementById(e.dataset.jahiaParent).getAttribute('nodetypes');
-        if (nt) {
-            return nt.split(' ');
+        const parentNt = e.ownerDocument.getElementById(e.dataset.jahiaParent).getAttribute('nodetypes');
+        if (parentNt) {
+            parentNt.split(' ').forEach(t => types.add(t));
         }
     }
 
-    return [];
+    return [...types];
 };
 
 const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCallback, onSaved}) => {

--- a/src/main/java/org/jahia/modules/contenteditor/utils/ContentEditorUtils.java
+++ b/src/main/java/org/jahia/modules/contenteditor/utils/ContentEditorUtils.java
@@ -51,6 +51,8 @@ import java.util.stream.Stream;
  */
 public class ContentEditorUtils {
 
+    private static final Logger logger = LoggerFactory.getLogger(ContentEditorUtils.class);
+
     private ContentEditorUtils() {
         // prevent new instance of this class
     }
@@ -146,17 +148,21 @@ public class ContentEditorUtils {
 
     private static void getAllowedTypes(Set<String> allowedTypes, List<String> filterNodeType, ExtendedNodeType subType, boolean includeSubTypes) {
         if (filterNodeType != null) {
-            filterNodeType.forEach(ThrowingConsumer.unchecked(filterType -> {
-                if (NodeTypeRegistry.getInstance().getNodeType(filterType).isMixin() || includeSubTypes) {
-                    if (subType.isNodeType(filterType)) {
-                        allowedTypes.add(subType.getName());
+            filterNodeType.forEach(filterType -> {
+                try {
+                    if (NodeTypeRegistry.getInstance().getNodeType(filterType).isMixin() || includeSubTypes) {
+                        if (subType.isNodeType(filterType)) {
+                            allowedTypes.add(subType.getName());
+                        }
+                    } else {
+                        if (subType.getName().equals(filterType)) {
+                            allowedTypes.add(subType.getName());
+                        }
                     }
-                } else {
-                    if (subType.getName().equals(filterType)) {
-                        allowedTypes.add(subType.getName());
-                    }
+                } catch (RepositoryException e) {
+                    logger.warn("Unknown node type '{}', skipping", filterType);
                 }
-            }));
+            });
         } else {
             allowedTypes.add(subType.getName());
         }

--- a/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
@@ -192,7 +192,7 @@ describe('Page builder - insertion points', () => {
             .visit(siteKey, 'en', 'pages/home/page-six-multiple')
             .switchToPageBuilder();
 
-        const updatedModule = pageBuilder.getModule(modulePath);
+        const updatedModule = pageBuilder.getModule(modulePath, false);
         updatedModule.get().scrollIntoView();
         updatedModule.get().click('bottomLeft', {force: true});
 

--- a/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
@@ -146,7 +146,7 @@ describe('Page builder - insertion points', () => {
     after(() => {
         // Reset limit back to default
         setButtonLimit('5');
-        deleteSite(siteKey);
+        //deleteSite(siteKey);
     });
 
     beforeEach(() => {
@@ -179,6 +179,7 @@ describe('Page builder - insertion points', () => {
             .visit(siteKey, 'en', 'pages/home/page-six-multiple')
             .switchToPageBuilder();
 
+        cy.wait(3000)
         for (let i = 1; i <= 6; i++) {
             assertButtonByRole(pageBuilder, `cent:childObject${i}`);
         }

--- a/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
@@ -179,30 +179,21 @@ describe('Page builder - insertion points', () => {
             .visit(siteKey, 'en', 'pages/home/page-six-multiple')
             .switchToPageBuilder();
 
-        cy.wait(3000)
-        cy.log('Works up to here')
         for (let i = 1; i <= 6; i++) {
             assertButtonByRole(pageBuilder, `cent:childObject${i}`);
         }
-
-        cy.log('Works up to here 1')
 
         clickButtonByRole(pageBuilder, 'cent:childObject1');
         const contentEditor = new ContentEditor();
         contentEditor.create();
 
-        cy.log('Works up to here 2')
-
-        const updatedModule = pageBuilder.getModule(modulePath, false);
+        const updatedModule = pageBuilder.getModule(modulePath);
         updatedModule.get().scrollIntoView();
         updatedModule.get().click('bottomLeft', {force: true});
 
-        cy.log('Works up to here 3')
         for (let i = 1; i <= 6; i++) {
             assertButtonByRole(pageBuilder, `cent:childObject${i}`);
         }
-
-        cy.log('Works up to here 4')
     });
 
     it('sixChildObjectsSingle still shows six buttons while sixChildObjectsMultiple collapses to one when limit is 5', () => {

--- a/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
@@ -21,7 +21,7 @@ const assertButtonByRole = (pageBuilder, role: string) => {
 };
 
 const clickButtonByRole = (pageBuilder, role: string) => {
-    pageBuilder.iframe().get().find(`button[data-sel-role="${role}"]`).should('be.visible').click();
+    pageBuilder.iframe().get().find(`button[data-sel-role="${role}"]`).filter(':visible').click();
 };
 
 /**
@@ -182,6 +182,54 @@ describe('Page builder - insertion points', () => {
                 }]
             }]
         });
+
+        // Page with cent:twoChildObjectsOneMultiple with childObject2 already populated
+        addNode({
+            name: 'page-two-one-multiple-populated',
+            parentPathOrId: homePath,
+            primaryNodeType: 'jnt:page',
+            properties: [
+                {name: 'jcr:title', value: 'Two Child Objects One Multiple Populated', language: 'en'},
+                {name: 'j:templateName', value: 'simple'}
+            ],
+            children: [{
+                name: 'area-main',
+                primaryNodeType: 'jnt:contentList',
+                mixins: ['jmix:isAreaList'],
+                children: [{
+                    name: 'test-two-one-multiple-populated',
+                    primaryNodeType: 'cent:twoChildObjectsOneMultiple',
+                    children: [{
+                        name: 'childObject2',
+                        primaryNodeType: 'cent:childObject2'
+                    }]
+                }]
+            }]
+        });
+
+        // Page with cent:sixChildObjectsSingle with childObject5 already populated
+        addNode({
+            name: 'page-six-single-populated',
+            parentPathOrId: homePath,
+            primaryNodeType: 'jnt:page',
+            properties: [
+                {name: 'jcr:title', value: 'Six Child Objects Single Populated', language: 'en'},
+                {name: 'j:templateName', value: 'simple'}
+            ],
+            children: [{
+                name: 'area-main',
+                primaryNodeType: 'jnt:contentList',
+                mixins: ['jmix:isAreaList'],
+                children: [{
+                    name: 'test-six-single-populated',
+                    primaryNodeType: 'cent:sixChildObjectsSingle',
+                    children: [{
+                        name: 'childObject5',
+                        primaryNodeType: 'cent:childObject5'
+                    }]
+                }]
+            }]
+        });
     });
 
     after(() => {
@@ -297,13 +345,82 @@ describe('Page builder - insertion points', () => {
         const header = module.getBox().getHeader();
         header.getButton('contentItemActionsMenu').click();
 
-        // Verify "New content" exists in the context menu and click it
+        // This verifies that we can create an item of childObject1 type as defined by the definition using context menu
         const menu = getComponentBySelector(Menu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)');
         menu.selectByRole('createContent');
 
         const selector = getComponent(ContentTypeSelector);
         const ce = selector.searchForContentType('cent:childObject1').selectContentType('cent:childObject1').create();
         ce.cancel();
+    });
+
+    it('shows correct working buttons for twoChildObjectsOneMultiple with childObject2 populated', () => {
+        const modulePath = `${homePath}/page-two-one-multiple-populated/area-main/test-two-one-multiple-populated`;
+        const pageBuilder = JContent
+            .visit(siteKey, 'en', 'pages/home/page-two-one-multiple-populated')
+            .switchToPageBuilder();
+
+        let module = pageBuilder.getModule(modulePath, false);
+        module.get().scrollIntoView();
+        module.get().click('bottomLeft', {force: true});
+
+        // With childObject2 populated, only childObject1 (named) and childObject3 (wildcard) buttons remain,
+        // plus insertion point button — verify exactly 3 create buttons total
+        let createButtons = module.getAllCreateButtons();
+        createButtons.should('have.length', 3);
+
+        createButtons.getButtonByRole('cent:childObject1').should('exist').should('have.length', 1);
+        createButtons.getButtonByRole('cent:childObject3').should('exist').should('have.length', 2);
+
+        // Verify childObject1 can be created
+        assertButtonByRole(pageBuilder, 'cent:childObject1');
+        clickButtonByRole(pageBuilder, 'cent:childObject1');
+        let contentEditor = new ContentEditor();
+        contentEditor.create();
+
+        module = pageBuilder.getModule(modulePath, false);
+        module.get().scrollIntoView();
+        module.get().click('bottomLeft', {force: true});
+
+        createButtons = module.getAllCreateButtons();
+        createButtons.should('have.length', 3);
+        createButtons.getButtonByRole('cent:childObject3').should('exist').should('have.length', 3);
+
+        createButtons.getButtonByRole('cent:childObject3').get().first().click();
+        contentEditor = new ContentEditor();
+        contentEditor.create();
+    });
+
+    it('shows correct buttons for sixChildObjectsSingle with childObject5 populated', () => {
+        const modulePath = `${homePath}/page-six-single-populated/area-main/test-six-single-populated`;
+        const pageBuilder = JContent
+            .visit(siteKey, 'en', 'pages/home/page-six-single-populated')
+            .switchToPageBuilder();
+
+        let module = pageBuilder.getModule(modulePath, false);
+        module.get().scrollIntoView();
+        module.get().click('bottomLeft', {force: true});
+
+        let createButtons = module.getAllCreateButtons();
+        createButtons.should('have.length', 5);
+        createButtons.get().find('button[data-sel-role="cent:childObject5"]').should('not.exist');
+
+        clickButtonByRole(pageBuilder, 'cent:childObject1');
+        let contentEditor = new ContentEditor();
+        contentEditor.create();
+
+        module = pageBuilder.getModule(modulePath, false);
+        module.get().scrollIntoView();
+        module.get().click('bottomLeft', {force: true});
+
+        createButtons = module.getAllCreateButtons();
+        createButtons.should('have.length', 4);
+        createButtons.get().find('button[data-sel-role="cent:childObject1"]').should('not.exist');
+
+        module.get().click('bottomRight', {force: true});
+        clickButtonByRole(pageBuilder, 'cent:childObject2');
+        contentEditor = new ContentEditor();
+        contentEditor.create();
     });
 });
 

--- a/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
@@ -24,6 +24,49 @@ const clickButtonByRole = (pageBuilder, role: string) => {
     pageBuilder.iframe().get().find(`button[data-sel-role="${role}"]`).should('be.visible').click();
 };
 
+/**
+ *  [cent:twoChildObjectsOneMultiple] > jnt:content, jmix:basicContent, jmix:editorialContent
+ *   - someProperty (string)
+ *   + childObject1 (cent:childObject1)
+ *   + childObject2 (cent:childObject2)
+ *   + * (cent:childObject3)
+ *
+ *  [cent:sixChildObjectsSingle] > jnt:content, jmix:basicContent, jmix:editorialContent
+ *   - someProperty (string)
+ *   + childObject1 (cent:childObject1)
+ *   + childObject2 (cent:childObject2)
+ *   + childObject3 (cent:childObject3)
+ *   + childObject4 (cent:childObject4)
+ *   + childObject5 (cent:childObject5)
+ *   + childObject6 (cent:childObject6)
+ *
+ *  [cent:sixChildObjectsMultiple] > jnt:content, jmix:basicContent, jmix:editorialContent
+ *   - someProperty (string)
+ *   + * (cent:childObject1)
+ *   + * (cent:childObject2)
+ *   + * (cent:childObject3)
+ *   + * (cent:childObject4)
+ *   + * (cent:childObject5)
+ *   + * (cent:childObject6)
+ *
+ *   Note on functionality:
+ *
+ *   Given the definitions above and a child limit of > 6 it is expected that:
+ *
+ *   [cent:twoChildObjectsOneMultiple] will show 3 buttons: childObject1, childObject2, childObject3
+ *   where only childObject3 can be used multiple times the other two disapper once used.
+ *
+ *   [cent:sixChildObjectsSingle] will show 6 buttons respectivaly named and all single use.
+ *
+ *   [cent:sixChildObjectsMultiple] will show 6 multiple use buttons.
+ *
+ *   When the module which contains the definition is clicked and a child element exist (created using one of the buttons) then
+ *   additional buttons (all + * types) will be added on top of that module IN ADDITION to all currently available buttons.
+ *
+ *   When the limit is < 6 then all single use buttons are expected to be shown and all buttons that fall into multiple category will be
+ *   replaced by one "New content" button which will show content type selector LIMITED to available types, in this case six types.
+ *
+ */
 describe('Page builder - insertion points', () => {
     const siteKey = 'insertionPointsSite';
     const homePath = `/sites/${siteKey}/home`;

--- a/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
@@ -1,0 +1,189 @@
+import {addNode, createSite, deleteSite, enableModule} from '@jahia/cypress';
+import gql from 'graphql-tag';
+import {ContentEditor, JContent} from '../../page-object';
+
+const setButtonLimit = (value: string) => {
+    return cy.apollo({
+        mutation: gql`mutation {
+            admin {
+                jahia {
+                    configuration(pid: "org.jahia.modules.jcontent") {
+                        value(name: "createChildrenDirectButtons.limit", value: "${value}")
+                    }
+                }
+            }
+        }`
+    });
+};
+
+const assertButtonByRole = (pageBuilder, role: string) => {
+    pageBuilder.iframe().get().find(`button[data-sel-role="${role}"]`).should('be.visible');
+};
+
+const clickButtonByRole = (pageBuilder, role: string) => {
+    pageBuilder.iframe().get().find(`button[data-sel-role="${role}"]`).should('be.visible').click();
+};
+
+describe('Page builder - insertion points', () => {
+    const siteKey = 'insertionPointsSite';
+    const homePath = `/sites/${siteKey}/home`;
+
+    before(() => {
+        createSite(siteKey, {
+            templateSet: 'dx-base-demo-templates',
+            serverName: 'localhost',
+            locale: 'en'
+        });
+        enableModule('jcontent-test-module', siteKey);
+
+        // Set limit to 8 so all child types show individual buttons
+        setButtonLimit('8');
+
+        // Page with cent:twoChildObjectsOneMultiple
+        addNode({
+            name: 'page-two-one-multiple',
+            parentPathOrId: homePath,
+            primaryNodeType: 'jnt:page',
+            properties: [
+                {name: 'jcr:title', value: 'Two Child Objects One Multiple', language: 'en'},
+                {name: 'j:templateName', value: 'simple'}
+            ],
+            children: [{
+                name: 'area-main',
+                primaryNodeType: 'jnt:contentList',
+                mixins: ['jmix:isAreaList'],
+                children: [{
+                    name: 'test-two-one-multiple',
+                    primaryNodeType: 'cent:twoChildObjectsOneMultiple'
+                }]
+            }]
+        });
+
+        // Page with cent:sixChildObjectsSingle
+        addNode({
+            name: 'page-six-single',
+            parentPathOrId: homePath,
+            primaryNodeType: 'jnt:page',
+            properties: [
+                {name: 'jcr:title', value: 'Six Child Objects Single', language: 'en'},
+                {name: 'j:templateName', value: 'simple'}
+            ],
+            children: [{
+                name: 'area-main',
+                primaryNodeType: 'jnt:contentList',
+                mixins: ['jmix:isAreaList'],
+                children: [{
+                    name: 'test-six-single',
+                    primaryNodeType: 'cent:sixChildObjectsSingle'
+                }]
+            }]
+        });
+
+        // Page with cent:sixChildObjectsMultiple
+        addNode({
+            name: 'page-six-multiple',
+            parentPathOrId: homePath,
+            primaryNodeType: 'jnt:page',
+            properties: [
+                {name: 'jcr:title', value: 'Six Child Objects Multiple', language: 'en'},
+                {name: 'j:templateName', value: 'simple'}
+            ],
+            children: [{
+                name: 'area-main',
+                primaryNodeType: 'jnt:contentList',
+                mixins: ['jmix:isAreaList'],
+                children: [{
+                    name: 'test-six-multiple',
+                    primaryNodeType: 'cent:sixChildObjectsMultiple'
+                }]
+            }]
+        });
+    });
+
+    after(() => {
+        // Reset limit back to default
+        setButtonLimit('5');
+        deleteSite(siteKey);
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession();
+    });
+
+    it('shows correct create buttons for twoChildObjectsOneMultiple', () => {
+        const pageBuilder = JContent
+            .visit(siteKey, 'en', 'pages/home/page-two-one-multiple')
+            .switchToPageBuilder();
+
+        assertButtonByRole(pageBuilder, 'cent:childObject1');
+        assertButtonByRole(pageBuilder, 'cent:childObject2');
+        assertButtonByRole(pageBuilder, 'cent:childObject3');
+    });
+
+    it('shows correct create buttons for sixChildObjectsSingle', () => {
+        const pageBuilder = JContent
+            .visit(siteKey, 'en', 'pages/home/page-six-single')
+            .switchToPageBuilder();
+
+        for (let i = 1; i <= 6; i++) {
+            assertButtonByRole(pageBuilder, `cent:childObject${i}`);
+        }
+    });
+
+    it('shows correct create buttons for sixChildObjectsMultiple and verifies insertion points after create', () => {
+        const modulePath = `${homePath}/page-six-multiple/area-main/test-six-multiple`;
+        const pageBuilder = JContent
+            .visit(siteKey, 'en', 'pages/home/page-six-multiple')
+            .switchToPageBuilder();
+
+        for (let i = 1; i <= 6; i++) {
+            assertButtonByRole(pageBuilder, `cent:childObject${i}`);
+        }
+
+        clickButtonByRole(pageBuilder, 'cent:childObject1');
+        const contentEditor = new ContentEditor();
+        contentEditor.create();
+
+        const updatedModule = pageBuilder.getModule(modulePath, false);
+        updatedModule.get().scrollIntoView();
+        updatedModule.get().click('bottomLeft', {force: true});
+
+        for (let i = 1; i <= 6; i++) {
+            assertButtonByRole(pageBuilder, `cent:childObject${i}`);
+        }
+    });
+
+    it('sixChildObjectsSingle still shows six buttons while sixChildObjectsMultiple collapses to one when limit is 5', () => {
+        setButtonLimit('5');
+
+        const singlePageBuilder = JContent
+            .visit(siteKey, 'en', 'pages/home/page-six-single')
+            .switchToPageBuilder();
+
+        for (let i = 1; i <= 6; i++) {
+            assertButtonByRole(singlePageBuilder, `cent:childObject${i}`);
+        }
+
+        const multiplePageBuilder = JContent
+            .visit(siteKey, 'en', 'pages/home/page-six-multiple')
+            .switchToPageBuilder();
+
+        const multipleModule = multiplePageBuilder.getModule(`${homePath}/page-six-multiple/area-main/test-six-multiple`);
+        const multipleButtons = multipleModule.getCreateButtons();
+        multipleButtons.get().scrollIntoView();
+        multipleButtons.getButton('New content').click();
+
+        const contentTypeDialog = 'div[aria-labelledby="dialog-createNewContent"]';
+        cy.get(contentTypeDialog).should('be.visible');
+        for (let i = 1; i <= 6; i++) {
+            cy.get(contentTypeDialog)
+                .find(`[data-sel-role="content-type-tree-item"][data-sel-content-type="cent:childObject${i}"]`)
+                .should('exist');
+        }
+
+        cy.get(contentTypeDialog)
+            .find('[data-sel-role="content-type-tree-item"]')
+            .should('have.length', 6);
+    });
+});
+

--- a/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
@@ -180,21 +180,29 @@ describe('Page builder - insertion points', () => {
             .switchToPageBuilder();
 
         cy.wait(3000)
+        cy.log('Works up to here')
         for (let i = 1; i <= 6; i++) {
             assertButtonByRole(pageBuilder, `cent:childObject${i}`);
         }
+
+        cy.log('Works up to here 1')
 
         clickButtonByRole(pageBuilder, 'cent:childObject1');
         const contentEditor = new ContentEditor();
         contentEditor.create();
 
+        cy.log('Works up to here 2')
+
         const updatedModule = pageBuilder.getModule(modulePath, false);
         updatedModule.get().scrollIntoView();
         updatedModule.get().click('bottomLeft', {force: true});
 
+        cy.log('Works up to here 3')
         for (let i = 1; i <= 6; i++) {
             assertButtonByRole(pageBuilder, `cent:childObject${i}`);
         }
+
+        cy.log('Works up to here 4')
     });
 
     it('sixChildObjectsSingle still shows six buttons while sixChildObjectsMultiple collapses to one when limit is 5', () => {

--- a/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
@@ -356,7 +356,7 @@ describe('Page builder - insertion points', () => {
 
     it('shows correct working buttons for twoChildObjectsOneMultiple with childObject2 populated', () => {
         const modulePath = `${homePath}/page-two-one-multiple-populated/area-main/test-two-one-multiple-populated`;
-        const pageBuilder = JContent
+        let pageBuilder = JContent
             .visit(siteKey, 'en', 'pages/home/page-two-one-multiple-populated')
             .switchToPageBuilder();
 
@@ -378,6 +378,10 @@ describe('Page builder - insertion points', () => {
         let contentEditor = new ContentEditor();
         contentEditor.create();
 
+        pageBuilder = JContent
+            .visit(siteKey, 'en', 'pages/home/page-two-one-multiple-populated')
+            .switchToPageBuilder();
+
         module = pageBuilder.getModule(modulePath, false);
         module.get().scrollIntoView();
         module.get().click('bottomLeft', {force: true});
@@ -393,7 +397,7 @@ describe('Page builder - insertion points', () => {
 
     it('shows correct buttons for sixChildObjectsSingle with childObject5 populated', () => {
         const modulePath = `${homePath}/page-six-single-populated/area-main/test-six-single-populated`;
-        const pageBuilder = JContent
+        let pageBuilder = JContent
             .visit(siteKey, 'en', 'pages/home/page-six-single-populated')
             .switchToPageBuilder();
 
@@ -408,6 +412,10 @@ describe('Page builder - insertion points', () => {
         clickButtonByRole(pageBuilder, 'cent:childObject1');
         let contentEditor = new ContentEditor();
         contentEditor.create();
+
+        pageBuilder = JContent
+            .visit(siteKey, 'en', 'pages/home/page-six-single-populated')
+            .switchToPageBuilder();
 
         module = pageBuilder.getModule(modulePath, false);
         module.get().scrollIntoView();

--- a/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
@@ -1,6 +1,6 @@
-import {addNode, createSite, deleteSite, enableModule} from '@jahia/cypress';
+import {addNode, createSite, deleteSite, enableModule, getComponent, getComponentBySelector, Menu} from '@jahia/cypress';
 import gql from 'graphql-tag';
-import {ContentEditor, JContent} from '../../page-object';
+import {ContentEditor, ContentTypeSelector, JContent} from '../../page-object';
 
 const setButtonLimit = (value: string) => {
     return cy.apollo({
@@ -65,6 +65,27 @@ const clickButtonByRole = (pageBuilder, role: string) => {
  *
  *   When the limit is < 6 then all single use buttons are expected to be shown and all buttons that fall into multiple category will be
  *   replaced by one "New content" button which will show content type selector LIMITED to available types, in this case six types.
+ *
+ *   Below are some possible renderings that can happen depending on the definition.
+ *
+ *   Definition of multiple children of types a and b
+ *   <div id="moduleABC" jahiatype="module" nodetypes="a b">
+ *        <div type="placeholder" path="*"/>
+ *   </div>
+ *
+ *   Definition of a single named child a and multiple children of type b
+ *   <div id="moduleABC" jahiatype="module" nodetypes="b">
+ *       <div type="placeholder" path="childName" nodetypes="a"/>
+ *       <div type="placeholder" path="*"/>
+ *   </div>
+ *
+ *   If named child is added the placehoder will be replaced by <div type="existingNode" />. This is true for all named children.
+ *
+ *   Definition of multiple named children of type a and b (it could also be just one child). Note that the parent no longer has nodetypes.
+ *   <div id="moduleABC" jahiatype="module">
+ *       <div type="placeholder" path="childName" nodetypes="a"/>
+ *       <div type="placeholder" path="childName" nodetypes="b"/>
+ *   </div>
  *
  */
 describe('Page builder - insertion points', () => {
@@ -138,6 +159,26 @@ describe('Page builder - insertion points', () => {
                 children: [{
                     name: 'test-six-multiple',
                     primaryNodeType: 'cent:sixChildObjectsMultiple'
+                }]
+            }]
+        });
+
+        // Page with cent:oneChildMultipleList
+        addNode({
+            name: 'page-one-child-list',
+            parentPathOrId: homePath,
+            primaryNodeType: 'jnt:page',
+            properties: [
+                {name: 'jcr:title', value: 'One Child Multiple List', language: 'en'},
+                {name: 'j:templateName', value: 'simple'}
+            ],
+            children: [{
+                name: 'area-main',
+                primaryNodeType: 'jnt:contentList',
+                mixins: ['jmix:isAreaList'],
+                children: [{
+                    name: 'test-one-child-list',
+                    primaryNodeType: 'cent:oneChildMultipleList'
                 }]
             }]
         });
@@ -232,6 +273,37 @@ describe('Page builder - insertion points', () => {
         cy.get(contentTypeDialog)
             .find('[data-sel-role="content-type-tree-item"]')
             .should('have.length', 6);
+    });
+
+    it('shows correct buttons for oneChildMultipleList and verifies context menu', () => {
+        const modulePath = `${homePath}/page-one-child-list/area-main/test-one-child-list`;
+        const pageBuilder = JContent
+            .visit(siteKey, 'en', 'pages/home/page-one-child-list')
+            .switchToPageBuilder();
+
+        // Should show both "New childObject1" (typed button) and "New content" (generic)
+        assertButtonByRole(pageBuilder, 'cent:childObject1');
+        assertButtonByRole(pageBuilder, 'createContent');
+
+        // Click on the module to select it and show header
+        const module = pageBuilder.getModule(modulePath, false);
+        module.get().scrollIntoView();
+        module.get().click('bottomLeft', {force: true});
+
+        assertButtonByRole(pageBuilder, 'cent:childObject1');
+        assertButtonByRole(pageBuilder, 'createContent');
+
+        // Open the three-dot menu from the header
+        const header = module.getBox().getHeader();
+        header.getButton('contentItemActionsMenu').click();
+
+        // Verify "New content" exists in the context menu and click it
+        const menu = getComponentBySelector(Menu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)');
+        menu.selectByRole('createContent');
+
+        const selector = getComponent(ContentTypeSelector);
+        const ce = selector.searchForContentType('cent:childObject1').selectContentType('cent:childObject1').create();
+        ce.cancel();
     });
 });
 

--- a/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
@@ -175,7 +175,7 @@ describe('Page builder - insertion points', () => {
 
     it('shows correct create buttons for sixChildObjectsMultiple and verifies insertion points after create', () => {
         const modulePath = `${homePath}/page-six-multiple/area-main/test-six-multiple`;
-        const pageBuilder = JContent
+        let pageBuilder = JContent
             .visit(siteKey, 'en', 'pages/home/page-six-multiple')
             .switchToPageBuilder();
 
@@ -186,6 +186,11 @@ describe('Page builder - insertion points', () => {
         clickButtonByRole(pageBuilder, 'cent:childObject1');
         const contentEditor = new ContentEditor();
         contentEditor.create();
+
+        // Renavigate to refresh module state
+        pageBuilder = JContent
+            .visit(siteKey, 'en', 'pages/home/page-six-multiple')
+            .switchToPageBuilder();
 
         const updatedModule = pageBuilder.getModule(modulePath);
         updatedModule.get().scrollIntoView();

--- a/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
@@ -146,7 +146,7 @@ describe('Page builder - insertion points', () => {
     after(() => {
         // Reset limit back to default
         setButtonLimit('5');
-        //deleteSite(siteKey);
+        deleteSite(siteKey);
     });
 
     beforeEach(() => {

--- a/tests/cypress/page-object/jcontent.ts
+++ b/tests/cypress/page-object/jcontent.ts
@@ -310,7 +310,7 @@ export class JContentPageBuilder extends JContent {
         const parentFrame = this.iframe(bypassFrameLoadedCheck);
         // I see cypress querying the module even before iFrame has settled and verified.
         // Force a wait here to settle the iframe first before continuing
-        cy.wait(1500); // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
         const module = getComponentBySelector(PageBuilderModule, `[jahiatype="module"][path="${path}"]`, parentFrame);
         module.should('exist').and('be.visible');
         module.parentFrame = parentFrame;

--- a/tests/cypress/page-object/jcontent.ts
+++ b/tests/cypress/page-object/jcontent.ts
@@ -310,7 +310,7 @@ export class JContentPageBuilder extends JContent {
         const parentFrame = this.iframe(bypassFrameLoadedCheck);
         // I see cypress querying the module even before iFrame has settled and verified.
         // Force a wait here to settle the iframe first before continuing
-        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.wait(1500); // eslint-disable-line cypress/no-unnecessary-waiting
         const module = getComponentBySelector(PageBuilderModule, `[jahiatype="module"][path="${path}"]`, parentFrame);
         module.should('exist').and('be.visible');
         module.parentFrame = parentFrame;

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModule.ts
@@ -65,6 +65,14 @@ export class PageBuilderModule extends BaseComponent {
         }));
     }
 
+    getAllCreateButtons() {
+        return new PageBuilderModuleCreateButton(
+            this.getBox().getHeader().get().invoke('attr', 'data-jahia-id').then(id => {
+                return this.parentFrame.get().find(`[jahiatype="createbuttons"][data-jahia-parent="${id}"]`).filter(':visible');
+            })
+        );
+    }
+
     assertHasNoCreateButtons() {
         this.get().find('[jahiatype="module"][type="placeholder"]').invoke('attr', 'id').then(id => {
             return cy.get('iframe[data-sel-role="page-builder-frame-active"]').find(`[jahiatype="createbuttons"][data-jahia-id="${id}"]`).should('not.exist');

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -228,6 +228,9 @@
  + childObject1 (cent:childObject1)
  + childObject2 (cent:childObject2)
 
+[cent:oneChildMultipleList] > jnt:contentList, jmix:editorialContent orderable
+  + * (cent:childObject1)
+
  [cent:twoChildObjectsOneMultiple] > jnt:content, jmix:basicContent, jmix:editorialContent
   - someProperty (string)
   + childObject1 (cent:childObject1)

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -204,3 +204,52 @@
 
 [cemix:emptyTemplateMixin2] > jmix:templateMixin mixin
  extends = cent:emptyTemplateMixinTest
+
+[cent:childObject1] > jnt:content, jmix:basicContent, jmix:editorialContent
+ - obj1 (string)
+
+[cent:childObject2] > jnt:content, jmix:basicContent, jmix:editorialContent
+ - obj2 (string)
+
+[cent:childObject3] > jnt:content, jmix:basicContent, jmix:editorialContent
+ - obj3 (string)
+
+[cent:childObject4] > jnt:content, jmix:basicContent, jmix:editorialContent
+ - obj4 (string)
+
+ [cent:childObject5] > jnt:content, jmix:basicContent, jmix:editorialContent
+  - obj5 (string)
+
+ [cent:childObject6] > jnt:content, jmix:basicContent, jmix:editorialContent
+  - obj6 (string)
+
+[cent:twoChildObjects] > jnt:content, jmix:basicContent, jmix:editorialContent
+ - someProperty (string)
+ + childObject1 (cent:childObject1)
+ + childObject2 (cent:childObject2)
+
+ [cent:twoChildObjectsOneMultiple] > jnt:content, jmix:basicContent, jmix:editorialContent
+  - someProperty (string)
+  + childObject1 (cent:childObject1)
+  + childObject2 (cent:childObject2)
+  + * (cent:childObject3)
+
+ [cent:sixChildObjectsSingle] > jnt:content, jmix:basicContent, jmix:editorialContent
+  - someProperty (string)
+  + childObject1 (cent:childObject1)
+  + childObject2 (cent:childObject2)
+  + childObject3 (cent:childObject3)
+  + childObject4 (cent:childObject4)
+  + childObject5 (cent:childObject5)
+  + childObject6 (cent:childObject6)
+
+ [cent:sixChildObjectsMultiple] > jnt:content, jmix:basicContent, jmix:editorialContent
+  - someProperty (string)
+  + * (cent:childObject1)
+  + * (cent:childObject2)
+  + * (cent:childObject3)
+  + * (cent:childObject4)
+  + * (cent:childObject5)
+  + * (cent:childObject6)
+
+

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/cent_childObject1/html/childObject1.jsp
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/cent_childObject1/html/childObject1.jsp
@@ -1,0 +1,1 @@
+<div>childObject1</div>

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/cent_childObject2/html/childObject2.jsp
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/cent_childObject2/html/childObject2.jsp
@@ -1,0 +1,1 @@
+<div>childObject2</div>

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/cent_childObject3/html/childObject3.jsp
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/cent_childObject3/html/childObject3.jsp
@@ -1,0 +1,1 @@
+<div>childObject3</div>

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/cent_childObject4/html/childObject4.jsp
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/cent_childObject4/html/childObject4.jsp
@@ -1,0 +1,1 @@
+<div>childObject4</div>

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/cent_childObject5/html/childObject5.jsp
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/cent_childObject5/html/childObject5.jsp
@@ -1,0 +1,1 @@
+<div>childObject5</div>

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/cent_childObject6/html/childObject6.jsp
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/cent_childObject6/html/childObject6.jsp
@@ -1,0 +1,1 @@
+<div>childObject6</div>

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/cent_sixChildObjectsMultiple/html/sixChildObjectsMultiple.jsp
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/cent_sixChildObjectsMultiple/html/sixChildObjectsMultiple.jsp
@@ -18,6 +18,17 @@
 <%--@elvariable id="currentResource" type="org.jahia.services.render.Resource"--%>
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
 sixChildObjectsMultiple
+<c:set value="${jcr:getChildrenOfType(currentNode, 'cent:childObject1')}" var="childrenOne"/>
+
+<c:if test="${not empty childrenOne}">
+    <div>
+        <c:forEach items="${childrenOne}" var="ch1" varStatus="status">
+            <div>
+                <template:module path="${ch1.path}" editable="true" />
+            </div>
+        </c:forEach>
+    </div>
+</c:if>
 
 <c:if test="${renderContext.editMode}">
 <template:module path="*"/>

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/cent_sixChildObjectsMultiple/html/sixChildObjectsMultiple.jsp
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/cent_sixChildObjectsMultiple/html/sixChildObjectsMultiple.jsp
@@ -1,0 +1,24 @@
+<%@ page language="java" contentType="text/html;charset=UTF-8" %>
+<%@ taglib prefix="template" uri="http://www.jahia.org/tags/templateLib" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="jcr" uri="http://www.jahia.org/tags/jcr" %>
+<%@ taglib prefix="ui" uri="http://www.jahia.org/tags/uiComponentsLib" %>
+<%@ taglib prefix="functions" uri="http://www.jahia.org/tags/functions" %>
+<%@ taglib prefix="query" uri="http://www.jahia.org/tags/queryLib" %>
+<%@ taglib prefix="utility" uri="http://www.jahia.org/tags/utilityLib" %>
+<%@ taglib prefix="s" uri="http://www.jahia.org/tags/search" %>
+<%--@elvariable id="currentNode" type="org.jahia.services.content.JCRNodeWrapper"--%>
+<%--@elvariable id="out" type="java.io.PrintWriter"--%>
+<%--@elvariable id="script" type="org.jahia.services.render.scripting.Script"--%>
+<%--@elvariable id="scriptInfo" type="java.lang.String"--%>
+<%--@elvariable id="workspace" type="java.lang.String"--%>
+<%--@elvariable id="renderContext" type="org.jahia.services.render.RenderContext"--%>
+<%--@elvariable id="currentResource" type="org.jahia.services.render.Resource"--%>
+<%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
+sixChildObjectsMultiple
+
+<c:if test="${renderContext.editMode}">
+<template:module path="*"/>
+</c:if>

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/cent_sixChildObjectsSingle/html/sixChildObjectsSingle.jsp
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/cent_sixChildObjectsSingle/html/sixChildObjectsSingle.jsp
@@ -1,0 +1,30 @@
+<%@ page language="java" contentType="text/html;charset=UTF-8" %>
+<%@ taglib prefix="template" uri="http://www.jahia.org/tags/templateLib" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="jcr" uri="http://www.jahia.org/tags/jcr" %>
+<%@ taglib prefix="ui" uri="http://www.jahia.org/tags/uiComponentsLib" %>
+<%@ taglib prefix="functions" uri="http://www.jahia.org/tags/functions" %>
+<%@ taglib prefix="query" uri="http://www.jahia.org/tags/queryLib" %>
+<%@ taglib prefix="utility" uri="http://www.jahia.org/tags/utilityLib" %>
+<%@ taglib prefix="s" uri="http://www.jahia.org/tags/search" %>
+<%--@elvariable id="currentNode" type="org.jahia.services.content.JCRNodeWrapper"--%>
+<%--@elvariable id="out" type="java.io.PrintWriter"--%>
+<%--@elvariable id="script" type="org.jahia.services.render.scripting.Script"--%>
+<%--@elvariable id="scriptInfo" type="java.lang.String"--%>
+<%--@elvariable id="workspace" type="java.lang.String"--%>
+<%--@elvariable id="renderContext" type="org.jahia.services.render.RenderContext"--%>
+<%--@elvariable id="currentResource" type="org.jahia.services.render.Resource"--%>
+<%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
+
+sixChildObjectsSingle
+
+<c:if test="${renderContext.editMode}">
+    <template:module path="childObject1"/>
+    <template:module path="childObject2"/>
+    <template:module path="childObject3"/>
+    <template:module path="childObject4"/>
+    <template:module path="childObject5"/>
+    <template:module path="childObject6"/>
+</c:if>

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/cent_twoChildObjectsOneMultiple/html/twoChildObjectsOneMultiple.jsp
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/cent_twoChildObjectsOneMultiple/html/twoChildObjectsOneMultiple.jsp
@@ -1,0 +1,26 @@
+<%@ page language="java" contentType="text/html;charset=UTF-8" %>
+<%@ taglib prefix="template" uri="http://www.jahia.org/tags/templateLib" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="jcr" uri="http://www.jahia.org/tags/jcr" %>
+<%@ taglib prefix="ui" uri="http://www.jahia.org/tags/uiComponentsLib" %>
+<%@ taglib prefix="functions" uri="http://www.jahia.org/tags/functions" %>
+<%@ taglib prefix="query" uri="http://www.jahia.org/tags/queryLib" %>
+<%@ taglib prefix="utility" uri="http://www.jahia.org/tags/utilityLib" %>
+<%@ taglib prefix="s" uri="http://www.jahia.org/tags/search" %>
+<%--@elvariable id="currentNode" type="org.jahia.services.content.JCRNodeWrapper"--%>
+<%--@elvariable id="out" type="java.io.PrintWriter"--%>
+<%--@elvariable id="script" type="org.jahia.services.render.scripting.Script"--%>
+<%--@elvariable id="scriptInfo" type="java.lang.String"--%>
+<%--@elvariable id="workspace" type="java.lang.String"--%>
+<%--@elvariable id="renderContext" type="org.jahia.services.render.RenderContext"--%>
+<%--@elvariable id="currentResource" type="org.jahia.services.render.Resource"--%>
+<%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
+twoChildObjectsOneMultiple
+
+<c:if test="${renderContext.editMode}">
+    <template:module path="childObject1"/>
+    <template:module path="childObject2"/>
+    <template:module path="*"/>
+</c:if>


### PR DESCRIPTION
### Description
Correctly resolve insertion point buttons. Make sure DOMs placeholder elements are used as the source of truth for driving what types of create buttons are available. Make sure that create buttons and insertion points are shown correctly for definitions with fixed and variable number of children. So if I have a definition with 4 different types of children defined as `+ *` I can see 4 distinct buttons for these types and not 4 buttons of the same type.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
