### PR TITLE
ci: Migrate workflows to reusable integration test job

### DIFF
--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -25,68 +25,16 @@ on:
 jobs:
   integration-tests:
     name: Integration Tests
-    runs-on: self-hosted
-    steps:
-      - uses: jahia/jahia-modules-action/helper@v2
-      - uses: actions/checkout@v6
-      - uses: KengoTODA/actions-setup-docker-compose@main
-        with:
-          version: '1.29.2'
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 'lts/*'
-      - uses: jahia/jahia-modules-action/integration-tests@v2
-        with:
-          module_id: jcontent
-          testrail_project: jContent Module
-          jahia_image: ${{ github.event.inputs.jahia_image }}
-          should_skip_artifacts: true
-          should_skip_notifications: true
-          should_skip_testrail: true
-          should_skip_zencrepes: false
-          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
-          github_artifact_name: jcontent-standalone-artifacts-${{ github.run_number }}
-          bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}
-          tests_manifest: ${{ github.event.inputs.manifest }}
-          tests_profile: ${{ github.event.inputs.config_file }}
-          jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}
-          docker_registries: |
-            [
-              {
-                "registry": "ghcr.io",
-                "username": "${{ secrets.GH_PACKAGES_USERNAME }}",
-                "password": "${{ secrets.GH_PACKAGES_TOKEN }}"
-              },
-              {
-                "username": "${{ secrets.DOCKERHUB_USERNAME }}",
-                "password": "${{ secrets.DOCKERHUB_PASSWORD }}"
-              }
-            ]
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          testrail_username: ${{ secrets.TESTRAIL_USERNAME }}
-          testrail_password: ${{ secrets.TESTRAIL_PASSWORD }}
-          incident_pagerduty_api_key: ${{ secrets.INCIDENT_PAGERDUTY_API_KEY }}
-          incident_pagerduty_reporter_email: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_EMAIL }}
-          incident_pagerduty_reporter_id: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_ID }}
-          incident_google_spreadsheet_id: ${{ secrets.INCIDENT_GOOGLE_SPREADSHEET_ID }}
-          incident_google_client_email: ${{ secrets.INCIDENT_GOOGLE_CLIENT_EMAIL }}
-          incident_google_api_key_base64: ${{ secrets.INCIDENT_GOOGLE_PRIVATE_KEY_BASE64 }}
-          zencrepes_secret: ${{ secrets.ZENCREPES_WEBHOOK_SECRET }}
-      - name: Test Report
-        uses: phoenix-actions/test-reporting@v15
-        if: success() || failure()
-        with:
-          name: Tests Report (Manual Run)
-          path: tests/artifacts/results/xml_reports/**/*.xml
-          reporter: java-junit
-          fail-on-error: 'false'
-          output-to: 'step-summary'
-
-      # Tmate only starts if any of the previous steps fails.
-      # Be careful since it also means that if a step fails the workflow will
-      # keep running until it reaches the timeout.
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 15
+    secrets: inherit
+    uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
+    with:
+      module_id: jcontent
+      jahia_image: ${{ github.event.inputs.jahia_image }}
+      jahia_cluster_enabled: ${{ fromJSON(github.event.inputs.jahia_cluster_enabled) }}
+      tests_profile: ${{ github.event.inputs.config_file }}
+      provisioning_manifest: ${{ github.event.inputs.manifest }}
+      artifact_prefix: jcontent-manual-${{ github.run_number }}
+      should_skip_testrail: true
+      testrail_project: jContent Module
+      timeout_job: 140
+      timeout_step: 90

--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -28,11 +28,11 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: jahia/jahia-modules-action/helper@v2
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: KengoTODA/actions-setup-docker-compose@main
         with:
           version: '1.29.2'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
       - uses: jahia/jahia-modules-action/integration-tests@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,9 +6,8 @@ on:
     - cron:  '15 1 * * 1-5'
 
 jobs:
-  integration-tests-standalone:
+  integration-tests:
     name: Integration Tests ${{ matrix.config_file }}
-    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:
@@ -21,68 +20,15 @@ jobs:
           - cypress.config-pageBuilder.ts
           - cypress.config-pickers.ts
           - cypress.config-categoryManager.ts
