### PR TITLE
fix: Prevent invisible create buttons from becoming visible

### DIFF
--- a/.chachalog/JQdPvzXL.md
+++ b/.chachalog/JQdPvzXL.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Prevent invisible create buttons from becoming visible (#2352)

--- a/packages/editframe-styles/src/Create.module.scss
+++ b/packages/editframe-styles/src/Create.module.scss
@@ -14,6 +14,7 @@
     flex-wrap: nowrap;
     justify-content: center;
     align-items: center;
+    overflow: hidden;
 
     // Hide container if there is no children
     &:empty {


### PR DESCRIPTION
### Description
Prevent invisible create buttons from becoming visible. The buttons that belong to hidden connect have 0 height/width and should not appear in the view.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
