### PR TITLE
feat: Replace username with user metadata in UI

### DIFF
--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderBadges/PublicationInfoBadge.tooltip.js
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderBadges/PublicationInfoBadge.tooltip.js
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import {Constants} from '../../../ContentEditor.constants';
+import {getDisplayName} from '~/utils/userDisplay';
 
 function formatDate(date, locale, format = 'LLL') {
     return dayjs(date).locale(locale).format(format);
@@ -10,7 +11,7 @@ const tooltips = {
         return {
             key: 'label.contentEditor.publicationStatusTooltip.modified',
             args: {
-                userName: publicationInfoContext.lastModifiedBy || '?',
+                userName: getDisplayName(publicationInfoContext.lastModifiedByUser) || publicationInfoContext.lastModifiedBy || '?',
                 timestamp: formatDate(publicationInfoContext.lastModified, uilang)
             }
         };
@@ -19,7 +20,7 @@ const tooltips = {
         return {
             key: 'label.contentEditor.publicationStatusTooltip.published',
             args: {
-                userName: publicationInfoContext.lastPublishedBy || '?',
+                userName: getDisplayName(publicationInfoContext.lastPublishedByUser) || publicationInfoContext.lastPublishedBy || '?',
                 timestamp: formatDate(publicationInfoContext.lastPublished, uilang)
             }
         };

--- a/src/javascript/ContentEditor/contexts/PublicationInfo/PublicationInfo.gql-queries.js
+++ b/src/javascript/ContentEditor/contexts/PublicationInfo/PublicationInfo.gql-queries.js
@@ -13,11 +13,23 @@ export const PublicationInfoQuery = gql`
                 lastModifiedBy:property(name:"jcr:lastModifiedBy", language: $language){
                     value
                 }
+                lastModifiedByUser(language: $language) {
+                    username
+                    firstname
+                    lastname
+                    email
+                }
                 lastModified:property(name:"jcr:lastModified", language: $language){
                     value
                 }
                 lastPublishedBy:property(name:"j:lastPublishedBy", language: $language){
                     value
+                }
+                lastPublishedByUser(language: $language) {
+                    username
+                    firstname
+                    lastname
+                    email
                 }
                 lastPublished:property(name:"j:lastPublished", language: $language){
                     value

--- a/src/javascript/ContentEditor/contexts/PublicationInfo/usePublicationInfo.jsx
+++ b/src/javascript/ContentEditor/contexts/PublicationInfo/usePublicationInfo.jsx
@@ -34,8 +34,10 @@ export const usePublicationInfo = (queryParams, t) => {
         existsInLive: data.jcr.nodeById.aggregatedPublicationInfo.existsInLive,
         lastModified: data.jcr.nodeById.lastModified?.value,
         lastModifiedBy: data.jcr.nodeById.lastModifiedBy?.value,
+        lastModifiedByUser: data.jcr.nodeById.lastModifiedByUser,
         lastPublished: data.jcr.nodeById.lastPublished?.value,
         lastPublishedBy: data.jcr.nodeById.lastPublishedBy?.value,
+        lastPublishedByUser: data.jcr.nodeById.lastPublishedByUser,
         publicationInfoPolling: false
     };
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/columns/columns.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/columns/columns.js
@@ -1,5 +1,4 @@
 import {
-    Cell,
     CellCreatedBy,
     CellLastModified,
     CellName,

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/columns/columns.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/columns/columns.js
@@ -1,5 +1,6 @@
 import {
     Cell,
+    CellCreatedBy,
     CellLastModified,
     CellName,
     CellPublicationStatus,
@@ -71,7 +72,7 @@ export const createdBy = {
     sortable: true,
     property: 'createdBy.value',
     Header: Header,
-    Cell: Cell,
+    Cell: CellCreatedBy,
     width: '150px'
 
 };

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellCreatedBy.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/CellCreatedBy.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {TableBodyCell, Typography} from '@jahia/moonstone';
+import {getDisplayName} from '~/utils/userDisplay';
+
+export const CellCreatedBy = ({value, cell, column, row}) => {
+    const displayName = getDisplayName(row?.original?.createdByUser) || value;
+    return (
+        <TableBodyCell key={row.id + column.id}
+                       {...cell.getCellProps()}
+                       width={column.width}
+                       data-cm-role={'table-content-list-cell-' + column.id}
+        >
+            <Typography>{displayName}</Typography>
+        </TableBodyCell>
+    );
+};
+
+CellCreatedBy.propTypes = {
+    value: PropTypes.string,
+    cell: PropTypes.object,
+    column: PropTypes.object,
+    row: PropTypes.object
+};

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/index.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/components/cells/index.js
@@ -9,3 +9,4 @@ export * from './CellStatus';
 export * from './CellType';
 export * from './CellNameNoIcon';
 export * from './CellFileSize';
+export * from './CellCreatedBy';

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PublicationStatus/PublicationStatus.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/PublicationStatus/PublicationStatus.jsx
@@ -7,6 +7,7 @@ import JContentConstants from '~/JContent/JContent.constants';
 import {lodash as _} from 'lodash';
 import {useSelector} from 'react-redux';
 import {getDefaultLocale, isMarkedForDeletion} from '~/JContent/JContent.utils';
+import {getDisplayName} from '~/utils/userDisplay';
 
 import styles from './PublicationStatus.scss';
 
@@ -25,7 +26,7 @@ export const PublicationStatus = ({previewSelection}) => {
             <Typography component="span"
                         className={styles.publicationInfoMarkedForDeletion}
             >
-                {t('jcontent:label.contentManager.contentPreview.markedForDeletionBy', {userName: _.get(previewSelection, 'deletedBy.value', '')})}
+                {t('jcontent:label.contentManager.contentPreview.markedForDeletionBy', {userName: getDisplayName(previewSelection?.deletedByUser) || _.get(previewSelection, 'deletedBy.value', '')})}
             &nbsp;
                 <time>{dayjs(_.get(previewSelection, 'deleted.value', '')).locale(defaultLocale).format('LLL')}</time>
             </Typography>
@@ -38,7 +39,7 @@ export const PublicationStatus = ({previewSelection}) => {
                 <Typography component="p"
                             className={styles.publicationInfoModified}
                 >
-                    {t('jcontent:label.contentManager.contentPreview.modifiedBy', {userName: _.get(previewSelection, 'lastModifiedBy.value', '')})}
+                    {t('jcontent:label.contentManager.contentPreview.modifiedBy', {userName: getDisplayName(previewSelection?.lastModifiedByUser) || _.get(previewSelection, 'lastModifiedBy.value', '')})}
                 &nbsp;
                     <time>{dayjs(_.get(previewSelection, 'lastModified.value', '')).locale(defaultLocale).format('LLL')}</time>
                 </Typography>
@@ -48,7 +49,7 @@ export const PublicationStatus = ({previewSelection}) => {
                 <Typography component="p"
                             className={styles.publicationInfoPublished}
                 >
-                    {t('jcontent:label.contentManager.contentPreview.publishedBy', {userName: _.get(previewSelection, 'lastPublishedBy.value', '')})}
+                    {t('jcontent:label.contentManager.contentPreview.publishedBy', {userName: getDisplayName(previewSelection?.lastPublishedByUser) || _.get(previewSelection, 'lastPublishedBy.value', '')})}
                 &nbsp;
                     <time>{dayjs(_.get(previewSelection, 'lastPublished.value', '')).locale(defaultLocale).format('LLL')}</time>
                 </Typography>
@@ -66,7 +67,7 @@ export const PublicationStatus = ({previewSelection}) => {
                 <Typography component="p"
                             className={styles.publicationInfoUnpublished}
                 >
-                    {t('jcontent:label.contentManager.contentPreview.unPublishedBy', {userName: _.get(previewSelection, 'lastModifiedBy.value', '')})}
+                    {t('jcontent:label.contentManager.contentPreview.unPublishedBy', {userName: getDisplayName(previewSelection?.lastModifiedByUser) || _.get(previewSelection, 'lastModifiedBy.value', '')})}
                 &nbsp;
                     <time>{dayjs(_.get(previewSelection, 'lastModified.value', '')).locale(defaultLocale).format('LLL')}</time>
                 </Typography>

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/BaseQueryHandler.gql-queries.js
@@ -23,6 +23,12 @@ export const QueryHandlersFragments = {
                 createdBy: property(name: "jcr:createdBy") {
                     value
                 }
+                createdByUser {
+                    username
+                    firstname
+                    lastname
+                    email
+                }
                 created: property(name: "jcr:created") {
                     value
                 }
@@ -46,20 +52,44 @@ export const QueryHandlersFragments = {
                 lockOwner: property(name: "jcr:lockOwner") {
                     value
                 }
+                lockOwnerUser {
+                    username
+                    firstname
+                    lastname
+                    email
+                }
                 lastPublished: property(name: "j:lastPublished", language: $language) {
                     value
                 }
                 lastPublishedBy: property(name: "j:lastPublishedBy", language: $language) {
                     value
                 }
+                lastPublishedByUser(language: $language) {
+                    username
+                    firstname
+                    lastname
+                    email
+                }
                 lastModifiedBy: property(name: "jcr:lastModifiedBy", language: $language) {
                     value
+                }
+                lastModifiedByUser(language: $language) {
+                    username
+                    firstname
+                    lastname
+                    email
                 }
                 lastModified: property(name: "jcr:lastModified", language: $language) {
                     value
                 }
                 deletedBy: property(name: "j:deletionUser", language: $language) {
                     value
+                }
+                deletedByUser(language: $language) {
+                    username
+                    firstname
+                    lastname
+                    email
                 }
                 deleted: property(name: "j:deletionDate", language: $language) {
                     value

--- a/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.gql-queries.js
@@ -7,6 +7,12 @@ export const contentStatusFragment = {
         lastModifiedBy: property(name: "jcr:lastModifiedBy", language: $language) {
             value
         }
+        lastModifiedByUser(language: $language) {
+            username
+            firstname
+            lastname
+            email
+        }
         lastModified: property(name: "jcr:lastModified", language: $language) {
             value
         }
@@ -16,8 +22,20 @@ export const contentStatusFragment = {
         lastPublishedBy: property(name: "j:lastPublishedBy", language: $language) {
             value
         }
+        lastPublishedByUser(language: $language) {
+            username
+            firstname
+            lastname
+            email
+        }
         deletedBy: property(name: "j:deletionUser", language: $language) {
             value
+        }
+        deletedByUser(language: $language) {
+            username
+            firstname
+            lastname
+            email
         }
         deleted: property(name: "j:deletionDate", language: $language) {
             value
@@ -27,6 +45,12 @@ export const contentStatusFragment = {
         }
         lockOwner: property(name: "jcr:lockOwner") {
             value
+        }
+        lockOwnerUser {
+            username
+            firstname
+            lastname
+            email
         }
         lockTypes: property(name: "j:lockTypes") {
             values

--- a/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.utils.js
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.utils.js
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 
 import {getDefaultLocale} from '~/JContent/JContent.utils';
 import JContentConstants from '~/JContent/JContent.constants';
+import {getDisplayName} from '~/utils/userDisplay';
 
 function formatDate(date, locale = 'en', format = 'LLL') {
     return dayjs(date).locale(locale).format(format);
@@ -12,13 +13,13 @@ const tooltips = {
         return {
             key: 'label.contentManager.lockedBy',
             args: {
-                userName: node?.lockOwner?.value || '?'
+                userName: getDisplayName(node?.lockOwnerUser) || node?.lockOwner?.value || '?'
             }
         };
     },
     markedForDeletion: (node, locale) => {
         const ancestor = node.ancestors && (node.ancestors.length !== 0) && node.ancestors[0];
-        const deletedBy = node?.deletedBy?.value || ancestor?.deletedBy?.value;
+        const deletedBy = getDisplayName(node?.deletedByUser) || node?.deletedBy?.value || ancestor?.deletedBy?.value;
         const date = node?.deleted?.value || ancestor?.deleted?.value;
         return {
             key: 'label.contentManager.publicationStatus.markedForDeletion',
@@ -32,7 +33,7 @@ const tooltips = {
         return {
             key: 'label.contentManager.publicationStatus.modified',
             args: {
-                userName: node?.lastModifiedBy?.value || '?',
+                userName: getDisplayName(node?.lastModifiedByUser) || node?.lastModifiedBy?.value || '?',
                 timestamp: formatDate(node?.lastModified?.value, locale)
             }
         };
@@ -46,7 +47,7 @@ const tooltips = {
         return {
             key: 'label.contentManager.publicationStatus.published',
             args: {
-                userName: node?.lastPublishedBy?.value || '?',
+                userName: getDisplayName(node?.lastPublishedByUser) || node?.lastPublishedBy?.value || '?',
                 timestamp: formatDate(node?.lastPublished?.value, locale)
             }
         };

--- a/src/javascript/JContent/PublicationStatus/publicationStatusRenderer.jsx
+++ b/src/javascript/JContent/PublicationStatus/publicationStatusRenderer.jsx
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import {Tooltip} from '@material-ui/core';
 import {getDefaultLocale, isMarkedForDeletion} from '~/JContent/JContent.utils';
 import {CloudCheck, Delete, File, NoCloud, Warning} from '@jahia/moonstone';
+import {getDisplayName} from '~/utils/userDisplay';
 
 function getFormattedDate(date, locale) {
     return dayjs(date).locale(getDefaultLocale(locale)).format('LLL');
@@ -50,7 +51,7 @@ class PublicationStatusNotPublished {
 
 class PublicationStatusPublished {
     geti18nDetailsMessage(node, t, locale = 'en') {
-        const userName = node?.lastPublishedBy?.value || '';
+        const userName = getDisplayName(node?.lastPublishedByUser) || node?.lastPublishedBy?.value || '';
         const lastPublished = node?.lastPublished?.value || '';
 
         return (
@@ -76,7 +77,7 @@ class PublicationStatusPublished {
 
 class PublicationStatusModified {
     geti18nDetailsMessage(node, t, locale = 'en') {
-        const userName = node?.lastModifiedBy?.value || '';
+        const userName = getDisplayName(node?.lastModifiedByUser) || node?.lastModifiedBy?.value || '';
         const lastModified = node?.lastModified?.value || '';
 
         return (
@@ -105,7 +106,7 @@ class PublicationStatusMarkedForDeletion {
         let parentDeletionUser = (node.ancestors && node.ancestors[0]?.deletionUser?.value) || '';
         let parentDeletionDate = (node.ancestors && node.ancestors[0]?.deletionDate?.value) || '';
 
-        let userName = node?.deletedBy?.value || parentDeletionUser;
+        let userName = getDisplayName(node?.deletedByUser) || node?.deletedBy?.value || parentDeletionUser;
         let deletedTs = node?.deleted?.value || parentDeletionDate;
 
         return (

--- a/src/javascript/utils/index.js
+++ b/src/javascript/utils/index.js
@@ -2,3 +2,4 @@ export * from './compose';
 export * from './getIcon';
 export {default as NodeIcon} from './NodeIcon';
 export {truncate, truncateMiddle} from './truncate';
+export {getDisplayName} from './userDisplay';

--- a/src/javascript/utils/userDisplay.js
+++ b/src/javascript/utils/userDisplay.js
@@ -1,0 +1,20 @@
+/**
+ * Returns a human-readable display name for a GQL user object.
+ *
+ * Priority: "Firstname Lastname" → email → username → null
+ *
+ * @param {Object|null|undefined} user - GQL User object with optional firstname, lastname, email, username
+ * @returns {string|null}
+ */
+export const getDisplayName = user => {
+    if (!user) {
+        return null;
+    }
+
+    const parts = [user.firstname, user.lastname].filter(Boolean);
+    if (parts.length > 0) {
+        return parts.join(' ');
+    }
+
+    return user.email || user.username || null;
+};


### PR DESCRIPTION
### Description

Adapts new user metadata graphql endpoint in the requests https://github.com/Jahia/graphql-core/pull/608

Dependent on graphql-core PR above  and needs to merged first.

Added util `getDisplayName` to display user metadata with specified order of display - name, email, username

Affected UI changes:

- Badge tooltips in:
  - content editor header
  - jcontent header
  - file grid cards
- Publication status and Created by columns in jcontent list and structured views

TODO 
- add tests

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
