### PR TITLE
test: Fix description tests, add skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,13 @@ The repo extends `@jahia/eslint-config` (`.eslintrc.json`). Key rules to always 
 - Place queries/mutations in `*.gql-queries.js` files using `gql` from `graphql-tag`.
 - Refetch logic uses `setRefetcher` / `unsetRefetcher` from `~/JContent/JContent.refetches`.
 
+## Java GraphQL API
+
+- **Every** `@GraphQLField`, `@GraphQLName`-annotated class, and `@GraphQLName`-annotated parameter **must** have a `@GraphQLDescription` annotation with a meaningful, non-empty description.
+- This is enforced by a CI schema-description test that walks all types under `Query`, `Mutation`, and `Subscription` and fails if any node is missing a description.
+- When creating or modifying a GraphQL type/field/input/parameter in `src/main/java/`, always add `@GraphQLDescription("...")` alongside `@GraphQLField` or `@GraphQLName`.
+- Import `graphql.annotations.annotationTypes.GraphQLDescription` (or use the wildcard import `graphql.annotations.annotationTypes.*` if the file already does).
+
 ## Cypress tests (tests/)
 
 - Specs live under `tests/cypress/e2e/<area>/*.cy.ts` and are TypeScript.

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/GqlEditorFormMutations.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/GqlEditorFormMutations.java
@@ -113,10 +113,10 @@ public class GqlEditorFormMutations {
     public boolean saveVisibilityCondition(
         @GraphQLName("uuid") @GraphQLNonNull @GraphQLDescription("UUID of the parent nodes ofr teh visibility condition") String uuid,
         @GraphQLName("locale") @GraphQLNonNull @GraphQLDescription("A string representation of a locale, in IETF BCP 47 language tag format, ie en_US, en, fr, fr_CH, ...") String locale,
-        @GraphQLName("newConditions") Collection<VisibilityConditionInput> newConditions,
-        @GraphQLName("updatedConditions") Collection<VisibilityConditionInput> updatedConditions,
-        @GraphQLName("removedConditions") Collection<String> removedConditions,
-        @GraphQLName("isMatchingAllConditions") @GraphQLDefaultValue(GqlUtils.SupplierFalse.class) Boolean isMatchingAllConditionsUpdate
+        @GraphQLName("newConditions") @GraphQLDescription("New visibility conditions to create") Collection<VisibilityConditionInput> newConditions,
+        @GraphQLName("updatedConditions") @GraphQLDescription("Existing visibility conditions to update") Collection<VisibilityConditionInput> updatedConditions,
+        @GraphQLName("removedConditions") @GraphQLDescription("UUIDs of visibility conditions to remove") Collection<String> removedConditions,
+        @GraphQLName("isMatchingAllConditions") @GraphQLDefaultValue(GqlUtils.SupplierFalse.class) @GraphQLDescription("When true, all conditions must match for the node to be visible; when false, any single match is sufficient") Boolean isMatchingAllConditionsUpdate
     ) {
         try {
             JCRSessionWrapper session = jcrSessionFactory.getCurrentUserSession(Constants.EDIT_WORKSPACE, LanguageCodeConverters.languageCodeToLocale(locale));

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/GqlEditorForms.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/GqlEditorForms.java
@@ -62,6 +62,7 @@ import java.util.stream.Collectors;
 /**
  * The root class for the GraphQL form API
  */
+@GraphQLDescription("Main entry point for the Content Editor form API — provides queries for form definitions, field constraints, content type trees, and node type information")
 public class GqlEditorForms {
 
     private static Logger logger = LoggerFactory.getLogger(GqlEditorForms.class);

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/VisibilityConditionInput.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/VisibilityConditionInput.java
@@ -1,5 +1,6 @@
 package org.jahia.modules.contenteditor.graphql.api;
 
+import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrPropertyInput;
@@ -7,17 +8,21 @@ import org.jahia.modules.graphql.provider.dxm.node.GqlJcrPropertyInput;
 import java.util.Collection;
 
 @GraphQLName("VisibilityConditionInput")
+@GraphQLDescription("Input type representing a visibility condition to be saved on a node")
 public class VisibilityConditionInput {
     @GraphQLField
     @GraphQLName("type")
+    @GraphQLDescription("The primary node type of the visibility condition")
     private String primaryType;
 
     @GraphQLField
     @GraphQLName("uuid")
+    @GraphQLDescription("The UUID of an existing visibility condition node, null for new conditions")
     private String uuid;
 
     @GraphQLField
     @GraphQLName("properties")
+    @GraphQLDescription("The properties to set on the visibility condition node")
     private Collection<GqlJcrPropertyInput> properties;
 
     public VisibilityConditionInput(@GraphQLName("type") String primaryType, @GraphQLName("uuid") String uuid, @GraphQLName("properties") Collection<GqlJcrPropertyInput> properties) {

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/ContextEntryInput.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/types/ContextEntryInput.java
@@ -23,17 +23,21 @@
  */
 package org.jahia.modules.contenteditor.graphql.api.types;
 
+import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 
 import java.util.List;
 
 @GraphQLName("ContextEntryInput")
+@GraphQLDescription("Input type representing a key-value context entry used to pass additional information for field constraint resolution")
 public class ContextEntryInput {
     @GraphQLField
+    @GraphQLDescription("The context entry key")
     private String key;
 
     @GraphQLField
+    @GraphQLDescription("The context entry values")
     private List<String> value;
 
     public ContextEntryInput(@GraphQLName("key") String key, @GraphQLName("value") List<String> value) {

--- a/src/main/java/org/jahia/modules/visibility/graphql/type/VisibilityConditionEvaluationResult.java
+++ b/src/main/java/org/jahia/modules/visibility/graphql/type/VisibilityConditionEvaluationResult.java
@@ -1,9 +1,11 @@
 package org.jahia.modules.visibility.graphql.type;
 
+import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import org.jahia.modules.graphql.provider.dxm.node.GqlJcrNode;
 
+@GraphQLDescription("Result of evaluating a single visibility condition on a node")
 public class VisibilityConditionEvaluationResult {
 
     private final GqlJcrNode conditionNode;
@@ -16,12 +18,14 @@ public class VisibilityConditionEvaluationResult {
 
     @GraphQLField
     @GraphQLName("conditionNode")
+    @GraphQLDescription("The JCR node representing the visibility condition")
     public GqlJcrNode getConditionNode() {
         return conditionNode;
     }
 
     @GraphQLField
     @GraphQLName("matches")
+    @GraphQLDescription("True if the visibility condition matches for the current context")
     public boolean isMatches() {
         return matches;
     }


### PR DESCRIPTION
### Description
Fix description tests, add skill. The test is in graphql and it breaks if descriptions are missing. I added a skill so that descriptions are generate if AI is used.
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