-    timeout-minutes: 140
-    steps:
-      - uses: jahia/jahia-modules-action/helper@v2
-      - uses: KengoTODA/actions-setup-docker-compose@main
-        with:
-          version: '1.29.2'
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 'lts/*'
-      - uses: actions/checkout@v6
-      - uses: jahia/jahia-modules-action/integration-tests@v2
-        with:
-          module_id: jcontent
-          incident_service: jcontent-${{ matrix.config_file }}
-          jahia_image: ${{ matrix.jahia_image }}
-          jahia_cluster_enabled: false
-          testrail_project: jContent Module
-          tests_manifest: provisioning-manifest-snapshot.yml
-          tests_profile: ${{ matrix.config_file }}
-          should_skip_artifacts: true
-          should_skip_notifications: false
-          should_skip_testrail: false
-          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
-          github_artifact_name: jcontent-nightly-${{ matrix.config_file }}-${{ github.run_number }}
-          jahia_artifact_name: jcontent-nightly-${{ matrix.config_file }}-${{ github.run_number }}
-          bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}
-          jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}
-          docker_registries: |
-            [
-              {
-                "registry": "ghcr.io",
-                "username": "${{ secrets.GH_PACKAGES_USERNAME }}",
-                "password": "${{ secrets.GH_PACKAGES_TOKEN }}"
-              },
-              {
-                "username": "${{ secrets.DOCKERHUB_USERNAME }}",
-                "password": "${{ secrets.DOCKERHUB_PASSWORD }}"
-              }
-            ]
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          testrail_username: ${{ secrets.TESTRAIL_USERNAME }}
-          testrail_password: ${{ secrets.TESTRAIL_PASSWORD }}
-          tests_report_name: Nightly ${{ matrix.config_file }}
-          incident_pagerduty_api_key: ${{ secrets.INCIDENT_PAGERDUTY_API_KEY }}
-          incident_pagerduty_reporter_email: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_EMAIL }}
-          incident_pagerduty_reporter_id: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_ID }}
-          incident_google_spreadsheet_id: ${{ secrets.INCIDENT_GOOGLE_SPREADSHEET_ID }}
-          incident_google_client_email: ${{ secrets.INCIDENT_GOOGLE_CLIENT_EMAIL }}
-          incident_google_api_key_base64: ${{ secrets.INCIDENT_GOOGLE_PRIVATE_KEY_BASE64 }}
-          zencrepes_secret: ${{ secrets.ZENCREPES_WEBHOOK_SECRET }}
-      - name: Test Report
-        uses: phoenix-actions/test-reporting@v15
-        id: test-report
-        if: success() || failure()
-        with:
-          name: Nightly ${{ matrix.config_file }}
-          path: tests/artifacts/results/xml_reports/**/*.xml
-          reporter: java-junit
-          fail-on-error: 'false'
-          output-to: 'step-summary'
-      - name: Print test report URL
-        run: |
-          echo "Test report URL is ${{ steps.test-report.outputs.runHtmlUrl }}"
-
+    secrets: inherit
+    uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
+    with:
+      module_id: jcontent
+      jahia_image: ${{ matrix.jahia_image }}
+      tests_profile: ${{ matrix.config_file }}
+      provisioning_manifest: provisioning-manifest-snapshot.yml
+      artifact_prefix: jcontent-nightly-${{ matrix.config_file }}-${{ github.run_number }}
+      incident_service: jcontent-${{ matrix.config_file }}
+      testrail_project: jContent Module
+      timeout_job: 140
+      timeout_step: 90

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,10 +27,10 @@ jobs:
       - uses: KengoTODA/actions-setup-docker-compose@main
         with:
           version: '1.29.2'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
           module_id: jcontent

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -12,7 +12,7 @@ jobs:
     name: Update module signature
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jahia/jahia-modules-action/update-signature@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
@@ -22,7 +22,7 @@ jobs:
     name: Static Analysis (linting, vulns)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: Jahia/jahia-modules-action/static-analysis@v2
         with:
           auditci_level: critical
@@ -32,8 +32,8 @@ jobs:
     name: Javascript unit tests (yarn test)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
       - name: Run yarn test
@@ -54,7 +54,7 @@ jobs:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jahia/jahia-modules-action/build@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
@@ -67,7 +67,7 @@ jobs:
     env:
       NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jahia/jahia-modules-action/sonar-analysis@v2
         with:
           primary_release_branch: main

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -78,10 +78,9 @@ jobs:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
 
-  integration-tests-standalone:
+  integration-tests:
     name: Integration Tests ${{ matrix.config_file }}
     needs: build
