### PR TITLE
fix: Use content type name when area is not a content list

### DIFF
--- a/.chachalog/BjcI9y9J.md
+++ b/.chachalog/BjcI9y9J.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Use content type name to indicate inserted content in page builder when area is not a content list (#2321)

--- a/src/javascript/JContent/EditFrame/DefaultBar.jsx
+++ b/src/javascript/JContent/EditFrame/DefaultBar.jsx
@@ -58,11 +58,11 @@ export const LabelBar = ({node, area, dragProps}) => {
     const title = truncate(node.displayName, 24);
     const boundComponentTitleAddOn = node?.boundComponent?.refNode?.displayName ? ` - ${t('jcontent:label.contentManager.pageBuilder.box.linkedTo')} ${node?.boundComponent?.refNode?.displayName}` : '';
 
-    if (area) {A
+    if (area) {
         let label = area.isArea ? 'Area' : area.isAbsolute ? 'Absolute Area' : 'List';
 
         if (area.isArea || area.isArea && node.primaryNodeType?.name !== 'jnt:contentList') {
-            label += ` - ${node.primaryNodeType?.displayName}`
+            label = `${node.primaryNodeType?.displayName}`
         }
 
         return (

--- a/src/javascript/JContent/EditFrame/DefaultBar.jsx
+++ b/src/javascript/JContent/EditFrame/DefaultBar.jsx
@@ -61,7 +61,7 @@ export const LabelBar = ({node, area, dragProps}) => {
     if (area) {
         let label = area.isArea ? 'Area' : area.isAbsolute ? 'Absolute Area' : 'List';
 
-        if ((area.isArea || area.isAbsolute) && node.primaryNodeType?.name !== 'jnt:contentList') {
+        if (area.isArea && node.primaryNodeType?.name !== 'jnt:contentList') {
             label = `${node.primaryNodeType?.displayName}`
         }
 

--- a/src/javascript/JContent/EditFrame/DefaultBar.jsx
+++ b/src/javascript/JContent/EditFrame/DefaultBar.jsx
@@ -61,7 +61,7 @@ export const LabelBar = ({node, area, dragProps}) => {
     if (area) {
         let label = area.isArea ? 'Area' : area.isAbsolute ? 'Absolute Area' : 'List';
 
-        if (area.isArea || area.isArea && node.primaryNodeType?.name !== 'jnt:contentList') {
+        if ((area.isArea || area.isAbsolute) && node.primaryNodeType?.name !== 'jnt:contentList') {
             label = `${node.primaryNodeType?.displayName}`
         }
 

--- a/src/javascript/JContent/EditFrame/DefaultBar.jsx
+++ b/src/javascript/JContent/EditFrame/DefaultBar.jsx
@@ -58,13 +58,19 @@ export const LabelBar = ({node, area, dragProps}) => {
     const title = truncate(node.displayName, 24);
     const boundComponentTitleAddOn = node?.boundComponent?.refNode?.displayName ? ` - ${t('jcontent:label.contentManager.pageBuilder.box.linkedTo')} ${node?.boundComponent?.refNode?.displayName}` : '';
 
-    if (area) {
+    if (area) {A
+        let label = area.isArea ? 'Area' : area.isAbsolute ? 'Absolute Area' : 'List';
+
+        if (area.isArea || area.isArea && node.primaryNodeType?.name !== 'jnt:contentList') {
+            label += ` - ${node.primaryNodeType?.displayName}`
+        }
+
         return (
             <>
                 {dragProps?.isDraggable && <HandleDrag color={dragProps?.isCanDrag ? undefined : 'gray'}/>}
                 <Chip variant="default"
                       color="accent"
-                      label={area.isArea ? 'Area' : area.isAbsolute ? 'Absolute Area' : 'List'}
+                      label={label}
                       icon={getAreaIcon(node, area)}/>
                 <Typography isNowrap weight="bold" variant="caption">{title}{boundComponentTitleAddOn}</Typography>
             </>

--- a/src/javascript/JContent/EditFrame/DefaultBar.jsx
+++ b/src/javascript/JContent/EditFrame/DefaultBar.jsx
@@ -62,7 +62,7 @@ export const LabelBar = ({node, area, dragProps}) => {
         let label = area.isArea ? 'Area' : area.isAbsolute ? 'Absolute Area' : 'List';
 
         if (area.isArea && node.primaryNodeType?.name !== 'jnt:contentList') {
-            label = `${node.primaryNodeType?.displayName}`
+            label = `${node.primaryNodeType?.displayName}`;
         }
 
         return (


### PR DESCRIPTION
### Description
Use content type name when area is not a content list so that users can see what type of content is displayed by the area. 
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
