### PR TITLE
fix: url encoding of links coming from plugins

### DIFF
--- a/.chachalog/ALTlb7A5.md
+++ b/.chachalog/ALTlb7A5.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": patch
+---
+
+Added url encoding of links coming from link and image picker, to resolve issues with symbols like ` + `. Backport of a fix from CK5.

--- a/src/javascript/ContentEditor/SelectorTypes/RichText/RichText.utils.js
+++ b/src/javascript/ContentEditor/SelectorTypes/RichText/RichText.utils.js
@@ -3,6 +3,16 @@ const contextPath = (window.contextJsParameters && window.contextJsParameters.co
 const contentPrefix = `${contextPath}/cms/{mode}/{lang}`;
 const filePrefix = `${contextPath}/files/{workspace}`;
 
+/**
+ * URL-encode each segment of a Jahia node path (preserving '/' separators) so that
+ * special characters such as '+' and spaces in folder/file names survive server-side
+ * link resolution. Inverse of the decodeURIComponent done in getPickerValue.
+ *
+ * @param {string} path the raw node path returned by the picker, e.g. /sites/x/files/test + test/f.pdf
+ * @returns {string} the path with each segment URL-encoded
+ */
+export const encodePath = path => path.split('/').map(encodeURIComponent).join('/');
+
 // Find "URL" input in CKEditor dialog.
 function getCKEditorUrlInputId(dialog) {
     if (!dialog) {
@@ -32,9 +42,9 @@ export function fillCKEditorPicker(setUrl, dialog, contentPicker, pickerResult) 
     if (pickerResult.url) {
         setUrl(pickerResult.url);
     } else {
-        // Wrap path to build Jahia url.
-        const pathWithEncodedFileName = pickerResult.path.replace(/\/([^/]+\.[^/?#]+)(\?|#|$)/, (_, fileName, suffix) => `/${encodeURIComponent(fileName)}${suffix}`);
-        setUrl(`${contentPicker ? contentPrefix : filePrefix}${pathWithEncodedFileName}${contentPicker ? '.html' : ''}`, {});
+        // Wrap path to build Jahia url. Encode every path segment (not just the file name) so that
+        // special characters such as '+' and spaces in folder names survive server-side resolution.
+        setUrl(`${contentPicker ? contentPrefix : filePrefix}${encodePath(pickerResult.path)}${contentPicker ? '.html' : ''}`, {});
     }
 }
 

--- a/src/javascript/ContentEditor/SelectorTypes/RichText/RichText.utils.spec.js
+++ b/src/javascript/ContentEditor/SelectorTypes/RichText/RichText.utils.spec.js
@@ -121,6 +121,15 @@ describe('RichText utils', () => {
             );
         });
 
+        it('should url-encode every path segment, not just the file name', () => {
+            contentPicker = false;
+            fillCKEditorPicker(setUrl, dialog, contentPicker, {path: '/sites/x/files/test + test/test.jpg'});
+            expect(setUrl).toHaveBeenCalledWith(
+                `/files/{workspace}/sites/x/files/${encodeURIComponent('test + test')}/test.jpg`,
+                {}
+            );
+        });
+
         it('should fill advTitle', () => {
             const setValueOfAdvTitle = jest.fn();
             dialog.getContentElement = jest.fn((_, id) => {


### PR DESCRIPTION
### Description
This PR applies the URL encoding to all parts of links coming from plugins, to sanitize symbols like ` + `.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
