### PR TITLE
fix: allow import of droppable content

### DIFF
--- a/.chachalog/rHpV7vIY.md
+++ b/.chachalog/rHpV7vIY.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": patch
+---
+
+Allow import of jmix:droppable content.

--- a/src/javascript/JContent/actions/fileUploadAction.jsx
+++ b/src/javascript/JContent/actions/fileUploadAction.jsx
@@ -27,7 +27,7 @@ const constraintsByType = {
         requiredSitePermission: [ACTION_PERMISSIONS.replaceWithAction]
     },
     import: {
-        showOnNodeTypes: ['jnt:contentFolder', 'jnt:category', 'jnt:page', 'jnt:area', 'jmix:list', 'jnt:navMenuText'],
+        showOnNodeTypes: ['jnt:contentFolder', 'jnt:category', 'jnt:page', 'jnt:area', 'jmix:list', 'jnt:navMenuText', 'jmix:droppableContent'],
         hideOnNodeTypes: ['jnt:folder'],
         requiredPermission: 'jcr:addChildNodes',
         requiredSitePermission: [ACTION_PERMISSIONS.importAction]

--- a/src/javascript/JContent/actions/fileUploadAction.jsx
+++ b/src/javascript/JContent/actions/fileUploadAction.jsx
@@ -30,7 +30,8 @@ const constraintsByType = {
         showOnNodeTypes: ['jnt:contentFolder', 'jnt:category', 'jnt:page', 'jnt:area', 'jmix:list', 'jnt:navMenuText', 'jmix:droppableContent'],
         hideOnNodeTypes: ['jnt:folder'],
         requiredPermission: 'jcr:addChildNodes',
-        requiredSitePermission: [ACTION_PERMISSIONS.importAction]
+        requiredSitePermission: [ACTION_PERMISSIONS.importAction],
+        getChildNodeTypes: true
     },
     fileUpload: {
         showOnNodeTypes: ['jnt:folder'],
@@ -84,7 +85,11 @@ export const FileUploadActionComponent = props => {
         elementById.click();
     };
 
-    const isVisible = res.checksResult;
+    // Import targets a container: in addition to the permission/type checks, the node must actually
+    // accept child content. This excludes droppable *leaf* content (jmix:droppableContent without
+    // allowed child node types), mirroring the container check used by the paste action.
+    const acceptsChildren = res.node?.allowedChildNodeTypes?.length > 0;
+    const isVisible = res.checksResult && (uploadType !== 'import' || acceptsChildren);
 
     return (
         <Render

--- a/tests/cypress/e2e/menuActions/importDroppableContent.cy.ts
+++ b/tests/cypress/e2e/menuActions/importDroppableContent.cy.ts
@@ -1,0 +1,38 @@
+import {addNode} from '@jahia/cypress';
+import {JContent} from '../../page-object';
+
+describe('Import action visibility on droppable content', {testIsolation: false}, () => {
+    const siteKey = 'jContentSite-importDroppable';
+
+    before(function () {
+        cy.executeGroovy('contentEditor/createSite.groovy', {SITEKEY: siteKey});
+        cy.loginAndStoreSession(); // Edit in chief
+        // Droppable container that accepts children but is none of the whitelisted types.
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: 'my-droppable',
+            primaryNodeType: 'cent:droppableContainer'
+        });
+        // Non-droppable leaf content: import must stay hidden here.
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: 'my-non-droppable',
+            primaryNodeType: 'cent:testTextField'
+        });
+    });
+
+    after(function () {
+        cy.executeGroovy('contentEditor/deleteSite.groovy', {SITEKEY: siteKey});
+        cy.logout();
+    });
+
+    it('shows the import action on droppable content that accepts children', function () {
+        const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+        jcontent.getTable().getRowByName('my-droppable').contextMenu().shouldHaveRoleItem('import');
+    });
+
+    it('does not show the import action on non-droppable content', function () {
+        const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+        jcontent.getTable().getRowByName('my-non-droppable').contextMenu().shouldNotHaveRoleItem('import');
+    });
+});

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -112,6 +112,9 @@
 [cent:html5PluginTestComponent] > jnt:content, mix:title, jmix:editorialContent, jmix:droppableContent, jmix:siteComponent
  - text (string, richtext[ckeditor.customConfig='$context/modules/jcontent-test-module/javascript/config.js'])
 
+[cent:droppableContainer] > jnt:content, jmix:editorialContent, jmix:droppableContent, mix:title
+ + * (jnt:content)
+
 [cemix:withCustomBar] mixin
 
 // Adding definitions and JSON overrides for the new content types based on https://jira.jahia.org/browse/QA-15148


### PR DESCRIPTION
### Description
This PR allows using the import action on droppable content.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
