### PR TITLE
fix: Exclude read-only fields from saving edit content

### DIFF
--- a/.chachalog/37c_v_rj.md
+++ b/.chachalog/37c_v_rj.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": patch
+---
+
+Exclude read-only fields from save content on edit to prevent editor permission issues on save (#2322)

--- a/.chachalog/37c_v_rj.md
+++ b/.chachalog/37c_v_rj.md
@@ -1,6 +1,6 @@
 ---
 # Allowed version bumps: patch, minor, major
-"@jahia/jcontent": patch
+"@jahia/jcontent": minor
 ---
 
-Exclude read-only fields from save content on edit to prevent editor permission issues on save (#2322)
+Exclude read-only fields from saved content during edits to prevent permission issues when saving. (#2322)

--- a/src/javascript/ContentEditor/ContentEditor/updateNode/updateNode.js
+++ b/src/javascript/ContentEditor/ContentEditor/updateNode/updateNode.js
@@ -23,7 +23,7 @@ export const updateNode = ({
     }
 }) => {
     const dataToMutate = getDataToMutate({nodeData, formValues: values, i18nContext, sections, lang: language});
-    const {childrenOrder, shouldModifyChildren} = getChildrenOrder(values, nodeData);
+    const {childrenOrder, shouldModifyChildren} = getChildrenOrder(values, nodeData, sections);
     const wipInfo = values[Constants.wip.fieldName];
     let variables = adaptUpdateRequest(nodeData, {
         uuid: nodeData.uuid,

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ManualOrdering/DragDrop/DraggableReference.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ManualOrdering/DragDrop/DraggableReference.jsx
@@ -18,10 +18,10 @@ export const DraggableReference = ({
     onValueMove,
     fieldName,
     fieldLength,
-    readOnly
+    isReadOnly
 }) => {
     const {t} = useTranslation('jcontent');
-    const isDraggable = fieldLength > 1 && !readOnly;
+    const isDraggable = fieldLength > 1 && !isReadOnly;
 
     const ref = useRef(null);
     const [{handlerId}, drop] = useReorderDrop(
@@ -53,7 +53,7 @@ export const DraggableReference = ({
                 emptyLabel={t('jcontent:label.contentEditor.edit.fields.imagePicker.addImage')}
                 emptyIcon={<File/>}
                 isReadOnly={child.readOnly}
-                cardAction={fieldLength > 1 && !readOnly &&
+                cardAction={fieldLength > 1 && !isReadOnly &&
                     <div className={styles.referenceCardActions}>
                         <div style={{display: 'flex', flexDirection: 'column', justifyContent: 'space-between'}}>
                             <Tooltip label={t('jcontent:label.contentEditor.section.listAndOrdering.btnMoveFirst')}>
@@ -119,7 +119,7 @@ DraggableReference.propTypes = {
     onReorder: PropTypes.func.isRequired,
     onValueMove: PropTypes.func.isRequired,
     fieldLength: PropTypes.number,
-    readOnly: PropTypes.bool,
+    isReadOnly: PropTypes.bool,
     onReorderDropped: PropTypes.func.isRequired,
     onReorderAborted: PropTypes.func.isRequired
 };

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ManualOrdering/DragDrop/DraggableReference.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ManualOrdering/DragDrop/DraggableReference.jsx
@@ -17,10 +17,11 @@ export const DraggableReference = ({
     onReorderAborted,
     onValueMove,
     fieldName,
-    fieldLength
+    fieldLength,
+    readOnly
 }) => {
     const {t} = useTranslation('jcontent');
-    const isDraggable = fieldLength > 1;
+    const isDraggable = fieldLength > 1 && !readOnly;
 
     const ref = useRef(null);
     const [{handlerId}, drop] = useReorderDrop(
@@ -52,7 +53,7 @@ export const DraggableReference = ({
                 emptyLabel={t('jcontent:label.contentEditor.edit.fields.imagePicker.addImage')}
                 emptyIcon={<File/>}
                 isReadOnly={child.readOnly}
-                cardAction={fieldLength > 1 &&
+                cardAction={fieldLength > 1 && !readOnly &&
                     <div className={styles.referenceCardActions}>
                         <div style={{display: 'flex', flexDirection: 'column', justifyContent: 'space-between'}}>
                             <Tooltip label={t('jcontent:label.contentEditor.section.listAndOrdering.btnMoveFirst')}>
@@ -118,6 +119,7 @@ DraggableReference.propTypes = {
     onReorder: PropTypes.func.isRequired,
     onValueMove: PropTypes.func.isRequired,
     fieldLength: PropTypes.number,
+    readOnly: PropTypes.bool,
     onReorderDropped: PropTypes.func.isRequired,
     onReorderAborted: PropTypes.func.isRequired
 };

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ManualOrdering/ManualOrdering.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ManualOrdering/ManualOrdering.jsx
@@ -3,8 +3,10 @@ import React, {Fragment} from 'react';
 import {DraggableReference} from './DragDrop';
 import {onDirectionalReorder, useReorderList} from '~/ContentEditor/utils';
 import PropTypes from 'prop-types';
+import {useContentEditorSectionContext} from '~/ContentEditor/contexts';
+import {Constants} from '~/ContentEditor/ContentEditor.constants';
 
-export const ManualOrderingField = ({field, form: {setFieldValue, setFieldTouched}}) => {
+export const ManualOrderingField = ({field, form: {setFieldValue, setFieldTouched}, readOnly}) => {
     const {handleReorder, reorderedItems, reset} = useReorderList(field.value ?? []);
 
     if (field.value === undefined) {
@@ -35,6 +37,7 @@ export const ManualOrderingField = ({field, form: {setFieldValue, setFieldTouche
                             index={index}
                             id={id}
                             fieldLength={field.value.length}
+                            readOnly={readOnly}
                             onReorder={handleReorder}
                             onValueMove={onValueMove}
                             onReorderDropped={handleFinalReorder}
@@ -52,13 +55,19 @@ ManualOrderingField.propTypes = {
     form: PropTypes.shape({
         setFieldValue: PropTypes.func.isRequired,
         setFieldTouched: PropTypes.func.isRequired
-    }).isRequired
+    }).isRequired,
+    readOnly: PropTypes.bool
 };
 
 export const ManualOrdering = () => {
+    const {sections} = useContentEditorSectionContext();
+    const orderingFieldSet = sections && sections.reduce((found, section) =>
+        found || section.fieldSets.find(fs => fs.name === Constants.ordering.automaticOrdering.mixin), null);
+    const readOnly = orderingFieldSet?.readOnly === true;
+
     return (
-        <FastField name="Children::Order">
-            {props => <ManualOrderingField {...props}/>}
+        <FastField name={Constants.ordering.childrenKey}>
+            {props => <ManualOrderingField {...props} readOnly={readOnly}/>}
         </FastField>
     );
 };

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ManualOrdering/ManualOrdering.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ManualOrdering/ManualOrdering.jsx
@@ -61,7 +61,7 @@ ManualOrderingField.propTypes = {
 
 export const ManualOrdering = () => {
     const {sections} = useContentEditorSectionContext();
-    const orderingFieldSet = sections && sections.reduce((found, section) =>
+    const orderingFieldSet = sections?.reduce((found, section) =>
         found || section.fieldSets.find(fs => fs.name === Constants.ordering.automaticOrdering.mixin), null);
     const readOnly = orderingFieldSet?.readOnly === true;
 

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ManualOrdering/ManualOrdering.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ManualOrdering/ManualOrdering.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import {useContentEditorSectionContext} from '~/ContentEditor/contexts';
 import {Constants} from '~/ContentEditor/ContentEditor.constants';
 
-export const ManualOrderingField = ({field, form: {setFieldValue, setFieldTouched}, readOnly}) => {
+export const ManualOrderingField = ({field, form: {setFieldValue, setFieldTouched}, isReadOnly}) => {
     const {handleReorder, reorderedItems, reset} = useReorderList(field.value ?? []);
 
     if (field.value === undefined) {
@@ -37,7 +37,7 @@ export const ManualOrderingField = ({field, form: {setFieldValue, setFieldTouche
                             index={index}
                             id={id}
                             fieldLength={field.value.length}
-                            readOnly={readOnly}
+                            isReadOnly={isReadOnly}
                             onReorder={handleReorder}
                             onValueMove={onValueMove}
                             onReorderDropped={handleFinalReorder}
@@ -56,18 +56,18 @@ ManualOrderingField.propTypes = {
         setFieldValue: PropTypes.func.isRequired,
         setFieldTouched: PropTypes.func.isRequired
     }).isRequired,
-    readOnly: PropTypes.bool
+    isReadOnly: PropTypes.bool
 };
 
 export const ManualOrdering = () => {
     const {sections} = useContentEditorSectionContext();
     const orderingFieldSet = sections?.reduce((found, section) =>
         found || section.fieldSets.find(fs => fs.name === Constants.ordering.automaticOrdering.mixin), null);
-    const readOnly = orderingFieldSet?.readOnly === true;
+    const isReadOnly = orderingFieldSet?.readOnly === true;
 
     return (
         <FastField name={Constants.ordering.childrenKey}>
-            {props => <ManualOrderingField {...props} readOnly={readOnly}/>}
+            {props => <ManualOrderingField {...props} isReadOnly={isReadOnly}/>}
         </FastField>
     );
 };

--- a/src/javascript/ContentEditor/utils/fields.utils.js
+++ b/src/javascript/ContentEditor/utils/fields.utils.js
@@ -123,7 +123,7 @@ export function getDataToMutate({nodeData, formValues, i18nContext, sections, la
 
     const keys = new Set(Object.keys(formValues));
     Object.values(i18nContext).filter(ctx => ctx.values !== undefined).forEach(ctx => Object.keys(ctx.values).forEach(k => keys.add(k)));
-    const fields = sections && getFields(sections).filter(field => !field.readOnly);
+    const fields = sections && getFields(sections).filter(field => !nodeData || !field.readOnly);
     const mixinsToMutate = getMixinsToMutate(nodeData, formValues, sections);
 
     keys.forEach(key => {

--- a/src/javascript/ContentEditor/utils/fields.utils.js
+++ b/src/javascript/ContentEditor/utils/fields.utils.js
@@ -123,7 +123,7 @@ export function getDataToMutate({nodeData, formValues, i18nContext, sections, la
 
     const keys = new Set(Object.keys(formValues));
     Object.values(i18nContext).filter(ctx => ctx.values !== undefined).forEach(ctx => Object.keys(ctx.values).forEach(k => keys.add(k)));
-    const fields = sections && getFields(sections);
+    const fields = sections && getFields(sections).filter(field => !field.readOnly);
     const mixinsToMutate = getMixinsToMutate(nodeData, formValues, sections);
 
     keys.forEach(key => {

--- a/src/javascript/ContentEditor/utils/fields.utils.spec.js
+++ b/src/javascript/ContentEditor/utils/fields.utils.spec.js
@@ -342,6 +342,17 @@ describe('EditPanel utils', () => {
             },
             formValues: {
                 [sections[0].fieldSets[2].name + '_readOnly']: 'new value'
+            },
+            // ReadOnly fields are skipped on edit (nodeData present) but saved on create (no nodeData)
+            newExpectedPropsToSave: [{
+                language: 'fr',
+                name: 'readOnly',
+                option: undefined,
+                type: 'type',
+                value: 'new value'
+            }],
+            newExpectedPropsFieldMapping: {
+                readOnly: sections[0].fieldSets[2].name + '_readOnly'
             }
         },
         {
@@ -684,7 +695,7 @@ describe('EditPanel utils', () => {
     const lang = 'fr';
 
     describe('getDataToMutate', () => {
-        testCases.forEach(({name, nodeData, formValues, ExpectedPropsToSave, ExpectedPropsToDelete, skipCreate, expectedPropsFieldMapping}) => {
+        testCases.forEach(({name, nodeData, formValues, ExpectedPropsToSave, ExpectedPropsToDelete, skipCreate, expectedPropsFieldMapping, newExpectedPropsToSave, newExpectedPropsFieldMapping}) => {
             it(`Existing ${name}`, () => {
                 const {propsToSave, propsToDelete, propFieldNameMapping} = getDataToMutate({nodeData, formValues, sections, lang, i18nContext: {}});
                 expect(propsToSave).toEqual(ExpectedPropsToSave || []);
@@ -694,14 +705,14 @@ describe('EditPanel utils', () => {
             if (!skipCreate) {
                 it(`New ${name}`, () => {
                     const {propsToSave, propsToDelete, propFieldNameMapping} = getDataToMutate({formValues, sections, lang, i18nContext: {}});
-                    expect(propsToSave).toEqual(ExpectedPropsToSave || []);
+                    expect(propsToSave).toEqual(newExpectedPropsToSave || ExpectedPropsToSave || []);
                     expect(propsToDelete).toEqual(ExpectedPropsToDelete || []);
-                    expect(propFieldNameMapping).toEqual(expectedPropsFieldMapping || {});
+                    expect(propFieldNameMapping).toEqual(newExpectedPropsFieldMapping || expectedPropsFieldMapping || {});
                 });
             }
         });
 
-        it('should not save a property belonging to a readOnly fieldset', () => {
+        it('should not save a property belonging to a readOnly fieldset on edit', () => {
             const readOnlyField = {
                 nodeType: 'readOnlyFs',
                 name: 'readOnlyFs_prop',
@@ -722,8 +733,9 @@ describe('EditPanel utils', () => {
                     ]
                 }
             ];
+            const nodeDataForEdit = {properties: [{name: 'prop', value: 'old value'}]};
             const formValues = {[readOnlyField.name]: 'new value'};
-            const {propsToSave, propsToDelete} = getDataToMutate({formValues, sections: sectionsWithReadOnlyFieldSet, lang, i18nContext: {}});
+            const {propsToSave, propsToDelete} = getDataToMutate({nodeData: nodeDataForEdit, formValues, sections: sectionsWithReadOnlyFieldSet, lang, i18nContext: {}});
             expect(propsToSave).toEqual([]);
             expect(propsToDelete).toEqual([]);
         });

--- a/src/javascript/ContentEditor/utils/fields.utils.spec.js
+++ b/src/javascript/ContentEditor/utils/fields.utils.spec.js
@@ -342,16 +342,6 @@ describe('EditPanel utils', () => {
             },
             formValues: {
                 [sections[0].fieldSets[2].name + '_readOnly']: 'new value'
-            },
-            ExpectedPropsToSave: [{
-                language: 'fr',
-                name: 'readOnly',
-                option: undefined,
-                type: 'type',
-                value: 'new value'
-            }],
-            expectedPropsFieldMapping: {
-                readOnly: sections[0].fieldSets[2].name + '_readOnly'
             }
         },
         {
@@ -709,6 +699,33 @@ describe('EditPanel utils', () => {
                     expect(propFieldNameMapping).toEqual(expectedPropsFieldMapping || {});
                 });
             }
+        });
+
+        it('should not save a property belonging to a readOnly fieldset', () => {
+            const readOnlyField = {
+                nodeType: 'readOnlyFs',
+                name: 'readOnlyFs_prop',
+                propertyName: 'prop',
+                requiredType: 'STRING',
+                readOnly: true,
+                multiple: false
+            };
+            const sectionsWithReadOnlyFieldSet = [
+                {
+                    fieldSets: [
+                        {
+                            name: 'readOnlyFs',
+                            readOnly: true,
+                            activated: true,
+                            fields: [readOnlyField]
+                        }
+                    ]
+                }
+            ];
+            const formValues = {[readOnlyField.name]: 'new value'};
+            const {propsToSave, propsToDelete} = getDataToMutate({formValues, sections: sectionsWithReadOnlyFieldSet, lang, i18nContext: {}});
+            expect(propsToSave).toEqual([]);
+            expect(propsToDelete).toEqual([]);
         });
     });
 

--- a/src/javascript/ContentEditor/utils/getChildrenOrder.js
+++ b/src/javascript/ContentEditor/utils/getChildrenOrder.js
@@ -1,6 +1,14 @@
-export function getChildrenOrder(formValues, nodeData) {
+import {Constants} from '~/ContentEditor/ContentEditor.constants';
+
+export function getChildrenOrder(formValues, nodeData, sections) {
     const doNotModifyReturn = {shouldModifyChildren: false, childrenOrder: []};
     if (!formValues['Children::Order'] || formValues['Children::Order'].length === 1) {
+        return doNotModifyReturn;
+    }
+
+    const orderingFieldSet = sections && sections.reduce((found, section) =>
+        found || section.fieldSets.find(fs => fs.name === Constants.ordering.automaticOrdering.mixin), null);
+    if (orderingFieldSet && orderingFieldSet.readOnly) {
         return doNotModifyReturn;
     }
 

--- a/src/javascript/ContentEditor/utils/getChildrenOrder.js
+++ b/src/javascript/ContentEditor/utils/getChildrenOrder.js
@@ -6,9 +6,9 @@ export function getChildrenOrder(formValues, nodeData, sections) {
         return doNotModifyReturn;
     }
 
-    const orderingFieldSet = sections && sections.reduce((found, section) =>
+    const orderingFieldSet = sections?.reduce((found, section) =>
         found || section.fieldSets.find(fs => fs.name === Constants.ordering.automaticOrdering.mixin), null);
-    if (orderingFieldSet && orderingFieldSet.readOnly) {
+    if (orderingFieldSet?.readOnly) {
         return doNotModifyReturn;
     }
 

--- a/src/javascript/ContentEditor/utils/getChildrenOrder.spec.js
+++ b/src/javascript/ContentEditor/utils/getChildrenOrder.spec.js
@@ -31,4 +31,23 @@ describe('getChildrenOrder', () => {
             childrenOrder: ['dc', 'ac']
         });
     });
+
+    it('should not modify children order when jmix:orderedList fieldset is readOnly', () => {
+        const formValue = {
+            'Children::Order': [{name: 'dc'}, {name: 'ac'}]
+        };
+        const nodeData = {
+            children: {
+                nodes: [{name: 'ac'}, {name: 'dc'}]
+            }
+        };
+        const sections = [
+            {
+                fieldSets: [
+                    {name: 'jmix:orderedList', readOnly: true}
+                ]
+            }
+        ];
+        expect(getChildrenOrder(formValue, nodeData, sections)).toEqual({shouldModifyChildren: false, childrenOrder: []});
+    });
 });

--- a/tests/cypress/e2e/contentEditor/contentEditorForm.cy.ts
+++ b/tests/cypress/e2e/contentEditor/contentEditorForm.cy.ts
@@ -52,7 +52,7 @@ describe('Content editor form', () => {
 
     beforeEach(() => {
         cy.loginAndStoreSession();
-        jcontent = JContent.visit('contentEditorSite', 'en', 'content-folders/contents');
+        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
     });
 
     function setDefaultSiteTemplate(templateName) {
@@ -119,7 +119,7 @@ describe('Content editor form', () => {
         contentEditor.cancelAndDiscard();
     });
 
-    it.only('should use site default template value', () => {
+    it('should use site default template value', () => {
         const contentTypeName = 'cent:testDefaultTemplate';
         const templateName = 'events';
         const fieldName = 'cent:testDefaultTemplate_j:templateName';
@@ -186,7 +186,7 @@ describe('Content editor form', () => {
 
         cy.logout();
         cy.login('mathias', 'password');
-        jcontent = JContent.visit('contentEditorSite', 'en', 'content-folders/contents');
+        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
         const contentEditor2 = jcontent.createContent('jnt:text');
         const field2 = contentEditor2.getField(SmallTextField, 'jnt:text_text');
         field2.get().find('input').should('have.attr', 'readonly', 'readonly');
@@ -198,7 +198,7 @@ describe('Content editor form', () => {
 
         cy.logout();
         cy.login('mathias', 'password');
-        jcontent = JContent.visit('contentEditorSite', 'en', 'content-folders/contents');
+        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
         jcontent.createContent('jnt:news');
         cy.get('[data-sel-content-editor-field="jnt:news_desc"]').should('not.exist');
     });
@@ -230,7 +230,7 @@ describe('Content editor form', () => {
     it('should not display advanced options tab for editor', () => {
         cy.logout();
         cy.login('mathias', 'password');
-        jcontent = JContent.visit('contentEditorSite', 'en', 'content-folders/contents');
+        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
         const ceEditor = jcontent.editComponentByRowName('myText');
 
         ceEditor.switchToAdvancedMode();
@@ -244,7 +244,7 @@ describe('Content editor form', () => {
         cy.logout();
         // Login as editor in chief
         cy.login('anne', 'password');
-        jcontent = JContent.visit('contentEditorSite', 'en', 'content-folders/contents');
+        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
         const ceEditor = jcontent.editComponentByRowName('myText');
         ceEditor.switchToAdvancedMode();
         ceEditor.switchToAdvancedOptions();
@@ -272,7 +272,7 @@ describe('Content editor form', () => {
     });
 
     it('should be able to check and uncheck boolean', () => {
-        jcontent = JContent.visit('contentEditorSite', 'en', 'content-folders/contents');
+        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
         const contentEditor = jcontent.editComponentByRowName('allFieldsSimple');
         contentEditor.switchToAdvancedMode();
 

--- a/tests/cypress/e2e/contentEditor/contentEditorForm.cy.ts
+++ b/tests/cypress/e2e/contentEditor/contentEditorForm.cy.ts
@@ -1,11 +1,14 @@
-import {JContent} from '../../page-object/jcontent';
+import {JContent} from '../../page-object';
 import {ChoiceListField, Field, SmallTextField} from '../../page-object/fields';
 import {
     addNode,
     Button,
-    Dropdown, enableModule,
+    createSite,
+    Dropdown,
+    enableModule,
     getComponentByRole,
-    getComponentBySelector, grantRoles
+    getComponentBySelector,
+    grantRoles
 } from '@jahia/cypress';
 import gql from 'graphql-tag';
 import {ContentEditor} from '../../page-object';
@@ -15,32 +18,22 @@ describe('Content editor form', () => {
     const siteKey = 'contentEditorSite';
 
     before(function () {
-        cy.executeGroovy('contentEditor/createSite.groovy', {SITEKEY: siteKey});
+        createSite(siteKey);
+        enableModule('jcontent-test-module', siteKey);
         enableModule('qa-module', siteKey);
-        cy.apollo({
-            mutation: gql`mutation GrantRoles {
-                jcr {
-                    grantRoles: mutateNode(pathOrId: "/sites/contentEditorSite") {
-                        grantRoles(roleNames: "editor", principalType: USER, principalName: "mathias")
-                    }
-                    addContent: mutateNode(pathOrId: "/sites/contentEditorSite/contents") {
-                        addChild(
-                            name: "alwaysActivatedOverrideTest", 
-                            primaryNodeType: "jnt:bigText", 
-                            properties: [{ name: "text", language: "en", value: "isAlwaysActivated override test" }]
-                        ) {
-                            uuid
-                        }
-                    }
-                }
-            }`
-        });
         grantRoles(`/sites/${siteKey}`, ['editor-in-chief'], 'anne', 'USER');
+        grantRoles(`/sites/${siteKey}`, ['editor'], 'mathias', 'USER');
         addNode({
             parentPathOrId: `/sites/${siteKey}/contents`,
             name: 'myText',
             primaryNodeType: 'jnt:text',
             properties: [{name: 'text', language: 'en', value: 'my text'}]
+        });
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: 'alwaysActivatedOverrideTest',
+            primaryNodeType: 'jnt:bigText',
+            properties: [{name: 'text', language: 'en', value: 'isAlwaysActivated override test'}]
         });
         addNode({
             parentPathOrId: `/sites/${siteKey}/contents`,
@@ -126,7 +119,7 @@ describe('Content editor form', () => {
         contentEditor.cancelAndDiscard();
     });
 
-    it('should use site default template value', () => {
+    it.only('should use site default template value', () => {
         const contentTypeName = 'cent:testDefaultTemplate';
         const templateName = 'events';
         const fieldName = 'cent:testDefaultTemplate_j:templateName';
@@ -134,12 +127,12 @@ describe('Content editor form', () => {
         cy.log('Set default template value for site');
         setDefaultSiteTemplate(templateName);
 
-        cy.log('verify default template is shown in new component');
+        cy.log('Verify default template is selected by default and is read-only');
         const contentEditor = jcontent.createContent(contentTypeName);
-        const field = contentEditor.getField(Field, fieldName);
-        field.get().find('[role="listbox"]')
-            .should('contain', templateName)
-            .and('have.class', 'moonstone-disabled'); // Read-only
+        const field = contentEditor.getChoiceListField(fieldName);
+        field.assertSelected(templateName);
+        field.isReadOnly();
+
         contentEditor.create(); // No errors on create
     });
 

--- a/tests/cypress/e2e/contentEditor/permissions.cy.ts
+++ b/tests/cypress/e2e/contentEditor/permissions.cy.ts
@@ -1,7 +1,8 @@
 import {JContent} from '../../page-object';
-import {RichTextField} from '../../page-object/fields';
+import {RichTextField, SmallTextField} from '../../page-object/fields';
 import gql from 'graphql-tag';
-import {deleteNode} from '@jahia/cypress';
+import {ContentEditor} from '../../page-object';
+import {createSite, createUser, deleteSite, deleteNode, deleteUser, getNodeByPath, grantRoles} from '@jahia/cypress';
 
 describe('permissions', () => {
     let jcontent: JContent;
@@ -36,6 +37,51 @@ describe('permissions', () => {
         contentEditor = jcontent.editComponentByText('test');
         const richText = contentEditor.getField(RichTextField, 'jnt:bigText_text');
         richText.type('test');
+    });
+});
+
+describe('translator permissions', () => {
+    const siteKey = 'translatorPermsSite';
+    const translatorLogin = {username: 'frTranslator', password: 'password'};
+
+    before(() => {
+        createSite(siteKey, {
+            languages: 'en,fr',
+            templateSet: 'dx-base-demo-templates',
+            serverName: 'localhost',
+            locale: 'en'
+        });
+        createUser(translatorLogin.username, translatorLogin.password);
+        grantRoles(`/sites/${siteKey}`, ['translator-fr'], translatorLogin.username, 'USER');
+    });
+
+    after(() => {
+        cy.logout();
+        deleteSite(siteKey);
+        deleteUser(translatorLogin.username);
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession(translatorLogin.username, translatorLogin.password);
+    });
+
+    afterEach(() => {
+        cy.logout();
+    });
+
+    it('should allow a translator to edit and save a page title in French', () => {
+        const jcontent = JContent.visit(siteKey, 'fr', 'pages/home');
+        jcontent.getAccordionItem('pages').getTreeItem('home').contextMenu().select('Edit');
+        const ce = new ContentEditor();
+
+        ce.getField(SmallTextField, 'jnt:page_jcr:title').addNewValue('Accueil traduit');
+        ce.save();
+
+        getNodeByPath(`/sites/${siteKey}/home`, ['jcr:title'], 'fr').then(result => {
+            const props = result.data.jcr.nodeByPath.properties;
+            const titleProp = props.find((prop: {name: string}) => prop.name === 'jcr:title');
+            expect(titleProp.value).to.eq('Accueil traduit');
+        });
     });
 });
 


### PR DESCRIPTION
### Description

We are currently getting permission issues because we are trying to save all fields, even read-only, on edits.

Added a check on fields.utils `getDataToMutate()` so that we filter out read-only fields during save when we are editing. Note that we do not do this on create as there could be pre-populated fields that needs to be saved even if they are read-only.

Also fixed issue of being able to drag/drop reorder children even when it's suppose to be read-only, and added checks for that as well.

#### Test

- added regression test for the scenario described in the issue

#### Misc 

- clean-up contentEditorForm test while investigating test failures

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
