### PR TITLE
feat: Add loading state for context menus

### DIFF
--- a/.chachalog/zPXZZpoQ.md
+++ b/.chachalog/zPXZZpoQ.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Improved context menus so they open immediately with a loading indicator and display available actions faster. (#2363)

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@jahia/data-helper": "^1.1.19",
     "@jahia/design-system-kit": "^1.2.1",
     "@jahia/icons": "^1.1.2",
-    "@jahia/moonstone": "^2.19.0",
+    "@jahia/moonstone": "^2.20.0",
     "@jahia/react-material": "^3.0.5",
     "@jahia/ui-extender": "^1.3.0",
     "@material-ui/core": "^3.9.3",

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/JahiaPicker/RightPanel/PickerContentLayout/PickerContentTable/PickerRow.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/JahiaPicker/RightPanel/PickerContentLayout/PickerContentTable/PickerRow.jsx
@@ -74,6 +74,7 @@ export const PickerRow = ({
                 setOpenRef={contextualMenu}
                 actionKey={previousModeTableConfig.contextualMenu}
                 path={node.path}
+                node={node}
             />}
             {row.cells.map(cell => <React.Fragment key={cell.column.id}>{cell.render('Cell')}</React.Fragment>)}
         </TableRow>

--- a/src/javascript/ContentEditor/actions/jcontent/createContent/createContent.utils.js
+++ b/src/javascript/ContentEditor/actions/jcontent/createContent/createContent.utils.js
@@ -8,8 +8,9 @@ import {Tag, toIconComponent} from '@jahia/moonstone';
 import React from 'react';
 
 export const useCreatableNodetypesTree = ({nodeTypes, childNodeName, includeSubTypes, path, uuid, uilang, excludedNodeTypes, showOnNodeTypes}) => {
-    const {data, error, loadingTypes} = useQuery(uuid ? getTreeOfContentWithRequirementsFromUuid : getTreeOfContentWithRequirements, {
+    const {data, error, loading} = useQuery(uuid ? getTreeOfContentWithRequirementsFromUuid : getTreeOfContentWithRequirements, {
         fetchPolicy: 'cache-and-network',
+        notifyOnNetworkStatusChange: true,
         variables: {
             nodeTypes: (nodeTypes && nodeTypes.length) > 0 ? nodeTypes : undefined,
             childNodeName,
@@ -25,7 +26,7 @@ export const useCreatableNodetypesTree = ({nodeTypes, childNodeName, includeSubT
 
     return {
         error,
-        loadingTypes,
+        loadingTypes: loading && !data,
         nodetypes: nodeTypeNotDisplayed ? [] : data.forms.contentTypesAsTree
     };
 };

--- a/src/javascript/ContentEditor/actions/jcontent/editContent/editContentAction.jsx
+++ b/src/javascript/ContentEditor/actions/jcontent/editContent/editContentAction.jsx
@@ -4,9 +4,11 @@ import * as PropTypes from 'prop-types';
 import {useSelector} from 'react-redux';
 import {useTranslation} from 'react-i18next';
 import {useContentEditorApiContext} from '~/ContentEditor/contexts/ContentEditorApi/ContentEditorApi.context';
+import {isDefinitelyHidden} from '~/JContent/actions/utils/nodeVisibilityUtils';
 
 export const EditContent = ({
     path,
+    node: prefetchedNode,
     isFullscreen,
     editCallback,
     render: Render,
@@ -16,13 +18,21 @@ export const EditContent = ({
     useTranslation('jcontent');
     const api = useContentEditorApiContext();
     const language = useSelector(state => state.language);
+
+    // Only use hideOnNodeTypes for pre-gate — showOnNodeTypes is skipped (subtype risk)
+    const skip = isDefinitelyHidden(prefetchedNode, {hideOnNodeTypes: otherProps.hideOnNodeTypes});
+
     const res = useNodeChecks(
         {path: path, language: language},
-        {...otherProps}
+        {skip, ...otherProps}
     );
 
     if (Loading && res.loading) {
         return <Loading {...otherProps}/>;
+    }
+
+    if (skip) {
+        return false;
     }
 
     return (
@@ -47,6 +57,7 @@ EditContent.defaultProps = {
 
 EditContent.propTypes = {
     path: PropTypes.string.isRequired,
+    node: PropTypes.object,
     isFullscreen: PropTypes.bool,
     editCallback: PropTypes.func,
     render: PropTypes.func.isRequired,

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/Row.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/Row.jsx
@@ -88,6 +88,7 @@ export const Row = ({
                 currentPath={node.path}
                 path={selection.length === 0 || selection.indexOf(node.path) === -1 ? node.path : null}
                 paths={selection.length === 0 || selection.indexOf(node.path) === -1 ? null : selection}
+                node={node}
             />
             {row.cells.map(cell => <React.Fragment key={cell.column.id}>{cell.render('Cell')}</React.Fragment>)}
         </TableRow>

--- a/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/FilesGrid/FileCard/FileCard.jsx
@@ -132,6 +132,7 @@ export const FileCard = ({
                     currentPath={node.path}
                     path={selection.length === 0 || selection.indexOf(node.path) === -1 ? node.path : null}
                     paths={selection.length === 0 || selection.indexOf(node.path) === -1 ? null : selection}
+                    node={node}
                 />
             )}
 

--- a/src/javascript/JContent/ContentTree/ContentTree.jsx
+++ b/src/javascript/JContent/ContentTree/ContentTree.jsx
@@ -249,7 +249,7 @@ export const ContentTree = ({setPathAction, openPathAction, closePathAction, ite
                           onContextMenuItem={(object, event) => {
                               event.stopPropagation();
                               if (contextualMenuAction) {
-                                  contextualMenu.current(event, {path: object.id});
+                                  contextualMenu.current(event, {path: object.id, node: object.treeItemProps?.node});
                               }
                           }}
                           onClickItem={object => {

--- a/src/javascript/JContent/ContentTree/ContentTree.jsx
+++ b/src/javascript/JContent/ContentTree/ContentTree.jsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useRef, useCallback} from 'react';
 import PropTypes from 'prop-types';
 import {shallowEqual, useDispatch, useSelector} from 'react-redux';
-import {displayName, lockInfo, useNodeInfo, useTreeEntries} from '@jahia/data-helper';
+import {displayName, lockInfo, operationSupport, useNodeInfo, useTreeEntries} from '@jahia/data-helper';
 import {PickerItemsFragment} from './ContentTree.gql-fragments';
 import {TreeView} from '@jahia/moonstone';
 import {ContextualMenu} from '@jahia/ui-extender';
@@ -138,7 +138,7 @@ export const ContentTree = ({setPathAction, openPathAction, closePathAction, ite
     }, []);
 
     const useTreeEntriesOptionsJson = {
-        fragments: [PickerItemsFragment.mixinTypes, PickerItemsFragment.primaryNodeType, PickerItemsFragment.isPublished, lockInfo, PickerItemsFragment.parentNode, displayName],
+        fragments: [PickerItemsFragment.mixinTypes, PickerItemsFragment.primaryNodeType, PickerItemsFragment.isPublished, lockInfo, operationSupport, PickerItemsFragment.parentNode, displayName],
         rootPaths: [rootPath],
         openPaths: openPaths,
         selectedPaths: [path],

--- a/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
@@ -436,6 +436,7 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
                     currentFrameRef={currentFrameRef}
                     currentDocument={currentDocument}
                     selection={selection}
+                    nodes={nodes}
                 />
             </HoverProvider>
 

--- a/src/javascript/JContent/EditFrame/Boxes/BoxesContextMenu.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/BoxesContextMenu.jsx
@@ -13,7 +13,7 @@ import {useHoverContext} from '~/JContent/EditFrame/Boxes/HoverContext';
  * @param {string} props.currentHoveredRef Current content path
  * @param {string[]} props.selection Array of selected paths
  */
-const BoxesContextMenu = ({currentFrameRef, currentDocument, selection}) => {
+const BoxesContextMenu = ({currentFrameRef, currentDocument, selection, nodes}) => {
     const contextualMenu = useRef();
     const {hoveredPath: currentPath} = useHoverContext();
 
@@ -73,6 +73,7 @@ const BoxesContextMenu = ({currentFrameRef, currentDocument, selection}) => {
             setOpenRef={contextualMenu}
             currentPath={currentPath}
             documentElement={currentDocument.documentElement}
+            node={nodes?.[currentPath]}
             {...pathObject}
         />
     );
@@ -82,6 +83,7 @@ BoxesContextMenu.propTypes = {
     currentDocument: PropTypes.any,
     currentFrameRef: PropTypes.any,
     currentPath: PropTypes.string,
+    nodes: PropTypes.object,
     selection: PropTypes.arrayOf(PropTypes.string)
 };
 

--- a/src/javascript/JContent/MenuItemRenderer.jsx
+++ b/src/javascript/JContent/MenuItemRenderer.jsx
@@ -5,7 +5,7 @@ import {ChevronDown, ChevronRight, MenuItem, Separator} from '@jahia/moonstone';
 import {MenuItemSkeleton} from './MenuItemSkeleton';
 import {MenuLoadingContext} from './MenuLoadingContext';
 
-export let MenuItemRenderer = ({buttonLabel, buttonLabelParams, menuContext, menuState, buttonIcon, buttonIconEnd, actionKey, enabled, isSeparator, onClick, onMouseEnter, onMouseLeave, buttonProps, isTitle}) => {
+export const MenuItemRenderer = ({buttonLabel, buttonLabelParams, menuContext, menuState, buttonIcon, buttonIconEnd, actionKey, enabled, isSeparator, onClick, onMouseEnter, onMouseLeave, buttonProps, isTitle}) => {
     const {t} = useTranslation('jcontent');
     const [hover, setHover] = useState(false);
     const isMenuLoading = useContext(MenuLoadingContext);

--- a/src/javascript/JContent/MenuItemRenderer.jsx
+++ b/src/javascript/JContent/MenuItemRenderer.jsx
@@ -1,18 +1,20 @@
-import React, {useState} from 'react';
+import React, {useContext, useState} from 'react';
 import PropTypes from 'prop-types';
 import {useTranslation} from 'react-i18next';
 import {ChevronDown, ChevronRight, MenuItem, Separator} from '@jahia/moonstone';
 import {MenuItemSkeleton} from './MenuItemSkeleton';
+import {MenuLoadingContext} from './MenuLoadingContext';
 
-export let MenuItemRenderer = ({buttonLabel, buttonLabelParams, menuContext, menuState, buttonIcon, buttonIconEnd, actionKey, enabled, isLoading, isSeparator, onClick, onMouseEnter, onMouseLeave, buttonProps, isTitle}) => {
+export let MenuItemRenderer = ({buttonLabel, buttonLabelParams, menuContext, menuState, buttonIcon, buttonIconEnd, actionKey, enabled, isSeparator, onClick, onMouseEnter, onMouseLeave, buttonProps, isTitle}) => {
     const {t} = useTranslation('jcontent');
     const [hover, setHover] = useState(false);
+    const isMenuLoading = useContext(MenuLoadingContext);
 
     if (isSeparator) {
         return <Separator invisible="firstOrLastChild"/>;
     }
 
-    if (isLoading) {
+    if (isMenuLoading) {
         return <MenuItemSkeleton/>;
     }
 
@@ -76,7 +78,6 @@ MenuItemRenderer.propTypes = {
     buttonIconEnd: PropTypes.object,
     // eslint-disable-next-line react/boolean-prop-naming
     enabled: PropTypes.bool,
-    isLoading: PropTypes.bool,
     isSeparator: PropTypes.bool,
     isTitle: PropTypes.bool,
 

--- a/src/javascript/JContent/MenuItemRenderer.jsx
+++ b/src/javascript/JContent/MenuItemRenderer.jsx
@@ -2,13 +2,18 @@ import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import {useTranslation} from 'react-i18next';
 import {ChevronDown, ChevronRight, MenuItem, Separator} from '@jahia/moonstone';
+import {MenuItemSkeleton} from './MenuItemSkeleton';
 
-export let MenuItemRenderer = ({buttonLabel, buttonLabelParams, menuContext, menuState, buttonIcon, buttonIconEnd, actionKey, enabled, isSeparator, onClick, onMouseEnter, onMouseLeave, buttonProps, isTitle}) => {
+export let MenuItemRenderer = ({buttonLabel, buttonLabelParams, menuContext, menuState, buttonIcon, buttonIconEnd, actionKey, enabled, isLoading, isSeparator, onClick, onMouseEnter, onMouseLeave, buttonProps, isTitle}) => {
     const {t} = useTranslation('jcontent');
     const [hover, setHover] = useState(false);
 
     if (isSeparator) {
         return <Separator invisible="firstOrLastChild"/>;
+    }
+
+    if (isLoading) {
+        return <MenuItemSkeleton/>;
     }
 
     // eslint-disable-next-line react/no-danger
@@ -27,7 +32,10 @@ export let MenuItemRenderer = ({buttonLabel, buttonLabelParams, menuContext, men
     };
 
     const onLeave = e => {
-        onMouseLeave(e);
+        if (onMouseLeave) {
+            onMouseLeave(e);
+        }
+
         setHover(false);
     };
 
@@ -68,6 +76,7 @@ MenuItemRenderer.propTypes = {
     buttonIconEnd: PropTypes.object,
     // eslint-disable-next-line react/boolean-prop-naming
     enabled: PropTypes.bool,
+    isLoading: PropTypes.bool,
     isSeparator: PropTypes.bool,
     isTitle: PropTypes.bool,
 

--- a/src/javascript/JContent/MenuItemSkeleton.jsx
+++ b/src/javascript/JContent/MenuItemSkeleton.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styles from './MenuItemSkeleton.module.scss';
 
 export const MenuItemSkeleton = () => (
-    <div className={styles.menuItemSkeleton}>
+    <div className={styles.menuItemSkeleton} data-sel-role="menu-item-skeleton">
         <div className={styles.bar}/>
     </div>
 );

--- a/src/javascript/JContent/MenuItemSkeleton.jsx
+++ b/src/javascript/JContent/MenuItemSkeleton.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import styles from './MenuItemSkeleton.module.scss';
+
+export const MenuItemSkeleton = () => (
+    <div className={styles.menuItemSkeleton}>
+        <div className={styles.bar}/>
+    </div>
+);

--- a/src/javascript/JContent/MenuItemSkeleton.module.scss
+++ b/src/javascript/JContent/MenuItemSkeleton.module.scss
@@ -2,7 +2,8 @@
     display: flex;
     align-items: center;
     padding: var(--moon-spacing-nano) var(--moon-spacing-medium);
-    height: 36px;
+    height: var(--moon-spacing-large);
+    min-width: 200px;
     box-sizing: border-box;
 }
 

--- a/src/javascript/JContent/MenuItemSkeleton.module.scss
+++ b/src/javascript/JContent/MenuItemSkeleton.module.scss
@@ -1,23 +1,26 @@
 .menuItemSkeleton {
     display: flex;
     align-items: center;
-    padding: var(--moon-spacing-nano) var(--moon-spacing-medium);
-    height: var(--moon-spacing-large);
-    min-width: 200px;
     box-sizing: border-box;
+    min-width: 200px;
+    height: var(--moon-spacing-large);
+    padding: var(--moon-spacing-nano) var(--moon-spacing-medium);
 }
 
 .bar {
-    border-radius: 4px;
-    height: 12px;
     width: 100%;
-    background: linear-gradient(
-        90deg,
-        var(--moon-color-gray_light40) 25%,
-        var(--moon-color-gray_light60) 50%,
-        var(--moon-color-gray_light40) 75%
-    );
+    height: 12px;
+
+    border-radius: 4px;
+    background:
+        linear-gradient(
+            90deg,
+            var(--moon-color-gray_light40) 25%,
+            var(--moon-color-gray_light60) 50%,
+            var(--moon-color-gray_light40) 75%
+        );
     background-size: 200% 100%;
+
     animation: shimmer 1.4s infinite;
 }
 

--- a/src/javascript/JContent/MenuItemSkeleton.module.scss
+++ b/src/javascript/JContent/MenuItemSkeleton.module.scss
@@ -1,0 +1,31 @@
+.menuItemSkeleton {
+    display: flex;
+    align-items: center;
+    padding: var(--moon-spacing-nano) var(--moon-spacing-medium);
+    height: 36px;
+    box-sizing: border-box;
+}
+
+.bar {
+    border-radius: 4px;
+    height: 12px;
+    width: 100%;
+    background: linear-gradient(
+        90deg,
+        var(--moon-color-gray_light40) 25%,
+        var(--moon-color-gray_light60) 50%,
+        var(--moon-color-gray_light40) 75%
+    );
+    background-size: 200% 100%;
+    animation: shimmer 1.4s infinite;
+}
+
+@keyframes shimmer {
+    0% {
+        background-position: 200% 0;
+    }
+
+    100% {
+        background-position: -200% 0;
+    }
+}

--- a/src/javascript/JContent/MenuLoadingContext.js
+++ b/src/javascript/JContent/MenuLoadingContext.js
@@ -1,0 +1,3 @@
+import {createContext} from 'react';
+
+export const MenuLoadingContext = createContext(false);

--- a/src/javascript/JContent/MenuRenderer.jsx
+++ b/src/javascript/JContent/MenuRenderer.jsx
@@ -7,8 +7,8 @@ export const MenuRenderer = ({isSubMenu, anchor, isOpen, isLoading, onClose, onE
         {...anchor}
         data-sel-role={'jcontent-' + menuKey}
         style={{zIndex: isSubMenu ? 9001 : 9000}}
-        hasOverlay={isOpen && !isLoading && !isSubMenu}
-        isDisplayed={isOpen && !isLoading}
+        hasOverlay={isOpen && !isSubMenu}
+        isDisplayed={isOpen}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         onClose={onClose}

--- a/src/javascript/JContent/MenuRenderer.jsx
+++ b/src/javascript/JContent/MenuRenderer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Menu} from '@jahia/moonstone';
+import {MenuLoadingContext} from './MenuLoadingContext';
 
 export const MenuRenderer = ({isSubMenu, anchor, isOpen, isLoading, onClose, onExited, onMouseEnter, onMouseLeave, children, menuKey, ...otherProps}) => (
     <Menu
@@ -15,7 +16,9 @@ export const MenuRenderer = ({isSubMenu, anchor, isOpen, isLoading, onClose, onE
         onExited={onExited}
         {...otherProps}
     >
-        {children}
+        <MenuLoadingContext.Provider value={isLoading}>
+            {children}
+        </MenuLoadingContext.Provider>
     </Menu>
 );
 

--- a/src/javascript/JContent/actions/clearAllLocksAction.jsx
+++ b/src/javascript/JContent/actions/clearAllLocksAction.jsx
@@ -4,11 +4,13 @@ import {useNodeChecks} from '@jahia/data-helper';
 import PropTypes from 'prop-types';
 import {useApolloClient} from '@apollo/client';
 
-export const ClearAllLocksActionComponent = ({path, render: Render, loading: Loading, ...others}) => {
+export const ClearAllLocksActionComponent = ({path, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const client = useApolloClient();
+    const skip = prefetchedNode?.operationsSupport?.lock === false;
     const res = useNodeChecks(
         {path},
         {
+            skip,
             getLockInfo: true,
             getOperationSupport: true,
             requiredPermission: ['clearLock']
@@ -17,6 +19,10 @@ export const ClearAllLocksActionComponent = ({path, render: Render, loading: Loa
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     const isVisible = res.checksResult && res.node && res.node.operationsSupport.lock && res.node.lockTypes !== null && res.node.lockTypes.values.indexOf(' deletion :deletion') === -1;
@@ -50,6 +56,8 @@ export const ClearAllLocksActionComponent = ({path, render: Render, loading: Loa
 
 ClearAllLocksActionComponent.propTypes = {
     path: PropTypes.string,
+
+    node: PropTypes.object,
 
     render: PropTypes.func.isRequired,
 

--- a/src/javascript/JContent/actions/compareHtmlAction/compareHtmlAction.jsx
+++ b/src/javascript/JContent/actions/compareHtmlAction/compareHtmlAction.jsx
@@ -3,12 +3,15 @@ import PropTypes from 'prop-types';
 import {createEncodedHashString} from '../../CompareDialog/util';
 import {useNodeChecks} from '@jahia/data-helper';
 import {useSelector} from 'react-redux';
+import {isDefinitelyHidden} from '../utils/nodeVisibilityUtils';
 
-export const CompareHtmlActionComponent = ({path, render: Render, loading: Loading, ...others}) => {
+export const CompareHtmlActionComponent = ({path, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const language = useSelector(state => state.language);
+    const skip = isDefinitelyHidden(prefetchedNode, {showOnNodeTypes: ['jnt:page', 'jmix:mainResource']});
     const res = useNodeChecks(
         {path, language},
         {
+            skip,
             showOnNodeTypes: ['jnt:page', 'jmix:mainResource'],
             getAggregatedPublicationInfo: {subNodes: true}
         }
@@ -21,6 +24,10 @@ export const CompareHtmlActionComponent = ({path, render: Render, loading: Loadi
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     const isVisible = res.checksResult && (res?.node?.aggregatedPublicationInfo.publicationStatus === 'PUBLISHED' ||
@@ -39,6 +46,7 @@ export const CompareHtmlActionComponent = ({path, render: Render, loading: Loadi
 
 CompareHtmlActionComponent.propTypes = {
     path: PropTypes.string,
+    node: PropTypes.object,
     render: PropTypes.func.isRequired,
     loading: PropTypes.func
 };

--- a/src/javascript/JContent/actions/compareHtmlAction/compareHtmlAction.jsx
+++ b/src/javascript/JContent/actions/compareHtmlAction/compareHtmlAction.jsx
@@ -7,12 +7,13 @@ import {isDefinitelyHidden} from '../utils/nodeVisibilityUtils';
 
 export const CompareHtmlActionComponent = ({path, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const language = useSelector(state => state.language);
-    const skip = isDefinitelyHidden(prefetchedNode, {showOnNodeTypes: ['jnt:page', 'jmix:mainResource']});
+    const showOnNodeTypes = ['jnt:page', 'jmix:mainResource'];
+    const skip = isDefinitelyHidden(prefetchedNode, {showOnNodeTypes});
     const res = useNodeChecks(
         {path, language},
         {
             skip,
-            showOnNodeTypes: ['jnt:page', 'jmix:mainResource'],
+            showOnNodeTypes,
             getAggregatedPublicationInfo: {subNodes: true}
         }
     );

--- a/src/javascript/JContent/actions/copyPaste/CopyCutActionComponent.jsx
+++ b/src/javascript/JContent/actions/copyPaste/CopyCutActionComponent.jsx
@@ -2,7 +2,7 @@ import {shallowEqual, useDispatch, useSelector} from 'react-redux';
 import {useApolloClient} from '@apollo/client';
 import {useNodeChecks} from '@jahia/data-helper';
 import copyPasteConstants from './copyPaste.constants';
-import {getName, hasMixin} from '~/JContent/JContent.utils';
+import {getName, hasMixin, JahiaAreasUtil} from '~/JContent/JContent.utils';
 import {setLocalStorage} from './localStorageHandler';
 import {copypaste} from './copyPaste.redux';
 import PropTypes from 'prop-types';
@@ -10,13 +10,14 @@ import React from 'react';
 import {ACTION_PERMISSIONS} from '../actions.constants';
 import {withNotifications} from '@jahia/react-material';
 import {useTranslation} from 'react-i18next';
-import {JahiaAreasUtil} from '../../JContent.utils';
 import {getClickedElementHook} from '~/JContent/EditFrame';
+import {isDefinitelyHidden} from '../utils/nodeVisibilityUtils';
 
 export const CopyCutActionComponent = withNotifications()(({
     path,
     paths,
     copyCutType,
+    node: prefetchedNode,
     render: Render,
     loading: Loading,
     notificationContext,
@@ -34,9 +35,19 @@ export const CopyCutActionComponent = withNotifications()(({
 
     const subPagesCondition = (others.hideIfHasNoSubPages) ? {getSubNodesCount: ['jnt:page', 'jmix:navMenuItem']} : {};
 
+    const pathHidden = !paths && path && (
+        JahiaAreasUtil.isJahiaArea(path) ||
+        others.hideForPaths?.some(p => new RegExp(p).test(path))
+    );
+    const skip = pathHidden || (!paths && isDefinitelyHidden(prefetchedNode, {
+        hideOnNodeTypes: others.hideOnNodeTypes,
+        hideMixins: ['jmix:markedForDeletionRoot']
+    }));
+
     const res = useNodeChecks(
         {path, paths, language, displayLanguage},
         {
+            skip,
             getPrimaryNodeType: true,
             getDisplayName: true,
             requiredPermission: type === copyPasteConstants.COPY ? ['jcr:read'] : ['jcr:removeNode'],
@@ -49,6 +60,10 @@ export const CopyCutActionComponent = withNotifications()(({
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     const isVisible = res.checksResult && !JahiaAreasUtil.isJahiaArea(path || paths) &&
@@ -83,6 +98,8 @@ CopyCutActionComponent.propTypes = {
     path: PropTypes.string,
 
     paths: PropTypes.arrayOf(PropTypes.string),
+
+    node: PropTypes.object,
 
     copyCutType: PropTypes.oneOf([copyPasteConstants.COPY, copyPasteConstants.COPY_PAGE, copyPasteConstants.CUT]),
 

--- a/src/javascript/JContent/actions/copyPaste/CopyMenuComponent.jsx
+++ b/src/javascript/JContent/actions/copyPaste/CopyMenuComponent.jsx
@@ -5,10 +5,18 @@ import PropTypes from 'prop-types';
 import {ACTION_PERMISSIONS} from '~/JContent/actions/actions.constants';
 import {hasMixin, JahiaAreasUtil} from '~/JContent/JContent.utils';
 import {useSelector} from 'react-redux';
+import {isDefinitelyHidden} from '~/JContent/actions/utils/nodeVisibilityUtils';
 
-export const CopyMenuComponent = ({path, paths, render: Render, loading: Loading, ...others}) => {
+export const CopyMenuComponent = ({path, paths, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const language = useSelector(state => state.language);
+
+    const skip = !paths && (
+        JahiaAreasUtil.isJahiaArea(path) ||
+        isDefinitelyHidden(prefetchedNode, {hideMixins: ['jmix:markedForDeletionRoot']})
+    );
+
     const res = useNodeChecks({path, paths, language}, {
+        skip,
         getPrimaryNodeType: true,
         getDisplayName: true,
         requiredPermission: ['jcr:read'],
@@ -23,6 +31,10 @@ export const CopyMenuComponent = ({path, paths, render: Render, loading: Loading
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return <Render {...others} isVisible={false}/>;
     }
 
     const isVisible = res.checksResult && !JahiaAreasUtil.isJahiaArea(path) &&
@@ -41,6 +53,7 @@ export const CopyMenuComponent = ({path, paths, render: Render, loading: Loading
 CopyMenuComponent.propTypes = {
     path: PropTypes.string,
     paths: PropTypes.arrayOf(PropTypes.string),
+    node: PropTypes.object,
     render: PropTypes.func.isRequired,
     loading: PropTypes.func
 };

--- a/src/javascript/JContent/actions/createFolderAction/createFolderAction.jsx
+++ b/src/javascript/JContent/actions/createFolderAction/createFolderAction.jsx
@@ -4,6 +4,7 @@ import {useNodeChecks} from '@jahia/data-helper';
 import {ComponentRendererContext} from '@jahia/ui-extender';
 import PropTypes from 'prop-types';
 import {ACTION_PERMISSIONS} from '../actions.constants';
+import {isDefinitelyHidden} from '../utils/nodeVisibilityUtils';
 
 const constraintsByType = {
     contentFolder: {
@@ -23,18 +24,25 @@ const nodeType = {
     folder: 'jnt:folder'
 };
 
-export const CreateFolderActionComponent = ({path, createFolderType, render: Render, loading: Loading, ...others}) => {
+export const CreateFolderActionComponent = ({path, node: prefetchedNode, createFolderType, render: Render, loading: Loading, ...others}) => {
     const componentRenderer = useContext(ComponentRendererContext);
+    const constraints = constraintsByType[createFolderType || 'contentFolder'];
+    const skip = isDefinitelyHidden(prefetchedNode, {showOnNodeTypes: constraints.showOnNodeTypes});
     const res = useNodeChecks(
         {path},
         {
-            ...constraintsByType[createFolderType || 'contentFolder'],
+            skip,
+            ...constraints,
             getLockInfo: true
         }
     );
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     const onExit = () => {
@@ -55,6 +63,7 @@ export const CreateFolderActionComponent = ({path, createFolderType, render: Ren
 
 CreateFolderActionComponent.propTypes = {
     path: PropTypes.string,
+    node: PropTypes.object,
     createFolderType: PropTypes.string.isRequired,
     render: PropTypes.func.isRequired,
     loading: PropTypes.func

--- a/src/javascript/JContent/actions/deleteActions/deleteAction.jsx
+++ b/src/javascript/JContent/actions/deleteActions/deleteAction.jsx
@@ -6,18 +6,29 @@ import React, {useContext} from 'react';
 import {PATH_CATEGORIES_ITSELF, PATH_CONTENTS_ITSELF, PATH_FILES_ITSELF} from '../actions.constants';
 import Delete from './Delete';
 import {ComponentRendererContext} from '@jahia/ui-extender';
+import {isDefinitelyHidden} from '../utils/nodeVisibilityUtils';
 
 function checkAction(node) {
     return node.operationsSupport.markForDeletion && !isMarkedForDeletion(node) && !node.lockOwner;
 }
 
-export const DeleteActionComponent = ({path, paths, buttonProps, onDeleted, render: Render, loading: Loading, ...others}) => {
+export const DeleteActionComponent = ({path, paths, buttonProps, onDeleted, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const componentRenderer = useContext(ComponentRendererContext);
     const language = useSelector(state => state.language);
+
+    const pathHidden = !paths && path && (
+        JahiaAreasUtil.isJahiaArea(path) ||
+        [PATH_FILES_ITSELF, PATH_CONTENTS_ITSELF, PATH_CATEGORIES_ITSELF].some(p => new RegExp(p).test(path))
+    );
+    const skip = pathHidden || (!paths && (
+        isDefinitelyHidden(prefetchedNode, {hideMixins: ['jmix:markedForDeletion']}) ||
+        prefetchedNode?.operationsSupport?.markForDeletion === false
+    ));
 
     const res = useNodeChecks(
         {path, paths, language},
         {
+            skip,
             getProperties: ['jcr:mixinTypes'],
             getDisplayName: true,
             getOperationSupport: true,
@@ -37,6 +48,10 @@ export const DeleteActionComponent = ({path, paths, buttonProps, onDeleted, rend
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     const isVisible = res.checksResult && !JahiaAreasUtil.isJahiaArea(path || paths) && (res.node ? checkAction(res.node) : res.nodes.reduce((acc, node) => acc && checkAction(node), true));
@@ -64,6 +79,8 @@ DeleteActionComponent.propTypes = {
     path: PropTypes.string,
 
     paths: PropTypes.arrayOf(PropTypes.string),
+
+    node: PropTypes.object,
 
     buttonProps: PropTypes.object,
 

--- a/src/javascript/JContent/actions/deleteActions/deletePermanentlyAction.jsx
+++ b/src/javascript/JContent/actions/deleteActions/deletePermanentlyAction.jsx
@@ -1,7 +1,8 @@
 import React, {useContext} from 'react';
 import {useNodeChecks} from '@jahia/data-helper';
 import PropTypes from 'prop-types';
-import {isMarkedForDeletion} from '../../JContent.utils';
+import {hasMixin, isMarkedForDeletion} from '../../JContent.utils';
+import {isDefinitelyHidden} from '../utils/nodeVisibilityUtils';
 import {useSelector} from 'react-redux';
 import {PATH_CATEGORIES_ITSELF, PATH_CONTENTS_ITSELF, PATH_FILES_ITSELF} from './../actions.constants';
 import Delete from './Delete';
@@ -21,13 +22,20 @@ const checkAction = node => {
     return Boolean(isCategory || isMarkForDeletionAllowed || isAutoPublish);
 };
 
-export const DeletePermanentlyActionComponent = ({path, paths, buttonProps, onDeleted, render: Render, loading: Loading, ...others}) => {
+export const DeletePermanentlyActionComponent = ({path, paths, node: prefetchedNode, buttonProps, onDeleted, render: Render, loading: Loading, ...others}) => {
     const componentRenderer = useContext(ComponentRendererContext);
     const language = useSelector(state => state.language);
+
+    const isCategory = prefetchedNode?.primaryNodeType?.name === 'jnt:category';
+    const skip = !paths && Boolean(prefetchedNode) && (
+        isDefinitelyHidden(prefetchedNode, {hideOnNodeTypes: ['jnt:virtualsite']}) ||
+        (!isCategory && !isMarkedForDeletion(prefetchedNode) && !hasMixin(prefetchedNode, 'jmix:autoPublish'))
+    );
 
     const res = useNodeChecks(
         {path, paths, language},
         {
+            skip,
             getDisplayName: true,
             getPrimaryNodeType: true,
             getIsNodeTypes: ['jmix:autoPublish'],
@@ -49,6 +57,10 @@ export const DeletePermanentlyActionComponent = ({path, paths, buttonProps, onDe
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     let isVisible = res.checksResult && (res.node ? checkAction(res.node) : checkActionOnNodes(res));
@@ -77,6 +89,8 @@ DeletePermanentlyActionComponent.propTypes = {
     paths: PropTypes.arrayOf(PropTypes.string),
 
     buttonProps: PropTypes.object,
+
+    node: PropTypes.object,
 
     onDeleted: PropTypes.func,
 

--- a/src/javascript/JContent/actions/deleteActions/deletePermanentlyAction.jsx
+++ b/src/javascript/JContent/actions/deleteActions/deletePermanentlyAction.jsx
@@ -25,10 +25,11 @@ const checkAction = node => {
 export const DeletePermanentlyActionComponent = ({path, paths, node: prefetchedNode, buttonProps, onDeleted, render: Render, loading: Loading, ...others}) => {
     const componentRenderer = useContext(ComponentRendererContext);
     const language = useSelector(state => state.language);
+    const hideOnNodeTypes = ['jnt:virtualsite'];
 
     const isCategory = prefetchedNode?.primaryNodeType?.name === 'jnt:category';
     const skip = !paths && Boolean(prefetchedNode) && (
-        isDefinitelyHidden(prefetchedNode, {hideOnNodeTypes: ['jnt:virtualsite']}) ||
+        isDefinitelyHidden(prefetchedNode, {hideOnNodeTypes}) ||
         (!isCategory && !isMarkedForDeletion(prefetchedNode) && !hasMixin(prefetchedNode, 'jmix:autoPublish'))
     );
 
@@ -43,7 +44,7 @@ export const DeletePermanentlyActionComponent = ({path, paths, node: prefetchedN
             getAggregatedPublicationInfo: true,
             getOperationSupport: true,
             requiredPermission: ['jcr:removeNode'],
-            hideOnNodeTypes: ['jnt:virtualsite'],
+            hideOnNodeTypes,
             hideForPaths: [PATH_FILES_ITSELF, PATH_CONTENTS_ITSELF, PATH_CATEGORIES_ITSELF]
         },
         {

--- a/src/javascript/JContent/actions/deleteActions/undeleteAction.jsx
+++ b/src/javascript/JContent/actions/deleteActions/undeleteAction.jsx
@@ -11,13 +11,16 @@ function checkAction(node) {
     return node.operationsSupport.markForDeletion && isMarkedForDeletion(node);
 }
 
-export const UndeleteActionComponent = ({path, paths, buttonProps, onDeleted, render: Render, loading: Loading, ...others}) => {
+export const UndeleteActionComponent = ({path, paths, node: prefetchedNode, buttonProps, onDeleted, render: Render, loading: Loading, ...others}) => {
     const componentRenderer = useContext(ComponentRendererContext);
     const language = useSelector(state => state.language);
+
+    const skip = !paths && Boolean(prefetchedNode) && !isMarkedForDeletion(prefetchedNode);
 
     const res = useNodeChecks(
         {path, paths, language},
         {
+            skip,
             getProperties: ['jcr:mixinTypes'],
             getDisplayName: true,
             getOperationSupport: true,
@@ -36,6 +39,10 @@ export const UndeleteActionComponent = ({path, paths, buttonProps, onDeleted, re
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     const isVisible = res.checksResult && (res.node ? checkAction(res.node) : res.nodes?.reduce((acc, node) => acc && checkAction(node), true));
@@ -65,6 +72,8 @@ UndeleteActionComponent.propTypes = {
     paths: PropTypes.arrayOf(PropTypes.string),
 
     buttonProps: PropTypes.object,
+
+    node: PropTypes.object,
 
     onDeleted: PropTypes.func,
 

--- a/src/javascript/JContent/actions/downloadAsZip/DownloadAsZipActionComponent.jsx
+++ b/src/javascript/JContent/actions/downloadAsZip/DownloadAsZipActionComponent.jsx
@@ -12,9 +12,10 @@ export const DownloadAsZipActionComponent = ({path, paths, node: prefetchedNode,
         displayLanguage: state.uilang
     }), shallowEqual);
 
+    const showOnNodeTypes = ['jnt:file', 'jnt:folder'];
     const skip = compareVersions(window.contextJsParameters.dxVersion, '8.1.3.0') < 0 ||
         (!paths && isDefinitelyHidden(prefetchedNode, {
-            showOnNodeTypes: ['jnt:file', 'jnt:folder'],
+            showOnNodeTypes,
             hideMixins: ['jmix:markedForDeletionRoot']
         }));
 
@@ -26,7 +27,7 @@ export const DownloadAsZipActionComponent = ({path, paths, node: prefetchedNode,
             getDisplayName: true,
             getParent: true,
             getProperties: ['jcr:mixinTypes'],
-            showOnNodeTypes: ['jnt:file', 'jnt:folder']
+            showOnNodeTypes
         }
     );
 

--- a/src/javascript/JContent/actions/downloadAsZip/DownloadAsZipActionComponent.jsx
+++ b/src/javascript/JContent/actions/downloadAsZip/DownloadAsZipActionComponent.jsx
@@ -4,15 +4,24 @@ import {hasMixin} from '~/JContent/JContent.utils';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {compareVersions} from 'compare-versions';
+import {isDefinitelyHidden} from '../utils/nodeVisibilityUtils';
 
-export const DownloadAsZipActionComponent = ({path, paths, render: Render, loading: Loading, ...others}) => {
+export const DownloadAsZipActionComponent = ({path, paths, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const {language, displayLanguage} = useSelector(state => ({
         language: state.language,
         displayLanguage: state.uilang
     }), shallowEqual);
+
+    const skip = compareVersions(window.contextJsParameters.dxVersion, '8.1.3.0') < 0 ||
+        (!paths && isDefinitelyHidden(prefetchedNode, {
+            showOnNodeTypes: ['jnt:file', 'jnt:folder'],
+            hideMixins: ['jmix:markedForDeletionRoot']
+        }));
+
     const res = useNodeChecks(
         {path, paths, language, displayLanguage},
         {
+            skip,
             getPrimaryNodeType: true,
             getDisplayName: true,
             getParent: true,
@@ -23,6 +32,10 @@ export const DownloadAsZipActionComponent = ({path, paths, render: Render, loadi
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     // This action is only available for Jahia 8.1.3.0 or higher.
@@ -50,6 +63,8 @@ DownloadAsZipActionComponent.propTypes = {
     path: PropTypes.string,
 
     paths: PropTypes.arrayOf(PropTypes.string),
+
+    node: PropTypes.object,
 
     render: PropTypes.func.isRequired,
 

--- a/src/javascript/JContent/actions/downloadFileAction/downloadFileAction.jsx
+++ b/src/javascript/JContent/actions/downloadFileAction/downloadFileAction.jsx
@@ -3,12 +3,15 @@ import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 import {ComponentRendererContext} from '@jahia/ui-extender';
 import {DownloadFileDialog} from '~/JContent/actions/downloadFileAction/DownloadFileDialog';
+import {isDefinitelyHidden} from '../utils/nodeVisibilityUtils';
 
-export const DownloadFileActionComponent = ({path, render: Render, loading: Loading, ...others}) => {
+export const DownloadFileActionComponent = ({path, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const componentRenderer = useContext(ComponentRendererContext);
+    const skip = isDefinitelyHidden(prefetchedNode, {showOnNodeTypes: ['jnt:file']});
     const res = useNodeChecks(
         {path},
         {
+            skip,
             showOnNodeTypes: ['jnt:file'],
             requiredSitePermission: ['downloadAction']
         }
@@ -16,6 +19,10 @@ export const DownloadFileActionComponent = ({path, render: Render, loading: Load
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     const isVisible = res.checksResult;
@@ -38,6 +45,8 @@ export const DownloadFileActionComponent = ({path, render: Render, loading: Load
 
 DownloadFileActionComponent.propTypes = {
     path: PropTypes.string,
+
+    node: PropTypes.object,
 
     render: PropTypes.func.isRequired,
 

--- a/src/javascript/JContent/actions/downloadFileAction/downloadFileAction.jsx
+++ b/src/javascript/JContent/actions/downloadFileAction/downloadFileAction.jsx
@@ -7,12 +7,13 @@ import {isDefinitelyHidden} from '../utils/nodeVisibilityUtils';
 
 export const DownloadFileActionComponent = ({path, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const componentRenderer = useContext(ComponentRendererContext);
-    const skip = isDefinitelyHidden(prefetchedNode, {showOnNodeTypes: ['jnt:file']});
+    const showOnNodeTypes = ['jnt:file'];
+    const skip = isDefinitelyHidden(prefetchedNode, {showOnNodeTypes});
     const res = useNodeChecks(
         {path},
         {
             skip,
-            showOnNodeTypes: ['jnt:file'],
+            showOnNodeTypes,
             requiredSitePermission: ['downloadAction']
         }
     );

--- a/src/javascript/JContent/actions/editImage/editImageAction.jsx
+++ b/src/javascript/JContent/actions/editImage/editImageAction.jsx
@@ -3,13 +3,16 @@ import {useNodeChecks} from '@jahia/data-helper';
 import {ComponentRendererContext} from '@jahia/ui-extender';
 import PropTypes from 'prop-types';
 import {ACTION_PERMISSIONS} from '../actions.constants';
+import {isDefinitelyHidden} from '../utils/nodeVisibilityUtils';
 import ImageEditorDialog from '~/JContent/actions/editImage/ImageEditorDialog';
 
-export const EditImageActionComponent = ({path, render: Render, loading: Loading, ...others}) => {
+export const EditImageActionComponent = ({path, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const componentRenderer = useContext(ComponentRendererContext);
+    const skip = isDefinitelyHidden(prefetchedNode, {showOnNodeTypes: ['jmix:image']});
     const res = useNodeChecks(
         {path},
         {
+            skip,
             showOnNodeTypes: ['jmix:image'],
             requiredPermission: ['jcr:write'],
             requiredSitePermission: [ACTION_PERMISSIONS.openImageEditorAction]
@@ -18,6 +21,10 @@ export const EditImageActionComponent = ({path, render: Render, loading: Loading
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     const onExit = () => {
@@ -37,6 +44,7 @@ export const EditImageActionComponent = ({path, render: Render, loading: Loading
 
 EditImageActionComponent.propTypes = {
     path: PropTypes.string,
+    node: PropTypes.object,
     render: PropTypes.func.isRequired,
     loading: PropTypes.func
 };

--- a/src/javascript/JContent/actions/editImage/editImageAction.jsx
+++ b/src/javascript/JContent/actions/editImage/editImageAction.jsx
@@ -8,12 +8,13 @@ import ImageEditorDialog from '~/JContent/actions/editImage/ImageEditorDialog';
 
 export const EditImageActionComponent = ({path, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const componentRenderer = useContext(ComponentRendererContext);
-    const skip = isDefinitelyHidden(prefetchedNode, {showOnNodeTypes: ['jmix:image']});
+    const showOnNodeTypes = ['jmix:image'];
+    const skip = isDefinitelyHidden(prefetchedNode, {showOnNodeTypes});
     const res = useNodeChecks(
         {path},
         {
             skip,
-            showOnNodeTypes: ['jmix:image'],
+            showOnNodeTypes,
             requiredPermission: ['jcr:write'],
             requiredSitePermission: [ACTION_PERMISSIONS.openImageEditorAction]
         }

--- a/src/javascript/JContent/actions/fileUploadAction.jsx
+++ b/src/javascript/JContent/actions/fileUploadAction.jsx
@@ -6,6 +6,7 @@ import {batchActions} from 'redux-batched-actions';
 import {onFilesSelected} from '../ContentRoute/ContentLayout/Upload/Upload.utils';
 import {ComponentRendererContext} from '@jahia/ui-extender';
 import {ACTION_PERMISSIONS} from './actions.constants';
+import {isDefinitelyHidden} from './utils/nodeVisibilityUtils';
 
 const Upload = React.memo(() => (
     <input id="file-upload-input"
@@ -41,15 +42,24 @@ const constraintsByType = {
 };
 
 export const FileUploadActionComponent = props => {
-    const {path, uploadType, render: Render, loading: Loading} = props;
+    const {path, uploadType, node: prefetchedNode, render: Render, loading: Loading} = props;
     const componentRenderer = useContext(ComponentRendererContext);
     const dispatch = useDispatch();
     const dispatchBatch = actions => dispatch(batchActions(actions));
 
+    const constraints = constraintsByType[uploadType || 'upload'];
+    // Skip for upload/fileUpload/replaceWith (jnt:folder, jnt:file are leaf types — safe for exact match)
+    // Do not skip for 'import' (showOnNodeTypes includes jnt:page, jnt:contentFolder which have subtypes)
+    const skip = uploadType !== 'import' && isDefinitelyHidden(prefetchedNode, {
+        showOnNodeTypes: constraints.showOnNodeTypes,
+        hideOnNodeTypes: constraints.hideOnNodeTypes
+    });
+
     const res = useNodeChecks(
         {path},
         {
-            ...constraintsByType[uploadType || 'upload'],
+            skip,
+            ...constraints,
             getLockInfo: true
         }
     );
@@ -62,6 +72,10 @@ export const FileUploadActionComponent = props => {
 
     if (res.loading) {
         return (Loading && <Loading {...props}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     const handleClick = () => {
@@ -105,6 +119,8 @@ FileUploadActionComponent.propTypes = {
     path: PropTypes.string,
 
     uploadType: PropTypes.string,
+
+    node: PropTypes.object,
 
     render: PropTypes.func.isRequired,
 

--- a/src/javascript/JContent/actions/lockAction.jsx
+++ b/src/javascript/JContent/actions/lockAction.jsx
@@ -3,12 +3,15 @@ import gql from 'graphql-tag';
 import {useNodeChecks} from '@jahia/data-helper';
 import PropTypes from 'prop-types';
 import {useApolloClient} from '@apollo/client';
-
-export const LockActionComponent = ({path, render: Render, loading: Loading, ...others}) => {
+import {isDefinitelyHidden} from './utils/nodeVisibilityUtils';
+export const LockActionComponent = ({path, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const client = useApolloClient();
+    const skip = isDefinitelyHidden(prefetchedNode, {hideOnNodeTypes: ['jnt:navMenuText', 'jnt:category']}) ||
+        prefetchedNode?.operationsSupport?.lock === false;
     const res = useNodeChecks(
         {path},
         {
+            skip,
             getLockInfo: true,
             getCanLockUnlock: true,
             getOperationSupport: true,
@@ -20,6 +23,10 @@ export const LockActionComponent = ({path, render: Render, loading: Loading, ...
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     const isVisible = res.checksResult && res.node &&
@@ -57,6 +64,8 @@ export const LockActionComponent = ({path, render: Render, loading: Loading, ...
 
 LockActionComponent.propTypes = {
     path: PropTypes.string,
+
+    node: PropTypes.object,
 
     render: PropTypes.func.isRequired,
 

--- a/src/javascript/JContent/actions/lockAction.jsx
+++ b/src/javascript/JContent/actions/lockAction.jsx
@@ -6,7 +6,8 @@ import {useApolloClient} from '@apollo/client';
 import {isDefinitelyHidden} from './utils/nodeVisibilityUtils';
 export const LockActionComponent = ({path, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const client = useApolloClient();
-    const skip = isDefinitelyHidden(prefetchedNode, {hideOnNodeTypes: ['jnt:navMenuText', 'jnt:category']}) ||
+    const hideOnNodeTypes = ['jnt:navMenuText', 'jnt:category'];
+    const skip = isDefinitelyHidden(prefetchedNode, {hideOnNodeTypes}) ||
         prefetchedNode?.operationsSupport?.lock === false;
     const res = useNodeChecks(
         {path},
@@ -16,7 +17,7 @@ export const LockActionComponent = ({path, node: prefetchedNode, render: Render,
             getCanLockUnlock: true,
             getOperationSupport: true,
             requiredPermission: 'jcr:lockManagement',
-            hideOnNodeTypes: ['jnt:navMenuText', 'jnt:category'],
+            hideOnNodeTypes,
             getPermissions: ['lockPageAction']
         }
     );

--- a/src/javascript/JContent/actions/openInPageBuilderAction.jsx
+++ b/src/javascript/JContent/actions/openInPageBuilderAction.jsx
@@ -7,22 +7,25 @@ import JContentConstants from '~/JContent/JContent.constants';
 import {batchActions} from 'redux-batched-actions';
 import {expandTree} from '~/JContent/JContent.utils';
 import {useApolloClient} from '@apollo/client';
-
-export const OpenInPageBuilderActionComponent = ({path, render: Render, loading: Loading, ...others}) => {
+import {isDefinitelyHidden} from './utils/nodeVisibilityUtils';
+export const OpenInPageBuilderActionComponent = ({path, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const client = useApolloClient();
     const dispatch = useDispatch();
     const {mode, viewMode} = useSelector(state => ({mode: state.jcontent.mode, viewMode: state.jcontent.tableView.viewMode}), shallowEqual);
     const isSearch = (mode === JContentConstants.mode.SEARCH || mode === JContentConstants.mode.SQL2SEARCH);
     const isPageBuilderMode = (viewMode === JContentConstants.tableView.viewMode.PAGE_BUILDER);
 
+    const skip = !isPageBuilderMode && isDefinitelyHidden(prefetchedNode, {showOnNodeTypes: ['jmix:mainResource']});
+
     const res = useNodeChecks(isPageBuilderMode ? {} : {path}, {
+        skip,
         showOnNodeTypes: ['jmix:mainResource']
     });
     if (res.loading && Loading) {
         return <Loading {...others}/>;
     }
 
-    if (!res.node) {
+    if (skip || !res.node) {
         return (<Render {...others} isVisible={false}/>);
     }
 
@@ -52,6 +55,7 @@ export const OpenInPageBuilderActionComponent = ({path, render: Render, loading:
 
 OpenInPageBuilderActionComponent.propTypes = {
     path: PropTypes.string.isRequired,
+    node: PropTypes.object,
     render: PropTypes.func.isRequired,
     loading: PropTypes.func
 };

--- a/src/javascript/JContent/actions/openInPageBuilderAction.jsx
+++ b/src/javascript/JContent/actions/openInPageBuilderAction.jsx
@@ -15,11 +15,12 @@ export const OpenInPageBuilderActionComponent = ({path, node: prefetchedNode, re
     const isSearch = (mode === JContentConstants.mode.SEARCH || mode === JContentConstants.mode.SQL2SEARCH);
     const isPageBuilderMode = (viewMode === JContentConstants.tableView.viewMode.PAGE_BUILDER);
 
-    const skip = !isPageBuilderMode && isDefinitelyHidden(prefetchedNode, {showOnNodeTypes: ['jmix:mainResource']});
+    const showOnNodeTypes = ['jmix:mainResource'];
+    const skip = !isPageBuilderMode && isDefinitelyHidden(prefetchedNode, {showOnNodeTypes});
 
     const res = useNodeChecks(isPageBuilderMode ? {} : {path}, {
         skip,
-        showOnNodeTypes: ['jmix:mainResource']
+        showOnNodeTypes
     });
     if (res.loading && Loading) {
         return <Loading {...others}/>;

--- a/src/javascript/JContent/actions/previewAction.jsx
+++ b/src/javascript/JContent/actions/previewAction.jsx
@@ -5,20 +5,30 @@ import {useDispatch, useSelector} from 'react-redux';
 import {useNodeChecks} from '@jahia/data-helper';
 import PropTypes from 'prop-types';
 import JContentConstants from '~/JContent/JContent.constants';
+import {isDefinitelyHidden} from './utils/nodeVisibilityUtils';
 
-export const PreviewActionComponent = ({path, render: Render, loading: Loading, ...others}) => {
+export const PreviewActionComponent = ({path, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const dispatch = useDispatch();
     const viewMode = useSelector(state => state.jcontent.tableView?.viewMode);
+    const hideOnNodeTypes = ['jnt:page', 'jnt:folder', 'jnt:contentFolder', 'jnt:virtualsite', 'jnt:navMenuText', 'jnt:category'];
+
+    const isPageBuilderMode = viewMode === JContentConstants.tableView.viewMode.PAGE_BUILDER;
+    const skip = isPageBuilderMode || isDefinitelyHidden(prefetchedNode, {hideOnNodeTypes});
 
     const res = useNodeChecks(
         {path},
         {
-            hideOnNodeTypes: ['jnt:page', 'jnt:folder', 'jnt:contentFolder', 'jnt:virtualsite', 'jnt:navMenuText', 'jnt:category']
+            skip,
+            hideOnNodeTypes
         }
     );
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     return (
@@ -36,6 +46,8 @@ export const PreviewActionComponent = ({path, render: Render, loading: Loading, 
 
 PreviewActionComponent.propTypes = {
     path: PropTypes.string,
+
+    node: PropTypes.object,
 
     render: PropTypes.func.isRequired,
 

--- a/src/javascript/JContent/actions/publishAction.jsx
+++ b/src/javascript/JContent/actions/publishAction.jsx
@@ -7,6 +7,7 @@ import {useSelector} from 'react-redux';
 import {useTranslation} from 'react-i18next';
 import {setRefetcher, unsetRefetcher} from '../JContent.refetches';
 import {CloudCheck} from '@jahia/moonstone';
+import {isDefinitelyHidden} from './utils/nodeVisibilityUtils';
 
 function checkAction(res, node, publishType, isPublishingAllLanguages) {
     let enabled = true;
@@ -116,13 +117,19 @@ function getLabels({res, languageToUse, paths, t, props, publishType, isPublishi
 }
 
 export const PublishActionComponent = props => {
-    const {id, path, paths, language, publishType, isPublishingAllLanguages, enabled, isVisible, render: Render, loading: Loading} = props;
+    const {id, path, paths, node: prefetchedNode, language, publishType, isPublishingAllLanguages, enabled, isVisible, render: Render, loading: Loading} = props;
     const languageToUse = useSelector(state => language ? language : state.language);
     const {t} = useTranslation('jcontent');
+
+    const skip = !paths && (
+        isDefinitelyHidden(prefetchedNode, constraintsByType[publishType]) ||
+        prefetchedNode?.operationsSupport?.publication === false
+    );
 
     // Publication info needs to be refreshed in case subNodes have changed
     const queryOptions = {fetchPolicy: 'no-cache'};
     const res = useNodeChecks({path, paths, language: languageToUse}, {
+        skip,
         getDisplayName: true,
         getProperties: ['jcr:mixinTypes'],
         getSiteLanguages: true,
@@ -142,6 +149,10 @@ export const PublishActionComponent = props => {
 
     if (res.loading) {
         return (Loading && <Loading {...props}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     let actionChecks = res.node ? checkAction(res, res.node, publishType, isPublishingAllLanguages) : checkActionOnNodes(res, publishType, isPublishingAllLanguages);
@@ -180,6 +191,7 @@ PublishActionComponent.propTypes = {
     path: PropTypes.string,
     paths: PropTypes.arrayOf(PropTypes.string),
     language: PropTypes.string,
+    node: PropTypes.object,
     // eslint-disable-next-line react/boolean-prop-naming
     enabled: PropTypes.bool,
     isVisible: PropTypes.bool,

--- a/src/javascript/JContent/actions/publishDeletionAction.jsx
+++ b/src/javascript/JContent/actions/publishDeletionAction.jsx
@@ -14,10 +14,13 @@ const checkAction = node => node.operationsSupport.publication &&
         (node.aggregatedPublicationInfo.publicationStatus === 'NOT_PUBLISHED' &&
             (node.aggregatedPublicationInfo.existsInLive === undefined ? false : node.aggregatedPublicationInfo.existsInLive)));
 
-export const PublishDeletionActionComponent = ({path, paths, isAllSubTree, isPublishingAllLanguages, buttonProps, render: Render, loading: Loading, ...others}) => {
+export const PublishDeletionActionComponent = ({path, paths, node: prefetchedNode, isAllSubTree, isPublishingAllLanguages, buttonProps, render: Render, loading: Loading, ...others}) => {
     const language = useSelector(state => state.language);
 
+    const skip = !paths && Boolean(prefetchedNode) && !isMarkedForDeletion(prefetchedNode);
+
     const res = useNodeChecks({path, paths, language}, {
+        skip,
         getProperties: ['jcr:mixinTypes'],
         getAggregatedPublicationInfo: true,
         getOperationSupport: true,
@@ -29,6 +32,10 @@ export const PublishDeletionActionComponent = ({path, paths, isAllSubTree, isPub
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     let isVisible = res.node ? checkAction(res.node) : checkActionOnNodes(res);
@@ -53,6 +60,8 @@ PublishDeletionActionComponent.propTypes = {
     path: PropTypes.string,
 
     paths: PropTypes.arrayOf(PropTypes.string),
+
+    node: PropTypes.object,
 
     buttonProps: PropTypes.object,
 

--- a/src/javascript/JContent/actions/renameAction/renameAction.jsx
+++ b/src/javascript/JContent/actions/renameAction/renameAction.jsx
@@ -4,12 +4,15 @@ import {useNodeChecks} from '@jahia/data-helper';
 import {ComponentRendererContext} from '@jahia/ui-extender';
 import PropTypes from 'prop-types';
 import {PATH_FILES_ITSELF} from '../actions.constants';
+import {isDefinitelyHidden} from '../utils/nodeVisibilityUtils';
 
-export const RenameActionComponent = ({path, render: Render, loading: Loading, ...others}) => {
+export const RenameActionComponent = ({path, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const componentRenderer = useContext(ComponentRendererContext);
+    const skip = isDefinitelyHidden(prefetchedNode, {showOnNodeTypes: ['jnt:folder', 'jnt:file']});
     const res = useNodeChecks(
         {path},
         {
+            skip,
             requiredPermission: ['jcr:write'],
             showOnNodeTypes: ['jnt:folder', 'jnt:file'],
             hideForPaths: [PATH_FILES_ITSELF]
@@ -18,6 +21,10 @@ export const RenameActionComponent = ({path, render: Render, loading: Loading, .
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     const onExit = () => {
@@ -37,6 +44,7 @@ export const RenameActionComponent = ({path, render: Render, loading: Loading, .
 
 RenameActionComponent.propTypes = {
     path: PropTypes.string,
+    node: PropTypes.object,
     render: PropTypes.func.isRequired,
     loading: PropTypes.func
 };

--- a/src/javascript/JContent/actions/showPublicationManagerAction.jsx
+++ b/src/javascript/JContent/actions/showPublicationManagerAction.jsx
@@ -3,9 +3,10 @@ import {useNodeChecks} from '@jahia/data-helper';
 import PropTypes from 'prop-types';
 import {useSelector} from 'react-redux';
 import {useTranslation} from 'react-i18next';
+import {isDefinitelyHidden} from './utils/nodeVisibilityUtils';
 
 export const PublishManagerActionComponent = props => {
-    const {id, path, paths, publicationNodeTypes, buttonIcon, buttonLabel, render: Render, loading: Loading} = props;
+    const {id, path, paths, node: prefetchedNode, publicationNodeTypes, buttonIcon, buttonLabel, render: Render, loading: Loading} = props;
     const {language, siteKey} = useSelector(state => ({
         language: state.language,
         siteKey: state.site
@@ -13,7 +14,12 @@ export const PublishManagerActionComponent = props => {
 
     const {t} = useTranslation('jcontent');
 
+    const skip = !!paths ||
+        typeof window?.authoringApi?.showPublicationManager !== 'function' ||
+        isDefinitelyHidden(prefetchedNode, {hideOnNodeTypes: ['jnt:category', 'jmix:markedForDeletion']});
+
     const res = useNodeChecks({path, language}, {
+        skip,
         getDisplayName: true,
         getProperties: ['jcr:mixinTypes'],
         getSiteLanguages: true,
@@ -23,6 +29,10 @@ export const PublishManagerActionComponent = props => {
 
     if (res.loading) {
         return (Loading && <Loading {...props}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     const isVisible = !paths && res.checksResult && typeof window?.authoringApi?.showPublicationManager === 'function';
@@ -61,5 +71,6 @@ PublishManagerActionComponent.propTypes = {
     buttonLabel: PropTypes.string.isRequired,
     buttonIcon: PropTypes.node,
     isMediumLabel: PropTypes.bool,
+    node: PropTypes.object,
     publicationNodeTypes: PropTypes.arrayOf(PropTypes.string)
 };

--- a/src/javascript/JContent/actions/showPublicationManagerAction.jsx
+++ b/src/javascript/JContent/actions/showPublicationManagerAction.jsx
@@ -14,7 +14,7 @@ export const PublishManagerActionComponent = props => {
 
     const {t} = useTranslation('jcontent');
 
-    const skip = !!paths ||
+    const skip = Boolean(paths) ||
         typeof window?.authoringApi?.showPublicationManager !== 'function' ||
         isDefinitelyHidden(prefetchedNode, {hideOnNodeTypes: ['jnt:category', 'jmix:markedForDeletion']});
 

--- a/src/javascript/JContent/actions/subContentsAction.jsx
+++ b/src/javascript/JContent/actions/subContentsAction.jsx
@@ -8,15 +8,20 @@ import {useApolloClient} from '@apollo/client';
 import {useDispatch, useSelector} from 'react-redux';
 import {expandTree} from '~/JContent/JContent.utils';
 import {isInSearchMode} from '~/JContent/ContentRoute/ContentLayout/ContentLayout.utils';
+import {isDefinitelyHidden} from '~/JContent/actions/utils/nodeVisibilityUtils';
 
-export const SubContentsActionComponent = ({path, render: Render, loading: Loading, ...others}) => {
+export const SubContentsActionComponent = ({path, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const client = useApolloClient();
     const dispatch = useDispatch();
     const mode = useSelector(state => state.jcontent.mode);
     const viewMode = useSelector(state => state.jcontent.tableView.viewMode);
 
     const subNodesType = ['jnt:file', 'jnt:folder', 'jnt:content', 'jnt:contentFolder'];
+
+    const skip = isInSearchMode(mode) || isDefinitelyHidden(prefetchedNode, {hideOnNodeTypes: ['jnt:virtualsite', 'jnt:category']});
+
     const res = useNodeChecks({path}, {
+        skip,
         getSubNodesCount: subNodesType,
         getPrimaryNodeType: true,
         hideOnNodeTypes: ['jnt:virtualsite', 'jnt:category']
@@ -24,6 +29,10 @@ export const SubContentsActionComponent = ({path, render: Render, loading: Loadi
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     const isContainerType = ['jnt:page', 'jnt:folder', 'jnt:contentFolder'].includes(res?.node?.primaryNodeType?.name);
@@ -49,6 +58,8 @@ export const SubContentsActionComponent = ({path, render: Render, loading: Loadi
 
 SubContentsActionComponent.propTypes = {
     path: PropTypes.string,
+
+    node: PropTypes.object,
 
     render: PropTypes.func.isRequired,
 

--- a/src/javascript/JContent/actions/unlockAction.jsx
+++ b/src/javascript/JContent/actions/unlockAction.jsx
@@ -4,11 +4,13 @@ import {useNodeChecks} from '@jahia/data-helper';
 import PropTypes from 'prop-types';
 import {useApolloClient} from '@apollo/client';
 
-export const UnlockActionComponent = ({path, render: Render, loading: Loading, ...others}) => {
+export const UnlockActionComponent = ({path, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const client = useApolloClient();
+    const skip = prefetchedNode?.operationsSupport?.lock === false;
     const res = useNodeChecks(
         {path},
         {
+            skip,
             getLockInfo: true,
             getCanLockUnlock: true,
             getOperationSupport: true,
@@ -18,6 +20,10 @@ export const UnlockActionComponent = ({path, render: Render, loading: Loading, .
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     const isVisible = res.checksResult && res.node &&
@@ -55,6 +61,8 @@ export const UnlockActionComponent = ({path, render: Render, loading: Loading, .
 
 UnlockActionComponent.propTypes = {
     path: PropTypes.string,
+
+    node: PropTypes.object,
 
     render: PropTypes.func.isRequired,
 

--- a/src/javascript/JContent/actions/utils/nodeVisibilityUtils.js
+++ b/src/javascript/JContent/actions/utils/nodeVisibilityUtils.js
@@ -13,7 +13,9 @@ import {hasMixin} from '~/JContent/JContent.utils';
  * @param {string[]} [options.showOnNodeTypes] - Action is only shown for these node types/mixins
  * @param {string[]} [options.hideOnNodeTypes] - Action is hidden for these node types/mixins
  * @param {string[]} [options.hideMixins] - Action is hidden when node has any of these mixins
- * @param {string[]} [options.showMixins] - Action is only shown when node has at least one of these mixins
+ * @param {string[]} [options.showMixins] - Action is only shown when node has at least one of these mixins.
+ *   WARNING: Only safe when the mixin is always dynamically applied (addMixin) and never declared as a
+ *   supertype in a node type definition — otherwise inherited mixins won't appear in mixinTypes.
  * @returns {boolean}
  */
 export function isDefinitelyHidden(prefetchedNode, {

--- a/src/javascript/JContent/actions/utils/nodeVisibilityUtils.js
+++ b/src/javascript/JContent/actions/utils/nodeVisibilityUtils.js
@@ -1,0 +1,55 @@
+import {hasMixin} from '~/JContent/JContent.utils';
+
+/**
+ * Returns true if prefetched row data is sufficient to determine the action
+ * is definitely NOT visible — allowing the action to return null immediately
+ * without mounting a loading placeholder.
+ *
+ * Returns false when prefetched data is absent, incomplete, or all checks pass —
+ * in that case the action should proceed to call useNodeChecks normally.
+ *
+ * @param {object|null|undefined} prefetchedNode - The node object from ContextualMenu props (row data)
+ * @param {object} options
+ * @param {string[]} [options.showOnNodeTypes] - Action is only shown for these node types/mixins
+ * @param {string[]} [options.hideOnNodeTypes] - Action is hidden for these node types/mixins
+ * @param {string[]} [options.hideMixins] - Action is hidden when node has any of these mixins
+ * @param {string[]} [options.showMixins] - Action is only shown when node has at least one of these mixins
+ * @returns {boolean}
+ */
+export function isDefinitelyHidden(prefetchedNode, {
+    showOnNodeTypes,
+    hideOnNodeTypes,
+    hideMixins,
+    showMixins
+} = {}) {
+    if (!prefetchedNode) {
+        return false;
+    }
+
+    const typeName = prefetchedNode.primaryNodeType?.name;
+    const mixins = prefetchedNode.mixinTypes?.map(m => m.name) ?? [];
+
+    if (showOnNodeTypes && typeName) {
+        const matches = showOnNodeTypes.some(t => typeName === t || mixins.includes(t));
+        if (!matches) {
+            return true;
+        }
+    }
+
+    if (hideOnNodeTypes && (typeName || mixins.length > 0)) {
+        const matches = hideOnNodeTypes.some(t => typeName === t || mixins.includes(t));
+        if (matches) {
+            return true;
+        }
+    }
+
+    if (hideMixins?.some(m => hasMixin(prefetchedNode, m))) {
+        return true;
+    }
+
+    if (showMixins && !showMixins.some(m => hasMixin(prefetchedNode, m))) {
+        return true;
+    }
+
+    return false;
+}

--- a/src/javascript/JContent/actions/zipUnzip/unzipAction.jsx
+++ b/src/javascript/JContent/actions/zipUnzip/unzipAction.jsx
@@ -10,15 +10,29 @@ import {isMarkedForDeletion} from '~/JContent/JContent.utils';
 import zipUnzipMutations from './zipUnzip.gql-mutations';
 import {ACTION_PERMISSIONS, PATH_FILES_ITSELF} from '../actions.constants';
 import {TransparentLoaderOverlay} from '~/JContent/TransparentLoaderOverlay';
+import {isDefinitelyHidden} from '../utils/nodeVisibilityUtils';
 
-export const UnzipActionComponent = withNotifications()(({path, paths, render: Render, loading: Loading, notificationContext, ...others}) => {
+const ZIP_MIME_TYPES = new Set(['application/zip', 'application/x-zip-compressed']);
+
+export const UnzipActionComponent = withNotifications()(({path, paths, node: prefetchedNode, render: Render, loading: Loading, notificationContext, ...others}) => {
     const language = useSelector(state => state.language);
     const componentRenderer = useContext(ComponentRendererContext);
     const client = useApolloClient();
 
+    // Pre-gate: if prefetched row data already tells us this action is hidden, skip the network fetch
+    const prefetchMimeType = prefetchedNode?.content?.mimeType?.value;
+    const skip = !paths && (
+        isDefinitelyHidden(prefetchedNode, {
+            showOnNodeTypes: ['jnt:file'],
+            hideMixins: ['jmix:markedForDeletion']
+        }) ||
+        (prefetchMimeType !== undefined && !ZIP_MIME_TYPES.has(prefetchMimeType))
+    );
+
     const res = useNodeChecks(
         {path, paths, language},
         {
+            skip,
             getParent: true,
             getMimeType: true,
             getProperties: ['jcr:mixinTypes'],
@@ -33,7 +47,11 @@ export const UnzipActionComponent = withNotifications()(({path, paths, render: R
         return (Loading && <Loading {...others}/>) || false;
     }
 
-    let isVisible = res.checksResult && res.node && (res.node.mimeType === 'application/zip' || res.node.mimeType === 'application/x-zip-compressed') && !isMarkedForDeletion(res.node);
+    if (skip) {
+        return false;
+    }
+
+    let isVisible = res.checksResult && res.node && ZIP_MIME_TYPES.has(res.node.mimeType) && !isMarkedForDeletion(res.node);
 
     return (
         <Render
@@ -61,6 +79,8 @@ UnzipActionComponent.propTypes = {
     path: PropTypes.string,
 
     paths: PropTypes.arrayOf(PropTypes.string),
+
+    node: PropTypes.object,
 
     render: PropTypes.func.isRequired,
 

--- a/src/javascript/JContent/actions/zipUnzip/zipAction.jsx
+++ b/src/javascript/JContent/actions/zipUnzip/zipAction.jsx
@@ -13,15 +13,22 @@ import PropTypes from 'prop-types';
 import {ACTION_PERMISSIONS, PATH_FILES_ITSELF} from '../actions.constants';
 import {TransparentLoaderOverlay} from '~/JContent/TransparentLoaderOverlay';
 import {compareVersions} from 'compare-versions';
+import {isDefinitelyHidden} from '../utils/nodeVisibilityUtils';
 
-export const ZipActionComponent = withNotifications()(({path, paths, render: Render, loading: Loading, notificationContext, ...others}) => {
+export const ZipActionComponent = withNotifications()(({path, paths, node: prefetchedNode, render: Render, loading: Loading, notificationContext, ...others}) => {
     const componentRenderer = useContext(ComponentRendererContext);
     const client = useApolloClient();
     const dispatch = useDispatch();
 
+    const pathHidden = !paths && path && new RegExp(PATH_FILES_ITSELF).test(path);
+    const skip = compareVersions(window.contextJsParameters.dxVersion, '8.1.3.0') >= 0 ||
+        pathHidden ||
+        isDefinitelyHidden(prefetchedNode, {showOnNodeTypes: ['jnt:file', 'jnt:folder']});
+
     const res = useNodeChecks(
         {path, paths},
         {
+            skip,
             getParent: true,
             requiredPermission: ['jcr:addChildNodes'],
             requiredSitePermission: [ACTION_PERMISSIONS.zipAction],
@@ -32,6 +39,10 @@ export const ZipActionComponent = withNotifications()(({path, paths, render: Ren
 
     if (res.loading) {
         return (Loading && <Loading {...others}/>) || false;
+    }
+
+    if (skip) {
+        return false;
     }
 
     let isVisible = compareVersions(window.contextJsParameters.dxVersion, '8.1.3.0') < 0 && res.checksResult;
@@ -91,6 +102,8 @@ ZipActionComponent.propTypes = {
     path: PropTypes.string,
 
     paths: PropTypes.arrayOf(PropTypes.string),
+
+    node: PropTypes.object,
 
     render: PropTypes.func.isRequired,
 

--- a/tests/cypress/e2e/jcontent/preview.cy.ts
+++ b/tests/cypress/e2e/jcontent/preview.cy.ts
@@ -70,41 +70,40 @@ describe('JContent preview tests', () => {
     it('should show correct preview version in live and edit', () => {
         const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
 
-        // Open preview
+        cy.log('Open preview');
         jcontent.openPreview('previewText');
         cy.get('[data-sel-role=preview-type-content]').should('be.visible');
         cy.get('[data-cm-role=preview-name]').contains('preview me');
 
-        // Verify live button is disabled
+        cy.log('Verify live button is disabled');
         cy.get('button[data-cm-role="live-preview-button"]')
             .should('exist')
             .and('be.disabled');
         cy.get('[data-cm-role=preview-drawer-close]').click();
 
-        // Publish
+        cy.log('Publish');
         jcontent.getTable()
             .getRowByName('previewText')
             .contextMenu()
-            .submenu('Publish', 'jcontent-publishMenu')
-            .should('be.visible')
+            .submenu('Publish', 'jcontent-publishMenu').get()
             .within(() => {
                 cy.contains('span', 'Publish preview me - English').click();
             });
         jcontent.clickPublishNow();
 
-        // Reopen preview
+        cy.log('Reopen preview');
         jcontent.openPreview('previewText');
         cy.get('button[data-cm-role="live-preview-button"]').should('be.visible').click();
         cy.get('[data-cm-role=preview-name]').contains('preview me');
         cy.get('[data-cm-role=preview-drawer-close]').click();
 
-        // Edit
+        cy.log('Edit');
         jcontent.editComponentByRowName('previewText');
         const ce = new ContentEditor();
         ce.getSmallTextField('jnt:text_text').addNewValue('preview me edited');
         ce.save();
 
-        // Reopen preview
+        cy.log('Reopen preview after edit');
         jcontent.openPreview('previewText');
         cy.get('[data-sel-role=preview-type-content]').should('be.visible');
         cy.get('[data-cm-role=preview-name]').contains('preview me edited');
@@ -112,12 +111,11 @@ describe('JContent preview tests', () => {
         cy.get('[data-cm-role=preview-name]').contains('preview me');
         cy.get('[data-cm-role=preview-drawer-close]').click();
 
-        // Publish
+        cy.log('Publish after edit');
         jcontent.getTable()
             .getRowByName('previewText')
             .contextMenu()
-            .submenu('Publish', 'jcontent-publishMenu')
-            .should('be.visible')
+            .submenu('Publish', 'jcontent-publishMenu').get()
             .within(() => {
                 cy.contains('span', 'Publish preview me edited - English').click();
             });
@@ -128,12 +126,11 @@ describe('JContent preview tests', () => {
         cy.get('[data-cm-role=preview-name]').contains('preview me edited');
         cy.get('[data-cm-role=preview-drawer-close]').click();
 
-        // Unpublish
+        cy.log('Unpublish');
         jcontent.getTable()
             .getRowByName('previewText')
             .contextMenu()
-            .submenu('Publish', 'jcontent-publishMenu')
-            .should('be.visible')
+            .submenu('Publish', 'jcontent-publishMenu').get()
             .within(() => {
                 cy.contains('span', 'Unpublish preview me edited - English').click();
             });

--- a/tests/cypress/e2e/menuActions/contextMenuVisibility.cy.ts
+++ b/tests/cypress/e2e/menuActions/contextMenuVisibility.cy.ts
@@ -1,0 +1,155 @@
+import {JContent} from '../../page-object';
+import {addNode, createSite, deleteSite, getComponent, Menu, uploadFile} from '@jahia/cypress';
+import {GraphqlUtils} from '../../utils/graphqlUtils';
+
+const SLOW_QUERY_DELAY_MS = 2000;
+const MENU_VISIBILITY_THRESHOLD_MS = 1500;
+
+describe('Context menu visiblity', () => {
+    const siteKey = 'contextMenuSite';
+    const folderName = 'test-folder';
+    const childFolderName = 'test-child-folder';
+    const fileName = 'test-file.pdf';
+
+    before(() => {
+        createSite(siteKey);
+        uploadFile(
+            '/assets/uploadMedia/myfile.pdf',
+            `/sites/${siteKey}/files`,
+            fileName,
+            'application/pdf'
+        );
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: folderName,
+            primaryNodeType: 'jnt:contentFolder'
+        });
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents/${folderName}`,
+            name: childFolderName,
+            primaryNodeType: 'jnt:contentFolder'
+        });
+    });
+
+    after(() => {
+        deleteSite(siteKey);
+        cy.logout();
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession();
+    });
+
+    describe('loading state', () => {
+        it('should show skeleton items while GQL is in-flight', () => {
+            const jcontent = JContent.visit(siteKey, 'en', `content-folders/contents/${folderName}`);
+            jcontent.switchToListMode();
+            jcontent.getTable().getRowByName(childFolderName).get().should('be.visible');
+
+            cy.intercept('POST', '/modules/graphql', req => {
+                req.reply(res => {
+                    res.setDelay(SLOW_QUERY_DELAY_MS);
+                });
+            }).as('slowAllGql');
+
+            jcontent.getTable().getRowByName(childFolderName).get().rightclick();
+
+            cy.get('#menuHolder .moonstone-menu:not(.moonstone-hidden)', {
+                timeout: MENU_VISIBILITY_THRESHOLD_MS
+            }).should('be.visible')
+                .find('[data-sel-role="menu-item-skeleton"]')
+                .should('have.length.greaterThan', 0);
+
+            cy.wait('@slowAllGql');
+            cy.get('#menuHolder .moonstone-menu:not(.moonstone-hidden)')
+                .find('[data-sel-role="menu-item-skeleton"]')
+                .should('not.exist');
+        });
+    });
+
+    /**
+     * Context menu action visibility tests.
+     *
+     * These tests validate that the early-check pre-gates (isDefinitelyHidden) in each
+     * action component correctly show or hide actions based on the node type and mixin
+     * data available from the prefetched row, before any useNodeChecks GQL request fires.
+     *
+     * Each test right-clicks on a node of a specific type and asserts the presence or
+     * absence of menu items that should be gated by node type or mixin checks:
+     *
+     * - showOnNodeTypes: ['jnt:file'] gates → Download, Rename (media), Edit Image, Zip/Unzip
+     * - showOnNodeTypes: ['jnt:folder'] gates → Rename (media folders)
+     * - hideMixins: ['jmix:markedForDeletion'] gates → Delete (mark for deletion) hidden
+     *   when node is already marked
+     */
+    describe('action visibility', () => {
+        describe('jnt:file node', () => {
+            it('should show Download action', () => {
+                const jcontent = JContent.visit(siteKey, 'en', 'media/files');
+                jcontent.switchToListMode();
+                jcontent.getTable().getRowByName(fileName).contextMenu();
+                getComponent(Menu).shouldHaveRoleItem('downloadFile');
+            });
+
+            it('should show Rename action', () => {
+                const jcontent = JContent.visit(siteKey, 'en', 'media/files');
+                jcontent.switchToListMode();
+                jcontent.getTable().getRowByName(fileName).contextMenu();
+                getComponent(Menu).shouldHaveRoleItem('rename');
+            });
+        });
+
+        describe('jnt:contentFolder node', () => {
+            it('should NOT show Download action', () => {
+                const jcontent = JContent.visit(siteKey, 'en', `content-folders/contents/${folderName}`);
+                jcontent.switchToListMode();
+                jcontent.getTable().getRowByName(childFolderName).contextMenu();
+                getComponent(Menu).shouldNotHaveRoleItem('downloadFile');
+            });
+
+            it('should NOT show Rename action', () => {
+                const jcontent = JContent.visit(siteKey, 'en', `content-folders/contents/${folderName}`);
+                jcontent.switchToListMode();
+                jcontent.getTable().getRowByName(childFolderName).contextMenu();
+                getComponent(Menu).shouldNotHaveRoleItem('rename');
+            });
+
+            it('should show Delete action when not marked for deletion', () => {
+                const jcontent = JContent.visit(siteKey, 'en', `content-folders/contents/${folderName}`);
+                jcontent.switchToListMode();
+                jcontent.getTable().getRowByName(childFolderName).contextMenu();
+                getComponent(Menu).shouldHaveRoleItem('delete');
+            });
+        });
+
+        describe('node already marked for deletion', () => {
+            const markedFolderName = 'marked-folder';
+
+            before(() => {
+                addNode({
+                    parentPathOrId: `/sites/${siteKey}/contents/${folderName}`,
+                    name: markedFolderName,
+                    primaryNodeType: 'jnt:contentFolder'
+                });
+                GraphqlUtils.addMixins(
+                    `/sites/${siteKey}/contents/${folderName}/${markedFolderName}`,
+                    ['jmix:markedForDeletion', 'jmix:markedForDeletionRoot']
+                );
+            });
+
+            it('should NOT show Delete action', () => {
+                const jcontent = JContent.visit(siteKey, 'en', `content-folders/contents/${folderName}`);
+                jcontent.switchToListMode();
+                jcontent.getTable().getRowByName(markedFolderName).contextMenu();
+                getComponent(Menu).shouldNotHaveRoleItem('delete');
+            });
+
+            it('should show Delete permanently action', () => {
+                const jcontent = JContent.visit(siteKey, 'en', `content-folders/contents/${folderName}`);
+                jcontent.switchToListMode();
+                jcontent.getTable().getRowByName(markedFolderName).contextMenu();
+                getComponent(Menu).shouldHaveRoleItem('deletePermanently');
+            });
+        });
+    });
+});

--- a/tests/cypress/e2e/pageBuilder/clickSelectionAndNavigation.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/clickSelectionAndNavigation.cy.ts
@@ -56,7 +56,7 @@ describe('Page builder - navigation tests', () => {
         module.hasNoHeaderAndFooter();
     });
 
-    it.only('Can use breadcrumbs to navigate up and down hierarchy', () => {
+    it('Can use breadcrumbs to navigate up and down hierarchy', () => {
         const jcontent: JContent = JContent.visit(siteKey, 'en', 'pages/home');
         const pageBuilder: JContentPageBuilder = jcontent.switchToPageBuilder();
 
@@ -71,7 +71,7 @@ describe('Page builder - navigation tests', () => {
         cy.log('Click on the breadcrumb to navigate up');
         breadcrumbs.select('landing');
         module = pageBuilder.getModule(`/sites/${siteKey}/home/landing`);
-        module.getBox().getHeader().assertHeaderText('landing');
+        module.getBox().getHeader().scrollToTop().assertHeaderText('landing');
     });
 
     it('Click on links should open modal', () => {

--- a/tests/cypress/e2e/pageBuilder/clickSelectionAndNavigation.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/clickSelectionAndNavigation.cy.ts
@@ -56,7 +56,7 @@ describe('Page builder - navigation tests', () => {
         module.hasNoHeaderAndFooter();
     });
 
-    it('Can use breadcrumbs to navigate up and down hierarchy', () => {
+    it.only('Can use breadcrumbs to navigate up and down hierarchy', () => {
         const jcontent: JContent = JContent.visit(siteKey, 'en', 'pages/home');
         const pageBuilder: JContentPageBuilder = jcontent.switchToPageBuilder();
 

--- a/tests/cypress/page-object/contentTable.ts
+++ b/tests/cypress/page-object/contentTable.ts
@@ -1,4 +1,5 @@
 import {BaseComponent, Table, TableRow} from '@jahia/cypress';
+import {JContentMenu} from './jcontentMenu';
 import Chainable = Cypress.Chainable;
 
 export class ContentTable extends Table {
@@ -52,6 +53,11 @@ export class ContentTable extends Table {
 }
 
 export class ContentTableRow extends TableRow {
+    contextMenu(): JContentMenu {
+        this.get().rightclick();
+        return new JContentMenu(cy.get('#menuHolder .moonstone-menu:not(.moonstone-hidden)'));
+    }
+
     isSelected(isSelected = true) {
         this.element.find('td[data-cm-role="table-content-list-cell-selection"] input')
             .should('have.attr', 'aria-checked', Boolean(isSelected).toString());

--- a/tests/cypress/page-object/fields/choiceListField.ts
+++ b/tests/cypress/page-object/fields/choiceListField.ts
@@ -30,9 +30,9 @@ export class ChoiceListField extends Field {
         }
 
         this.openDropdown();
-        const menu = getComponent(Menu, this);
         values.forEach(value => {
-            menu.selectByValue(value);
+            cy.get(`.moonstone-menu:not(.moonstone-hidden) .moonstone-menuItem[data-value="${value}"]`).scrollIntoView();
+            cy.get(`.moonstone-menu:not(.moonstone-hidden) .moonstone-menuItem[data-value="${value}"]`).click();
         });
         this.closeDropdown();
     }
@@ -48,8 +48,8 @@ export class ChoiceListField extends Field {
         }
 
         this.openDropdown();
-        const menu = getComponent(Menu, this);
-        menu.selectByValue(value);
+        cy.get(`.moonstone-menu:not(.moonstone-hidden) .moonstone-menuItem[data-value="${value}"]`).scrollIntoView();
+        cy.get(`.moonstone-menu:not(.moonstone-hidden) .moonstone-menuItem[data-value="${value}"]`).click();
         // For single-value choice lists, selecting the value closes the dropdown, no need to call this.closeDropdown()
     }
 

--- a/tests/cypress/page-object/index.ts
+++ b/tests/cypress/page-object/index.ts
@@ -6,6 +6,7 @@ export * from './pageComposer';
 export * from './accordionItem';
 export * from './categoryManager';
 export * from './sidePanel';
+export * from './jcontentMenu';
 export {AdvancedOptions} from './advancedOptions';
 export {
     PageBuilderModule,

--- a/tests/cypress/page-object/jcontentMenu.ts
+++ b/tests/cypress/page-object/jcontentMenu.ts
@@ -1,0 +1,35 @@
+import {Menu} from '@jahia/cypress';
+
+/**
+ * Extends the base Menu class with a more reliable submenu() implementation.
+ *
+ * The base implementation does realHover() then immediately queries for the submenu,
+ * which races against React's render cycle. This override:
+ *   1. Waits for skeleton items to clear (menu fully loaded) before hovering, since
+ *      skeleton items have no onMouseEnter handler and won't open the submenu.
+ *   2. Retries realHover() up to 3 times to handle the brief window where the menu
+ *      is repositioning after the skeleton→real transition.
+ */
+export class JContentMenu extends Menu {
+    submenu(item: string, menuRole: string): JContentMenu {
+        this.get()
+            .find('[data-sel-role="menu-item-skeleton"]')
+            .should('not.exist');
+
+        Cypress._.times(3, () => {
+            this.shouldHaveItem(item);
+            this.get()
+                .find('.moonstone-menuItem').contains(item)
+                .realHover();
+        });
+
+        cy.get(
+            `${Menu.defaultSelector}[data-sel-role="${menuRole}"]`,
+            {timeout: 10000}
+        ).should('be.visible');
+
+        return new JContentMenu(
+            cy.get(`${Menu.defaultSelector}[data-sel-role="${menuRole}"]`)
+        );
+    }
+}

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModuleHeader.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModuleHeader.ts
@@ -18,6 +18,13 @@ export class PageBuilderModuleHeader extends BaseComponent {
         this.get().find('p').contains(text);
     }
 
+    scrollToTop(): this {
+        cy.get('iframe[data-sel-role="page-builder-frame-active"]').then($iframe => {
+            $iframe[0].contentWindow.scrollTo(0, 0);
+        });
+        return this;
+    }
+
     select() {
         this.should('be.visible');
         this.get().click({metaKey: true, force: true});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2438,55 +2438,55 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/core@npm:^1.7.3":
-  version: 1.7.3
-  resolution: "@floating-ui/core@npm:1.7.3"
+"@floating-ui/core@npm:^1.7.5":
+  version: 1.7.5
+  resolution: "@floating-ui/core@npm:1.7.5"
   dependencies:
-    "@floating-ui/utils": "npm:^0.2.10"
-  checksum: 10c0/edfc23800122d81df0df0fb780b7328ae6c5f00efbb55bd48ea340f4af8c5b3b121ceb4bb81220966ab0f87b443204d37105abdd93d94846468be3243984144c
+    "@floating-ui/utils": "npm:^0.2.11"
+  checksum: 10c0/f9c52205e198b231d63a387b09c659aab08c46a1899e0b0bbe147b8b4f048b546f15ba17cb5d2a471da9534f1883d979425e13e5c4ceee67be63e4b0abd4db5d
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:^1.7.4":
-  version: 1.7.4
-  resolution: "@floating-ui/dom@npm:1.7.4"
+"@floating-ui/dom@npm:^1.7.6":
+  version: 1.7.6
+  resolution: "@floating-ui/dom@npm:1.7.6"
   dependencies:
-    "@floating-ui/core": "npm:^1.7.3"
-    "@floating-ui/utils": "npm:^0.2.10"
-  checksum: 10c0/da6166c25f9b0729caa9f498685a73a0e28251613b35d27db8de8014bc9d045158a23c092b405321a3d67c2064909b6e2a7e6c1c9cc0f62967dca5779f5aef30
+    "@floating-ui/core": "npm:^1.7.5"
+    "@floating-ui/utils": "npm:^0.2.11"
+  checksum: 10c0/5c098e0d7b58c9bc769f276cca1766994c2c9c70c92d091a61bba8b3e9be53c011e0a79a8457fc2fb2f3d91697a26eb52e0a4962ef936dc963b45f58613c212f
   languageName: node
   linkType: hard
 
-"@floating-ui/react-dom@npm:^2.1.6":
-  version: 2.1.6
-  resolution: "@floating-ui/react-dom@npm:2.1.6"
+"@floating-ui/react-dom@npm:^2.1.8":
+  version: 2.1.8
+  resolution: "@floating-ui/react-dom@npm:2.1.8"
   dependencies:
-    "@floating-ui/dom": "npm:^1.7.4"
+    "@floating-ui/dom": "npm:^1.7.6"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
-  checksum: 10c0/6654834a8e73ecbdbc6cad2ad8f7abc698ac7c1800ded4d61113525c591c03d2e3b59d3cf9205859221465ea38c87af4f9e6e204703c5b7a7e85332d1eef2e18
+  checksum: 10c0/26260ca4bb23b57c73b824062505abf977a008ce6e0463bdacca74f7e49853c4cd1d2bbf1a77c6caa17fa37dfffda2c6c4cd07a8737ebd7474aaff7818401d75
   languageName: node
   linkType: hard
 
-"@floating-ui/react@npm:^0.27.16":
-  version: 0.27.16
-  resolution: "@floating-ui/react@npm:0.27.16"
+"@floating-ui/react@npm:^0.27.19":
+  version: 0.27.19
+  resolution: "@floating-ui/react@npm:0.27.19"
   dependencies:
-    "@floating-ui/react-dom": "npm:^2.1.6"
-    "@floating-ui/utils": "npm:^0.2.10"
+    "@floating-ui/react-dom": "npm:^2.1.8"
+    "@floating-ui/utils": "npm:^0.2.11"
     tabbable: "npm:^6.0.0"
   peerDependencies:
     react: ">=17.0.0"
     react-dom: ">=17.0.0"
-  checksum: 10c0/a026266d8875e69de1ac1e1a00588660c8ee299c1e7d067c5c5fd1d69a46fd10acff5dd6cb66c3fe40a3347b443234309ba95f5b33d49059d0cda121f558f566
+  checksum: 10c0/2a2cdfd3e67e0606833b63f922ad2a9037974f22b944e1cb8c0991b4c40450f8413d69745c0bbf4646e5ba283747f60d2fdc9a8d289b68b24448e59d81a3a96d
   languageName: node
   linkType: hard
 
-"@floating-ui/utils@npm:^0.2.10":
-  version: 0.2.10
-  resolution: "@floating-ui/utils@npm:0.2.10"
-  checksum: 10c0/e9bc2a1730ede1ee25843937e911ab6e846a733a4488623cd353f94721b05ec2c9ec6437613a2ac9379a94c2fd40c797a2ba6fa1df2716f5ce4aa6ddb1cf9ea4
+"@floating-ui/utils@npm:^0.2.11":
+  version: 0.2.11
+  resolution: "@floating-ui/utils@npm:0.2.11"
+  checksum: 10c0/f4bcea1559bdbb721ecc8e8ead423ac58d6a5b6e70b602cf0810ba6ad4ed1c77211b207faa88b278a9042f0c743133de08a203ed6741c1b6443423332884d5b3
   languageName: node
   linkType: hard
 
@@ -2698,7 +2698,7 @@ __metadata:
     "@jahia/design-system-kit": "npm:^1.2.1"
     "@jahia/eslint-config": "npm:^2.1.0"
     "@jahia/icons": "npm:^1.1.2"
-    "@jahia/moonstone": "npm:^2.19.0"
+    "@jahia/moonstone": "npm:^2.20.0"
     "@jahia/react-material": "npm:^3.0.5"
     "@jahia/stylelint-config": "npm:^0.0.3"
     "@jahia/test-framework": "npm:^1.3.1"
@@ -2800,11 +2800,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jahia/moonstone@npm:^2.19.0":
-  version: 2.19.0
-  resolution: "@jahia/moonstone@npm:2.19.0"
+"@jahia/moonstone@npm:^2.20.0":
+  version: 2.20.0
+  resolution: "@jahia/moonstone@npm:2.20.0"
   dependencies:
-    "@floating-ui/react": "npm:^0.27.16"
+    "@floating-ui/react": "npm:^0.27.19"
     "@tanstack/react-table": "npm:^8.21.3"
     clsx: "npm:^2.1.1"
     re-resizable: "npm:^6.11.2"
@@ -2813,7 +2813,7 @@ __metadata:
     react: ^18.3.1
     react-dom: ^18.3.1
     react-table: ^7.8.0
-  checksum: 10c0/c97d35195b295f1a552a5bc6fcd2ed1b41be048b7b2fad91ca41f7972e49ae6926a5ff684c1ef15611a7f571bf2e16df32426f5bef9f6dd756b7bdce142c45f6
+  checksum: 10c0/7f74efaccb1db5ec651cfabb0106055ed6a6daa76c78ed9cafc49e6315f05533759825259ee4e6a35e811a00b7904d3e6f2da2733fba6c46029f299c957bd8d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Partially fixes issue around noticeable delay in context menus before it appears. This is due the bulk graphql query for determining visibility logic and permission checks for all actions, and that we only display context menu until response is received.

#### Performance fixes

 - Show menu immediately — the context menu now opens at once with skeleton loading placeholders instead of waiting for all actions to resolve
   - MenuLoadingContext — new React context propagates loading state; MenuItemRenderer renders <MenuItemSkeleton> while actions are resolving, then atomically replaces them when ready
 - loadingTypes fix in createContent.utils.js — changed to loading && !data so cached data is used immediately on subsequent opens; added notifyOnNetworkStatusChange: true to correctly track background refetch
 - Pre-gate visibility checks (nodeVisibilityUtils.js) — 20+ actions now call isDefinitelyHidden() to return early before triggering GQL, using hideOnNodeTypes, hideMixins, and showOnNodeTypes checks on data already available in the node payload
   - The function is intentionally pessimistic: it only returns true (hidden) when it can be determined with certainty from the available node data — if in any doubt, it returns false and falls through to the full GQL resolution. This is esp true for node types, where a full hierarchy is needed to check so we only enforce prechecks only on exact primary type matching, otherwise we defer to the original useNodeChecks.
 - Moonstone update — bumped to 2.20.0 which includes a ResizeObserver-based usePositioning fix, preventing menu repositioning flicker after loading transition
 
#### Test coverage

 - contextMenuVisibility.cy.ts — 7 Cypress tests covering skeleton loading state and per-node-type action visibility (jnt:file, jnt:contentFolder, jmix:markedForDeletion)**

