### PR TITLE
fix: Make sure bindable components can be selected in page builder when empty

### DIFF
--- a/.chachalog/upc21tuP.md
+++ b/.chachalog/upc21tuP.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Make sure bindable components can be selected in page builder when empty (#2330)

--- a/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
@@ -254,6 +254,12 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
                     element.dataset.jahiaPath = `${parent.dataset.jahiaPath}/${modulePath}`;
                 }
 
+                // If component is bindable (boostrap Pager for example) it can be the case that nothing is bound to it, as result it may be empty and difficult to edit.
+                // We need to make sure it is large enough to be selectable. This mimics what was previously done in page composer.
+                if (element.offsetHeight === 0 && element.getAttribute('bindable') === 'true') {
+                    element.style['min-height'] = '28px';
+                }
+
                 _modules.push(element);
             }
         });


### PR DESCRIPTION
### Description
Make sure bindable components can be selected in page builder when empty. Page composer adds a header in the case component is bindable, so if it is empty you can still select and edit it. This change does something similar, but instead of adding a header it makes component selectable in a way consistent with Page Builder aesthetics. 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
