### PR TITLE
ci: Fix nightly tests after main migration

### DIFF
--- a/.github/workflows/manual-run.yml
+++ b/.github/workflows/manual-run.yml
@@ -29,6 +29,7 @@ jobs:
     uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
     with:
       module_id: jcontent
+      module_branch: ${{ github.ref }}
       jahia_image: ${{ github.event.inputs.jahia_image }}
       jahia_cluster_enabled: ${{ fromJSON(github.event.inputs.jahia_cluster_enabled) }}
       tests_profile: ${{ github.event.inputs.config_file }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,7 @@ jobs:
     uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
     with:
       module_id: jcontent
+      module_branch: ${{ github.ref }}
       jahia_image: ${{ matrix.jahia_image }}
       tests_profile: ${{ matrix.config_file }}
       provisioning_manifest: provisioning-manifest-snapshot.yml

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ yarn-error.log
 graphql.config.json
 graphql.schema.json
 .env
+.vscode
 
 coverage/
 /storybook-static


### PR DESCRIPTION
### Description

Current nightly failing due to recent migration to reusable-integration-tests workflow: https://github.com/Jahia/jcontent/actions/runs/26486090763/job/77993763878#step:9:73

```
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/master*:refs/remotes/origin/master* +refs/tags/master*:refs/tags/master*
  The process '/usr/bin/git' failed with exit code 1
  Waiting 11 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/master*:refs/remotes/origin/master* +refs/tags/master*:refs/tags/master*
  The process '/usr/bin/git' failed with exit code 1
  Waiting 16 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/master*:refs/remotes/origin/master* +refs/tags/master*:refs/tags/master*
  Error: The process '/usr/bin/git' failed with exit code 1
```

reusable-integration-tests default to master so we need to pass current branch ref (which defaults to main) instead.