### PR TITLE
fix: Show insertion points for all children, adjust its position

### DIFF
--- a/.chachalog/IaxdmCjA.md
+++ b/.chachalog/IaxdmCjA.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Show insertion points for all children, adjust position to show above headers (#2349)

--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -202,7 +202,14 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
             insertionStyle.left = currentOffset.left - (btnWidth / 2);
             insertionStyle.flexDirection = 'column';
         } else {
-            insertionStyle.top = currentOffset.top - 16;
+            const marginTop = parseFloat(element.ownerDocument.defaultView.getComputedStyle(element).marginTop) || 0;
+            let parentPaddingTop = 0;
+
+            if (element.parentElement.firstElementChild === element) {
+                parentPaddingTop = parseFloat(element.ownerDocument.defaultView.getComputedStyle(element.parentElement).paddingTop) || 0;
+            }
+
+            insertionStyle.top = currentOffset.top - 16 - marginTop - parentPaddingTop;
         }
     }
 

--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -202,11 +202,11 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
             insertionStyle.left = currentOffset.left - (btnWidth / 2);
             insertionStyle.flexDirection = 'column';
         } else {
-            const marginTop = parseFloat(element.ownerDocument.defaultView.getComputedStyle(element).marginTop) || 0;
+            const marginTop = Number.parseFloat(element.ownerDocument.defaultView.getComputedStyle(element).marginTop) || 0;
             let parentPaddingTop = 0;
 
             if (element.parentElement.firstElementChild === element) {
-                parentPaddingTop = parseFloat(element.ownerDocument.defaultView.getComputedStyle(element.parentElement).paddingTop) || 0;
+                parentPaddingTop = Number.parseFloat(element.ownerDocument.defaultView.getComputedStyle(element.parentElement).paddingTop) || 0;
             }
 
             insertionStyle.top = currentOffset.top - 16 - marginTop - parentPaddingTop;

--- a/src/javascript/JContent/EditFrame/InsertionPoints.jsx
+++ b/src/javascript/JContent/EditFrame/InsertionPoints.jsx
@@ -37,9 +37,9 @@ const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCal
         .filter(({node}) => node !== null && node !== undefined);
 
     // Get all children of the clicked element that are [type="existingNode"] and add insertion points for each (insertion points appear on top)
-    const childrenElem = [...currentDocument.querySelectorAll(`[type="existingNode"][data-jahia-parent=${clickedElement.element.id}]`)]
+    const childrenElem = [...currentDocument.querySelectorAll(`[data-jahia-parent=${clickedElement.element.id}]`)]
         // Need to make sure that existingNode is not a weakreference but a subnode, which we can do by checking subpath
-        .filter(e => e.getAttribute('path').startsWith(clickedPath))
+        .filter(e => e.getAttribute('path')?.startsWith(clickedPath))
         .map(e => ({
             element: e,
             node: nodes?.[e.dataset.jahiaParent && e.ownerDocument.getElementById(e.dataset.jahiaParent).getAttribute('path')],


### PR DESCRIPTION
### Description
Show insertion points for all children including lists and areas, adjust its position so that it always appears on top the header if one is present (take margin/padding into consideration).

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
