### PR TITLE
fix: Allow to edit content from the ordering section

### DIFF
--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ManualOrdering/DragDrop/DraggableReference.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Sections/ChildrenSection/ManualOrdering/DragDrop/DraggableReference.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {useTranslation} from 'react-i18next';
 import {ReferenceCard} from '~/ContentEditor/DesignSystem/ReferenceCard';
 import {Tooltip, File, Button, ChevronLastList, ChevronFirstList, ChevronUp, ChevronDown} from '@jahia/moonstone';
-import {useReorderDrag, useReorderDrop} from '~/ContentEditor/utils';
+import {useOpenInEditor, useReorderDrag, useReorderDrop} from '~/ContentEditor/utils';
 import {getIconFromNode, getWebpUrl} from '~/utils';
 import styles from '~/ContentEditor/utils/dragAndDrop.scss';
 import clsx from 'clsx';
@@ -21,6 +21,7 @@ export const DraggableReference = ({
 }) => {
     const {t} = useTranslation('jcontent');
     const isDraggable = fieldLength > 1;
+    const openInEditor = useOpenInEditor();
 
     const ref = useRef(null);
     const [{handlerId}, drop] = useReorderDrop(
@@ -52,6 +53,12 @@ export const DraggableReference = ({
                 emptyLabel={t('jcontent:label.contentEditor.edit.fields.imagePicker.addImage')}
                 emptyIcon={<File/>}
                 isReadOnly={child.readOnly}
+                fieldData={{
+                    displayName: child.displayName,
+                    name: child.name,
+                    type: child.primaryNodeType.displayName,
+                    thumbnail: child.thumbnailUrl || getWebpUrl(child) || getIconFromNode(child)
+                }}
                 cardAction={fieldLength > 1 &&
                     <div className={styles.referenceCardActions}>
                         <div style={{display: 'flex', flexDirection: 'column', justifyContent: 'space-between'}}>
@@ -99,12 +106,7 @@ export const DraggableReference = ({
                             </Tooltip>
                         </div>
                     </div>}
-                fieldData={{
-                    displayName: child.displayName,
-                    name: child.name,
-                    type: child.primaryNodeType.displayName,
-                    thumbnail: child.thumbnailUrl || getWebpUrl(child) || getIconFromNode(child)
-                }}
+                onClick={() => openInEditor(child.uuid)}
             />
         </div>
     );

--- a/src/javascript/ContentEditor/utils/index.js
+++ b/src/javascript/ContentEditor/utils/index.js
@@ -9,4 +9,5 @@ export * from './getNodeTypeIcon';
 export * from './systemName.utils';
 export * from './useKeydownListener';
 export * from './useSwitchLanguage';
+export * from './useOpenInEditor';
 export * from './useReorderList';

--- a/src/javascript/ContentEditor/utils/useOpenInEditor.js
+++ b/src/javascript/ContentEditor/utils/useOpenInEditor.js
@@ -1,0 +1,37 @@
+import {useCallback} from 'react';
+import {shallowEqual, useSelector} from 'react-redux';
+import {useApolloClient} from '@apollo/client';
+import rison from 'rison-node';
+import {Constants} from '~/ContentEditor/ContentEditor.constants';
+import * as jcontentUtils from '~/JContent/JContent.utils';
+import {useContentEditorConfigContext} from '~/ContentEditor/contexts';
+
+/**
+ * Returns a callback that opens the given node UUID in a new tab
+ * with the Content Editor in fullscreen edit mode.
+ */
+export const useOpenInEditor = () => {
+    const {lang} = useContentEditorConfigContext();
+    const client = useApolloClient();
+    const {fallbackLanguage, currentUILang} = useSelector(
+        state => ({fallbackLanguage: state.language, currentUILang: state.uilang}),
+        shallowEqual
+    );
+
+    return useCallback(uuid => {
+        jcontentUtils.expandTree({uuid}, client).then(({mode, parentPath, site}) => {
+            const hash = rison.encode_uri({
+                contentEditor: [{
+                    uuid,
+                    uilang: currentUILang,
+                    lang: lang || fallbackLanguage,
+                    mode: Constants.routes.baseEditRoute,
+                    isFullscreen: true
+                }]
+            });
+            const url = jcontentUtils.buildUrl({site, language: lang || fallbackLanguage, mode, path: parentPath});
+            window.open(`${window.contextJsParameters.urlbase}${url}#${hash}`, '_blank');
+        });
+    }, [client, currentUILang, fallbackLanguage, lang]);
+};
+


### PR DESCRIPTION
### Description
Clicking on a reference card will open the associated node in a new tab for edition purposes

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
