### PR TITLE
chore: Change module reference to use 'js:' prefix

### DIFF
--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -14,7 +14,7 @@
     - 'mvn:org.jahia.modules/jahia-ui-root'
     - 'mvn:org.jahia.test/jcontent-test-module'
     - 'mvn:org.jahia.test/jcontent-test-template'
-    - 'mvn:org.jahia.modules.javascript/jcontent-test-js-template'
+    - 'js:mvn:org.jahia.modules.javascript/jcontent-test-js-template'
   autoStart: true
   uninstallPreviousVersion: true
 - include: 'provisioning.yml'

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -14,7 +14,7 @@
     - 'mvn:org.jahia.modules/jahia-ui-root'
     - 'mvn:org.jahia.test/jcontent-test-module'
     - 'mvn:org.jahia.test/jcontent-test-template'
-    - 'js:mvn:org.jahia.modules.javascript/jcontent-test-js-template'
+    - 'js:mvn:org.jahia.modules.javascript/jcontent-test-js-template/LATEST/tgz'
   autoStart: true
   uninstallPreviousVersion: true
 - include: 'provisioning.yml'


### PR DESCRIPTION
### Description
Module still not found in testsetup.
Compared to provisioning of other js-modules - added the prefix.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
