### PR TITLE
chore: Include 3_6_x branch in on-merge workflow

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - 'main'
+      - '3_6_x'
     tags-ignore:
       - '**'
 


### PR DESCRIPTION
### Description
Include 3_6_x branch in on-merge workflow.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