-    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:
@@ -93,61 +92,16 @@ jobs:
           - cypress.config-pageBuilder.ts
           - cypress.config-pickers.ts
           - cypress.config-categoryManager.ts
-    timeout-minutes: 140
-    steps:
-      - uses: jahia/jahia-modules-action/helper@v2
-      - uses: KengoTODA/actions-setup-docker-compose@main
-        with:
-          version: '1.29.2'
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-      - uses: actions/checkout@v4
-      - uses: jahia/jahia-modules-action/integration-tests@v2
-        with:
-          module_id: jcontent
-          testrail_project: jContent Module
-          tests_manifest: provisioning-manifest-build.yml
-          jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
-          jahia_cluster_enabled: false
-          should_skip_testrail: true
-          tests_profile: ${{ matrix.config_file }}
-          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
-          github_artifact_name: jcontent-standalone-${{ matrix.config_file }}-${{ github.run_number }}
-          jahia_artifact_name: jcontent-standalone-${{ matrix.config_file }}-${{ github.run_number }}
-          bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}
-          jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}
-          docker_registries: |
-            [
-              {
-                "registry": "ghcr.io",
-                "username": "${{ secrets.GH_PACKAGES_USERNAME }}",
-                "password": "${{ secrets.GH_PACKAGES_TOKEN }}"
-              },
-              {
-                "username": "${{ secrets.DOCKERHUB_USERNAME }}",
-                "password": "${{ secrets.DOCKERHUB_PASSWORD }}"
-              }
-            ]
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          tests_report_name: Test report (Standalone)
-          testrail_username: ${{ secrets.TESTRAIL_USERNAME }}
-          testrail_password: ${{ secrets.TESTRAIL_PASSWORD }}
-          incident_pagerduty_api_key: ${{ secrets.INCIDENT_PAGERDUTY_API_KEY }}
-          incident_pagerduty_reporter_email: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_EMAIL }}
-          incident_pagerduty_reporter_id: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_ID }}
-          incident_google_spreadsheet_id: ${{ secrets.INCIDENT_GOOGLE_SPREADSHEET_ID }}
-          incident_google_client_email: ${{ secrets.INCIDENT_GOOGLE_CLIENT_EMAIL }}
-          incident_google_api_key_base64: ${{ secrets.INCIDENT_GOOGLE_PRIVATE_KEY_BASE64 }}
-          zencrepes_secret: ${{ secrets.ZENCREPES_WEBHOOK_SECRET }}
-          timeout_minutes: 90
-      - name: Test Report
-        uses: phoenix-actions/test-reporting@v15
-        if: success() || failure()
-        with:
-          name: Tests Report ${{ matrix.config_file }}
-          path: tests/artifacts/results/xml_reports/**/*.xml
-          reporter: java-junit
-          fail-on-error: 'false'
-          output-to: 'checks'
+    secrets: inherit
+    uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
+    with:
+      module_id: jcontent
+      module_branch: ${{ github.ref }}
+      jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
+      tests_profile: ${{ matrix.config_file }}
+      provisioning_manifest: provisioning-manifest-build.yml
+      artifact_prefix: jcontent-${{ github.event.pull_request.number }}-${{ matrix.config_file }}
+      should_skip_testrail: true
+      testrail_project: jContent Module
+      timeout_job: 140
+      timeout_step: 90

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -53,11 +53,9 @@ jobs:
           dependencytrack_apikey: ${{ secrets.DEPENDENCYTRACK_APIKEY }}
           sbom_artifacts: 'build-artifacts'
 
-  integration-tests-standalone:
+  integration-tests:
     name: Integration Tests ${{ matrix.config_file }}
     needs: build
-    runs-on: self-hosted
-    timeout-minutes: 140
     strategy:
       fail-fast: false
       matrix:
@@ -69,60 +67,18 @@ jobs:
           - cypress.config-pageBuilder.ts
           - cypress.config-pickers.ts
           - cypress.config-categoryManager.ts
