### PR TITLE
feat: Add secured options for yarn install

### DIFF
--- a/.chachalog/oL0n0DwF.md
+++ b/.chachalog/oL0n0DwF.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Add secured options for yarn commands in CI (#2348)

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -36,11 +36,12 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
+      - name: Install JS dependencies without running package build scripts
+        shell: bash
+        run: yarn install --immutable --mode=skip-build
       - name: Run yarn test
         shell: bash
-        run: |
-          yarn
-          yarn test
+        run: yarn test
 
   build:
     name: Build Module

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -36,12 +36,11 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
-      - name: Install JS dependencies without running package build scripts
-        shell: bash
-        run: yarn install --immutable --mode=skip-build
       - name: Run yarn test
         shell: bash
-        run: yarn test
+        run: |
+          yarn
+          yarn test
 
   build:
     name: Build Module

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,4 @@ nodeLinker: node-modules
 yarnPath: .yarn/releases/yarn-4.12.0.cjs
 
 enableScripts: false
+enableImmutableInstalls: true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,5 +2,4 @@ nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs
 
-enableScripts: false
 enableImmutableInstalls: true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,3 @@
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs
-
-enableImmutableInstalls: true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,6 @@
 nodeLinker: "node-modules",
 
-yarnPath: "".yarn/releases/yarn-4.12.0.cjs",
+yarnPath: ".yarn/releases/yarn-4.12.0.cjs",
 
 npmMinimalAgeGate: "1w",
 

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,7 +1,7 @@
-nodeLinker: "node-modules",
+nodeLinker: node-modules
 
-yarnPath: ".yarn/releases/yarn-4.12.0.cjs",
+yarnPath: .yarn/releases/yarn-4.12.0.cjs
 
-npmMinimalAgeGate: "1w",
+npmMinimalAgeGate: 1w
 
-npmPreapprovedPackages: [@jahia*],
+npmPreapprovedPackages: [@jahia*]

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,4 +4,4 @@ yarnPath: .yarn/releases/yarn-4.12.0.cjs
 
 npmMinimalAgeGate: 1w
 
-npmPreapprovedPackages: [@jahia*]
+npmPreapprovedPackages: ["@jahia/*"]

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs
+
+enableScripts: false

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,7 @@
-nodeLinker: node-modules
+nodeLinker: "node-modules",
 
-yarnPath: .yarn/releases/yarn-4.12.0.cjs
+yarnPath: "".yarn/releases/yarn-4.12.0.cjs",
+
+npmMinimalAgeGate: "1w",
+
+npmPreapprovedPackages: [@jahia*],

--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,9 @@
                         <goals>
                             <goal>yarn</goal>
                         </goals>
+                        <configuration>
+                            <arguments>install --immutable --mode=skip-build</arguments>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>yarn post-install</id>

--- a/tests/jahia-module/jcontent-test-module/pom.xml
+++ b/tests/jahia-module/jcontent-test-module/pom.xml
@@ -102,6 +102,9 @@
                         <goals>
                             <goal>yarn</goal>
                         </goals>
+                        <configuration>
+                            <arguments>install --immutable</arguments>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>yarn post-install</id>


### PR DESCRIPTION
### Description
- In Yarn 4, `--frozen-lockfile` is legacy-style wording; `--immutable` / `enableImmutableInstalls` is the modern approach.
- `--ignore-scripts` behavior is effectively covered by `enableScripts: false`.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
