### PR TITLE
fix: sanitize filename in replace path to match stored node name

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/Upload/UploadItem/UploadItem.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/Upload/UploadItem/UploadItem.jsx
@@ -21,7 +21,7 @@ import {
     fileuploadTakeFromQueue,
     fileuploadUpdateUpload
 } from '~/JContent/ContentRoute/ContentLayout/Upload/Upload.redux';
-import {createMissingFolders, onFilesSelected} from '~/JContent/ContentRoute/ContentLayout/Upload/Upload.utils';
+import {createMissingFolders, onFilesSelected, sanitizeName} from '~/JContent/ContentRoute/ContentLayout/Upload/Upload.utils';
 import {uploadErrors} from '../Upload.constants';
 import clsx from 'clsx';
 
@@ -87,7 +87,7 @@ export const UploadItem = ({upload, index}) => {
         }
 
         if (type === 'replace') {
-            let newPath = `${normalizedPath}/${getFileName()}`;
+            let newPath = `${normalizedPath}/${sanitizeName(getFileName())}`;
             return registry.get('fileUpload', 'replace').handleUpload({path: newPath, file, client});
         }
 


### PR DESCRIPTION
## Summary
- File replace fails silently (blank page) for filenames containing uppercase letters (e.g. `Report.pdf`, `relatorio-anual-pt-BR.pdf`)
- Root cause: initial upload stores node via `sanitizeName()` (lowercases base name), but replace path used raw `getFileName()` — JCR path lookup is case-sensitive, so the node was not found
- Fix: apply `sanitizeName()` to the replace path to match stored node name
- Regression introduced in 3ede5420
- Fixes https://github.com/Jahia/jcontent/issues/2413

## Test plan
- [ ] Upload a file with uppercase in name (e.g. `MyFile.pdf`)
- [ ] Upload same file again → click Replace
- [ ] Confirm file is replaced, no blank page
- [ ] Confirm all-lowercase filename replace still works