-    steps:
-      - uses: jahia/jahia-modules-action/helper@v2
-      - uses: KengoTODA/actions-setup-docker-compose@main
-        with:
-          version: '1.29.2'
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 'lts/*'
-      - uses: actions/checkout@v6
-      - uses: jahia/jahia-modules-action/integration-tests@v2
-        with:
-          module_id: jcontent
-          testrail_project: jContent Module
-          tests_manifest: provisioning-manifest-build.yml
-          jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
-          tests_profile: ${{ matrix.config_file }}
-          github_token: ${{ secrets.GH_ISSUES_PRS_CHORES }}
-          github_artifact_name: jcontent-standalone-${{ matrix.config_file }}-${{ github.run_number }}
-          jahia_artifact_name: jcontent-standalone-${{ matrix.config_file }}-${{ github.run_number }}
-          bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}
-          jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}
-          docker_registries: |
-            [
-              {
-                "registry": "ghcr.io",
-                "username": "${{ secrets.GH_PACKAGES_USERNAME }}",
-                "password": "${{ secrets.GH_PACKAGES_TOKEN }}"
-              },
-              {
-                "username": "${{ secrets.DOCKERHUB_USERNAME }}",
-                "password": "${{ secrets.DOCKERHUB_PASSWORD }}"
-              }
-            ]
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          tests_report_name: Test report (Standalone)
-          testrail_username: ${{ secrets.TESTRAIL_USERNAME }}
-          testrail_password: ${{ secrets.TESTRAIL_PASSWORD }}
-          incident_pagerduty_api_key: ${{ secrets.INCIDENT_PAGERDUTY_API_KEY }}
-          incident_pagerduty_reporter_email: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_EMAIL }}
-          incident_pagerduty_reporter_id: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_ID }}
-          incident_google_spreadsheet_id: ${{ secrets.INCIDENT_GOOGLE_SPREADSHEET_ID }}
-          incident_google_client_email: ${{ secrets.INCIDENT_GOOGLE_CLIENT_EMAIL }}
-          incident_google_api_key_base64: ${{ secrets.INCIDENT_GOOGLE_PRIVATE_KEY_BASE64 }}
-          zencrepes_secret: ${{ secrets.ZENCREPES_WEBHOOK_SECRET }}
-      - name: Test Report
-        uses: phoenix-actions/test-reporting@v15
-        if: success() || failure()
-        with:
-          name: Tests Report ${{ matrix.config_file }}
-          path: tests/artifacts/results/xml_reports/**/*.xml
-          reporter: java-junit
-          fail-on-error: 'false'
-          output-to: 'checks'
+    secrets: inherit
+    uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
+    with:
+      module_id: jcontent
+      module_branch: ${{ github.ref }}
+      jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
+      tests_profile: ${{ matrix.config_file }}
+      provisioning_manifest: provisioning-manifest-build.yml
+      artifact_prefix: jcontent-${{ github.run_number }}-${{ matrix.config_file }}
+      testrail_project: jContent Module
+      timeout_job: 140
+      timeout_step: 90
 
   publish:
     name: Publish module

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -16,7 +16,7 @@ jobs:
     name: Update module signature
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jahia/jahia-modules-action/update-signature@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
@@ -34,7 +34,7 @@ jobs:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jahia/jahia-modules-action/build@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
@@ -74,10 +74,10 @@ jobs:
       - uses: KengoTODA/actions-setup-docker-compose@main
         with:
           version: '1.29.2'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
           module_id: jcontent
@@ -137,7 +137,7 @@ jobs:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jahia/jahia-modules-action/publish@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}

--- a/.github/workflows/release-tests-module.yml
+++ b/.github/workflows/release-tests-module.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # Providing the SSH PRIVATE of a user part of an admin group
       # is necessary to bypass PR checks
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ssh-key: ${{ secrets.GH_SSH_PRIVATE_KEY_JAHIACI }}
       # Setting up the SSH agent to be able to commit back to the repository
@@ -28,7 +28,7 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.GH_SSH_PRIVATE_KEY_JAHIACI }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -26,7 +26,7 @@ jobs:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ matrix.supported_branches }}
       - uses: jahia/jahia-modules-action/build@v2

--- a/.github/workflows/weekly-cluster.yml
+++ b/.github/workflows/weekly-cluster.yml
@@ -27,10 +27,10 @@ jobs:
       - uses: KengoTODA/actions-setup-docker-compose@main
         with:
           version: '1.29.2'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:
           module_id: jcontent


### PR DESCRIPTION
### Description

Restore test result summary by migrating current integration test job workflow to reusable one: https://github.com/Jahia/jahia-modules-action/blob/main/.github/workflows/reusable-integration-tests.yml

Also updated to-be-deprecated actions/checkout@v4 and actions/setup-node@v4 to v6
