### PR TITLE
fix: Apply overflow style only when insertion point is empty

### DIFF
--- a/src/javascript/JContent/EditFrame/Create.scss
+++ b/src/javascript/JContent/EditFrame/Create.scss
@@ -14,7 +14,6 @@
     flex-wrap: nowrap;
     justify-content: center;
     align-items: center;
-    overflow: hidden;
 
     // Hide container if there is no children
     &:empty {
@@ -41,6 +40,7 @@
 
     &.isEmpty {
         background: var(--color-gray_light_plain20);
+        overflow: hidden;
     }
 
     & button {


### PR DESCRIPTION
### Description
Apply overflow style only when insertion point is empty.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
