### PR TITLE
fix: Update how nodetypes are calculated for insertion points

### DIFF
--- a/.chachalog/n8RGewii.md
+++ b/.chachalog/n8RGewii.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Update how nodetypes are calculated for insertion points to prevent conflicting button types (#2389)

--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -65,9 +65,15 @@ export const getElemAttributes = ({element, parent}) => {
     // Need to check here if insertionPoint is an original create button or not,
     // otherwise it breaks create button for specific child nodes.
     const isInsertionPoint = element.getAttribute('type') !== 'placeholder';
-    const isMultipleChildPlaceholder = element.getAttribute('path') === '*';
 
-    const nodePath = (isInsertionPoint || isMultipleChildPlaceholder) ? null : element.getAttribute('path');
+    // This means this button is inserted as an extra with no underlying placeholder in place. So it makes no sense
+    // to make any conclusions about nodetypes or path. This information is passed in as a prop instead.
+    if (isInsertionPoint) {
+        return {};
+    }
+
+    const isMultipleChildPlaceholder = element.getAttribute('path') === '*';
+    const nodePath = (isMultipleChildPlaceholder) ? null : element.getAttribute('path');
     const nodeName = element.getAttribute('path').split('/').pop();
 
     // Nodetypes should not be undefined here because if nothing is found nothing should be used

--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -131,7 +131,7 @@ const useReorderNodes = ({parentPath}) => {
     return {reorderNodes};
 };
 
-export const Create = React.memo(({element, node, nodes, addIntervalCallback, clickedElement, onClick, onMouseOver, onMouseOut, onSaved, isInsertionPoint, isVertical, nodeDropData, nodeData, pasteData, nt}) => {
+export const Create = React.memo(({element, node, nodes, addIntervalCallback, clickedElement, onClick, onMouseOver, onMouseOut, onSaved, isInsertionPoint, isVertical, nodeDropData, nodeData, pasteData, suppliedNodeTypes}) => {
     const copyPasteNodes = useSelector(state => state.jcontent.copyPaste?.nodes, shallowEqual);
     const parent = element.dataset.jahiaParent && element.ownerDocument.getElementById(element.dataset.jahiaParent);
     const parentPath = parent.getAttribute('path');
@@ -231,7 +231,7 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
     const createAction = useMemo(() => (
         <DisplayAction
             actionKey="createContentPB"
-            nodeTypes={nt ? nt : nodeTypes}
+            nodeTypes={suppliedNodeTypes ? suppliedNodeTypes : nodeTypes}
             path={parentPath}
             name={nodePath}
             isDisabled={isDisabled}
@@ -241,7 +241,7 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
             onVisibilityChanged={onCreateVisibilityChanged}
             onCreate={onAction(({name}) => reorderNodes([name], nodeName))}
         />
-    ), [parentPath, nodePath, isDisabled, nodeData, btnRenderer, onCreateVisibilityChanged, onAction, reorderNodes, nodeName, nodeTypes]);
+    ), [parentPath, nodePath, isDisabled, nodeData, btnRenderer, onCreateVisibilityChanged, onAction, reorderNodes, nodeName, nodeTypes, suppliedNodeTypes]);
 
     return !anyDragging && (
         <div ref={drop}
@@ -298,5 +298,6 @@ Create.propTypes = {
     isVertical: PropTypes.bool,
     nodeDropData: PropTypes.object,
     nodeData: PropTypes.object,
-    pasteData: PropTypes.object
+    pasteData: PropTypes.object,
+    suppliedNodeTypes: PropTypes.arrayOf(PropTypes.string)
 };

--- a/src/javascript/JContent/EditFrame/Create.jsx
+++ b/src/javascript/JContent/EditFrame/Create.jsx
@@ -125,7 +125,7 @@ const useReorderNodes = ({parentPath}) => {
     return {reorderNodes};
 };
 
-export const Create = React.memo(({element, node, nodes, addIntervalCallback, clickedElement, onClick, onMouseOver, onMouseOut, onSaved, isInsertionPoint, isVertical, nodeDropData, nodeData, pasteData}) => {
+export const Create = React.memo(({element, node, nodes, addIntervalCallback, clickedElement, onClick, onMouseOver, onMouseOut, onSaved, isInsertionPoint, isVertical, nodeDropData, nodeData, pasteData, nt}) => {
     const copyPasteNodes = useSelector(state => state.jcontent.copyPaste?.nodes, shallowEqual);
     const parent = element.dataset.jahiaParent && element.ownerDocument.getElementById(element.dataset.jahiaParent);
     const parentPath = parent.getAttribute('path');
@@ -225,7 +225,7 @@ export const Create = React.memo(({element, node, nodes, addIntervalCallback, cl
     const createAction = useMemo(() => (
         <DisplayAction
             actionKey="createContentPB"
-            nodeTypes={nodeTypes}
+            nodeTypes={nt ? nt : nodeTypes}
             path={parentPath}
             name={nodePath}
             isDisabled={isDisabled}

--- a/src/javascript/JContent/EditFrame/InsertionPoints.jsx
+++ b/src/javascript/JContent/EditFrame/InsertionPoints.jsx
@@ -16,10 +16,10 @@ const getNodeTypes = e => {
 
     if (e.dataset.jahiaParent) {
         const parent = e.ownerDocument.getElementById(e.dataset.jahiaParent);
-        const parentNt = parent?.getAttribute('nodetypes');
-        if (parentNt) {
-            parentNt.split(' ').forEach(t => types.add(t));
-        }
+        // const parentNt = parent?.getAttribute('nodetypes');
+        // if (parentNt) {
+        //     parentNt.split(' ').forEach(t => types.add(t));
+        // }
 
         // This means that there's a defined placeholder and we want to use its nodetypes information for the insertion point.
         // This prevents an issue where the parent can have a different nodetypes value which happens because getConstraints is not taking into account

--- a/src/javascript/JContent/EditFrame/InsertionPoints.jsx
+++ b/src/javascript/JContent/EditFrame/InsertionPoints.jsx
@@ -5,6 +5,31 @@ import {useButtonsData} from '~/JContent/EditFrame/Boxes/dataHooks/useButtonsDat
 import {useSelector} from 'react-redux';
 import {usePasteData} from '~/JContent/EditFrame/Boxes/dataHooks/usePasteData';
 
+/**
+ * This function helps resolve required nodetypes for insertion points.
+ *
+ * Why is this necessary?
+ *
+ * Normally create buttons are resolved using existing placeholders (dedicated html with nodetype info, path etc.). You can see this in
+ * Create.jsx. With insertion points things get a little more complicated as we want to inject whatever the module accepts at the top of evert child
+ * (everything with data-jahia-parent on it) in addition to existing placeholders. Because the elements we find are no longer uniform (not just placeholders) we cannot rely on
+ * the mechanism in Create.jsx (getElemAttributes) to resolve nodetype info.
+ *
+ * This mechanism looks at several cases:
+ *
+ * 1. Found child is a placeholder (this means existing create button placeholder). If this placeholder has nodetype info then we need to use this info to get data about nodetypes.
+ * 2. Cases when we cannot resolve parent module id or fail to get the module return no node type information.
+ *
+ * Before I go further, it's helpful to note that there is an issue in Jahia with how it resolves contribute types, which can lead to a situation
+ * when the module and its placeholders will have mismatching info. So if it's a list which normally accepts jmix:droppableContent and contribute types
+ * are configured to accept a, b and c then the module will have jmix:droppableContent in nodetypes while the placeholder for path="*" (accepting multiple children) will have a, b and c.
+ * The correct way of generating html in this case would be to have a, b and c in both cases, but ConstraintsHelper.getConstraints() does not take into account
+ * contribute types (it is not something we can easily modify due to potential side effects as it is used in many places).
+ *
+ * 3. Node type info is available on the parent module and can potentially be used to compute constraints (there can be an exception, see 4).
+ * 4. There is a placeholder child with path="*" AND nodetype info defined then we use this nodetype info (see comment above).
+ * 5. There is also potential for the case when there is placehoder with nodetype info and one without, in which case we want to get data for nodetypes from both locations.
+ */
 const getNodeTypes = e => {
     // The element is placeholder with nodetypes defined, it gives us all the info we need.
     const ownNt = e.getAttribute('nodetypes');
@@ -61,7 +86,7 @@ const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCal
     // Get all children of the clicked element that are [type="existingNode"] and add insertion points for each (insertion points appear on top)
     const childrenElem = [...currentDocument.querySelectorAll(`[data-jahia-parent=${clickedElement.element.id}]`)]
         // Need to make sure that existingNode is not a weakreference but a subnode, which we can do by checking subpath
-        .filter(e => e.getAttribute('path')?.startsWith(clickedPath))
+        .filter(e => e.getAttribute('path')?.startsWith(clickedPath) && e.getAttribute('type') !== 'placeholder')
         .map(e => ({
             element: e,
             node: nodes?.[e.dataset.jahiaParent && e.ownerDocument.getElementById(e.dataset.jahiaParent).getAttribute('path')],

--- a/src/javascript/JContent/EditFrame/InsertionPoints.jsx
+++ b/src/javascript/JContent/EditFrame/InsertionPoints.jsx
@@ -6,42 +6,44 @@ import {useSelector} from 'react-redux';
 import {usePasteData} from '~/JContent/EditFrame/Boxes/dataHooks/usePasteData';
 
 const getNodeTypes = e => {
-    const types = new Set();
-
+    // The element is placeholder with nodetypes defined, it gives us all the info we need.
     const ownNt = e.getAttribute('nodetypes');
-    // Get own types only for placeholders (actual buttons) and avoid getting them from existingNodetypes (rendered modules)
     if (ownNt && e.getAttribute('type') === 'placeholder') {
-        ownNt.split(' ').forEach(t => types.add(t));
+        return ownNt.split(' ');
     }
 
-    if (e.dataset.jahiaParent) {
-        const parent = e.ownerDocument.getElementById(e.dataset.jahiaParent);
-        // const parentNt = parent?.getAttribute('nodetypes');
-        // if (parentNt) {
-        //     parentNt.split(' ').forEach(t => types.add(t));
-        // }
-
-        // This means that there's a defined placeholder and we want to use its nodetypes information for the insertion point.
-        // This prevents an issue where the parent can have a different nodetypes value which happens because getConstraints is not taking into account
-        // contribute types.
-        if (parent) {
-            const wildcardPlaceholders = parent.querySelectorAll(
-                `[type="placeholder"][path="*"][data-jahia-parent="${e.dataset.jahiaParent}"]`
-            );
-            if (wildcardPlaceholders.length > 0) {
-                types.clear();
-                wildcardPlaceholders.forEach(wp => {
-                    const wildcardNt = wp.getAttribute('nodetypes');
-                    if (wildcardNt) {
-                        wildcardNt.split(' ').forEach(t => types.add(t));
-                    }
-                });
-            }
-        }
-
+    const parentId = e.dataset.jahiaParent;
+    if (!parentId) {
+        return [];
     }
 
-    return [...types];
+    const parent = e.ownerDocument.getElementById(parentId);
+    if (!parent) {
+        return [];
+    }
+
+    // If the element is not a placeholder with nodetypes on it, we need to extract nodetype info from existing placeholders on the parent module or the parent module.
+    // There can be different cases. The idea is to determine if placeholders provide all the info we need (they do if they all have nodetypes attribute) or if we need to use a
+    // combination of placeholder-parent or just parent.
+    const parentNt = parent.getAttribute('nodetypes');
+    const parentTypes = parentNt ? parentNt.split(' ') : [];
+
+    // Check for wildcard placeholders (path="*") — their nodetypes take priority
+    const wildcardPlaceholders = [...parent.querySelectorAll(
+        `[type="placeholder"][path="*"][data-jahia-parent="${parentId}"]`
+    )];
+
+    if (wildcardPlaceholders.length === 0) {
+        return parentTypes;
+    }
+
+    // If any wildcard placeholder has no nodetypes, include parent types as well
+    const hasUntypedWildcard = wildcardPlaceholders.some(wp => !wp.getAttribute('nodetypes'));
+    const wildcardTypes = wildcardPlaceholders
+        .flatMap(wp => wp.getAttribute('nodetypes')?.split(' ') ?? []);
+
+    const merged = hasUntypedWildcard ? [...parentTypes, ...wildcardTypes] : wildcardTypes;
+    return [...new Set(merged)];
 };
 
 const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCallback, onSaved}) => {
@@ -74,8 +76,6 @@ const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCal
     const childData = useButtonsData({createButtons: childrenElem, language, uilang});
     const pasteData = usePasteData({createButtons: [...originalInsertionButtons, ...childrenElem], language});
 
-    console.log('A', childData)
-    console.log('B', originalData)
     return (
         [
             ...childrenElem.map(({element, node, attributes}) => (
@@ -84,7 +84,7 @@ const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCal
                         isVertical={isVertical}
                         node={node}
                         nodes={nodes}
-                        nt={attributes.nodeTypes}
+                        suppliedNodeTypes={attributes.nodeTypes}
                         nodeData={childData?.nodes?.[node.path]}
                         pasteData={pasteData}
                         element={element}

--- a/src/javascript/JContent/EditFrame/InsertionPoints.jsx
+++ b/src/javascript/JContent/EditFrame/InsertionPoints.jsx
@@ -15,10 +15,30 @@ const getNodeTypes = e => {
     }
 
     if (e.dataset.jahiaParent) {
-        const parentNt = e.ownerDocument.getElementById(e.dataset.jahiaParent).getAttribute('nodetypes');
+        const parent = e.ownerDocument.getElementById(e.dataset.jahiaParent);
+        const parentNt = parent?.getAttribute('nodetypes');
         if (parentNt) {
             parentNt.split(' ').forEach(t => types.add(t));
         }
+
+        // This means that there's a defined placeholder and we want to use its nodetypes information for the insertion point.
+        // This prevents an issue where the parent can have a different nodetypes value which happens because getConstraints is not taking into account
+        // contribute types.
+        if (parent) {
+            const wildcardPlaceholders = parent.querySelectorAll(
+                `[type="placeholder"][path="*"][data-jahia-parent="${e.dataset.jahiaParent}"]`
+            );
+            if (wildcardPlaceholders.length > 0) {
+                types.clear();
+                wildcardPlaceholders.forEach(wp => {
+                    const wildcardNt = wp.getAttribute('nodetypes');
+                    if (wildcardNt) {
+                        wildcardNt.split(' ').forEach(t => types.add(t));
+                    }
+                });
+            }
+        }
+
     }
 
     return [...types];
@@ -54,14 +74,17 @@ const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCal
     const childData = useButtonsData({createButtons: childrenElem, language, uilang});
     const pasteData = usePasteData({createButtons: [...originalInsertionButtons, ...childrenElem], language});
 
+    console.log('A', childData)
+    console.log('B', originalData)
     return (
         [
-            ...childrenElem.map(({element, node}) => (
+            ...childrenElem.map(({element, node, attributes}) => (
                 <Create key={`insertion-point-${element.getAttribute('id')}`}
                         isInsertionPoint
                         isVertical={isVertical}
                         node={node}
                         nodes={nodes}
+                        nt={attributes.nodeTypes}
                         nodeData={childData?.nodes?.[node.path]}
                         pasteData={pasteData}
                         element={element}

--- a/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
@@ -265,7 +265,7 @@ describe('Page builder - insertion points', () => {
         cy.loginAndStoreSession();
     });
 
-    it.skip('shows correct create buttons for twoChildObjectsOneMultiple', () => {
+    it('shows correct create buttons for twoChildObjectsOneMultiple', () => {
         const pageBuilder = JContent
             .visit(siteKey, 'en', 'pages/home/page-two-one-multiple')
             .switchToPageBuilder();
@@ -275,7 +275,7 @@ describe('Page builder - insertion points', () => {
         assertButtonByRole(pageBuilder, 'cent:childObject3');
     });
 
-    it.skip('shows correct create buttons for sixChildObjectsSingle', () => {
+    it('shows correct create buttons for sixChildObjectsSingle', () => {
         const pageBuilder = JContent
             .visit(siteKey, 'en', 'pages/home/page-six-single')
             .switchToPageBuilder();
@@ -285,7 +285,7 @@ describe('Page builder - insertion points', () => {
         }
     });
 
-    it.skip('shows correct create buttons for sixChildObjectsMultiple and verifies insertion points after create', () => {
+    it('shows correct create buttons for sixChildObjectsMultiple and verifies insertion points after create', () => {
         const modulePath = `${homePath}/page-six-multiple/area-main/test-six-multiple`;
         let pageBuilder = JContent
             .visit(siteKey, 'en', 'pages/home/page-six-multiple')
@@ -313,7 +313,7 @@ describe('Page builder - insertion points', () => {
         }
     });
 
-    it.skip('sixChildObjectsSingle still shows six buttons while sixChildObjectsMultiple collapses to one when limit is 5', () => {
+    it('sixChildObjectsSingle still shows six buttons while sixChildObjectsMultiple collapses to one when limit is 5', () => {
         setButtonLimit('5');
 
         const singlePageBuilder = JContent
@@ -346,7 +346,7 @@ describe('Page builder - insertion points', () => {
             .should('have.length', 6);
     });
 
-    it.skip('shows correct buttons for oneChildMultipleList and verifies context menu', () => {
+    it('shows correct buttons for oneChildMultipleList and verifies context menu', () => {
         const modulePath = `${homePath}/page-one-child-list/area-main/test-one-child-list`;
         const pageBuilder = JContent
             .visit(siteKey, 'en', 'pages/home/page-one-child-list')
@@ -377,7 +377,7 @@ describe('Page builder - insertion points', () => {
         ce.cancel();
     });
 
-    it.skip('shows correct working buttons for twoChildObjectsOneMultiple with childObject2 populated', () => {
+    it('shows correct working buttons for twoChildObjectsOneMultiple with childObject2 populated', () => {
         const modulePath = `${homePath}/page-two-one-multiple-populated/area-main/test-two-one-multiple-populated`;
         let pageBuilder = JContent
             .visit(siteKey, 'en', 'pages/home/page-two-one-multiple-populated')
@@ -418,7 +418,7 @@ describe('Page builder - insertion points', () => {
         contentEditor.create();
     });
 
-    it.skip('shows correct buttons for sixChildObjectsSingle with childObject5 populated', () => {
+    it('shows correct buttons for sixChildObjectsSingle with childObject5 populated', () => {
         const modulePath = `${homePath}/page-six-single-populated/area-main/test-six-single-populated`;
         let pageBuilder = JContent
             .visit(siteKey, 'en', 'pages/home/page-six-single-populated')

--- a/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
@@ -1,6 +1,7 @@
 import {addNode, createSite, deleteSite, enableModule, getComponent, getComponentBySelector, Menu} from '@jahia/cypress';
 import gql from 'graphql-tag';
 import {ContentEditor, ContentTypeSelector, JContent} from '../../page-object';
+import {MultipleLeftRightField} from '../../page-object/fields/multipleLeftRightField';
 
 const setButtonLimit = (value: string) => {
     return cy.apollo({
@@ -230,6 +231,28 @@ describe('Page builder - insertion points', () => {
                 }]
             }]
         });
+
+        addNode({
+            name: 'page-with-text',
+            parentPathOrId: homePath,
+            primaryNodeType: 'jnt:page',
+            properties: [
+                {name: 'jcr:title', value: 'Simple text in an area', language: 'en'},
+                {name: 'j:templateName', value: 'simple'}
+            ],
+            children: [{
+                name: 'area-main',
+                primaryNodeType: 'jnt:contentList',
+                mixins: ['jmix:isAreaList'],
+                children: [{
+                    name: 'test-page-with-text',
+                    primaryNodeType: 'jnt:bigText',
+                    properties: [
+                        {name: 'text', value: 'Hello there', language: 'en'}
+                    ]
+                }]
+            }]
+        });
     });
 
     after(() => {
@@ -242,7 +265,7 @@ describe('Page builder - insertion points', () => {
         cy.loginAndStoreSession();
     });
 
-    it('shows correct create buttons for twoChildObjectsOneMultiple', () => {
+    it.skip('shows correct create buttons for twoChildObjectsOneMultiple', () => {
         const pageBuilder = JContent
             .visit(siteKey, 'en', 'pages/home/page-two-one-multiple')
             .switchToPageBuilder();
@@ -252,7 +275,7 @@ describe('Page builder - insertion points', () => {
         assertButtonByRole(pageBuilder, 'cent:childObject3');
     });
 
-    it('shows correct create buttons for sixChildObjectsSingle', () => {
+    it.skip('shows correct create buttons for sixChildObjectsSingle', () => {
         const pageBuilder = JContent
             .visit(siteKey, 'en', 'pages/home/page-six-single')
             .switchToPageBuilder();
@@ -262,7 +285,7 @@ describe('Page builder - insertion points', () => {
         }
     });
 
-    it('shows correct create buttons for sixChildObjectsMultiple and verifies insertion points after create', () => {
+    it.skip('shows correct create buttons for sixChildObjectsMultiple and verifies insertion points after create', () => {
         const modulePath = `${homePath}/page-six-multiple/area-main/test-six-multiple`;
         let pageBuilder = JContent
             .visit(siteKey, 'en', 'pages/home/page-six-multiple')
@@ -290,7 +313,7 @@ describe('Page builder - insertion points', () => {
         }
     });
 
-    it('sixChildObjectsSingle still shows six buttons while sixChildObjectsMultiple collapses to one when limit is 5', () => {
+    it.skip('sixChildObjectsSingle still shows six buttons while sixChildObjectsMultiple collapses to one when limit is 5', () => {
         setButtonLimit('5');
 
         const singlePageBuilder = JContent
@@ -323,7 +346,7 @@ describe('Page builder - insertion points', () => {
             .should('have.length', 6);
     });
 
-    it('shows correct buttons for oneChildMultipleList and verifies context menu', () => {
+    it.skip('shows correct buttons for oneChildMultipleList and verifies context menu', () => {
         const modulePath = `${homePath}/page-one-child-list/area-main/test-one-child-list`;
         const pageBuilder = JContent
             .visit(siteKey, 'en', 'pages/home/page-one-child-list')
@@ -354,7 +377,7 @@ describe('Page builder - insertion points', () => {
         ce.cancel();
     });
 
-    it('shows correct working buttons for twoChildObjectsOneMultiple with childObject2 populated', () => {
+    it.skip('shows correct working buttons for twoChildObjectsOneMultiple with childObject2 populated', () => {
         const modulePath = `${homePath}/page-two-one-multiple-populated/area-main/test-two-one-multiple-populated`;
         let pageBuilder = JContent
             .visit(siteKey, 'en', 'pages/home/page-two-one-multiple-populated')
@@ -395,7 +418,7 @@ describe('Page builder - insertion points', () => {
         contentEditor.create();
     });
 
-    it('shows correct buttons for sixChildObjectsSingle with childObject5 populated', () => {
+    it.skip('shows correct buttons for sixChildObjectsSingle with childObject5 populated', () => {
         const modulePath = `${homePath}/page-six-single-populated/area-main/test-six-single-populated`;
         let pageBuilder = JContent
             .visit(siteKey, 'en', 'pages/home/page-six-single-populated')
@@ -429,6 +452,94 @@ describe('Page builder - insertion points', () => {
         clickButtonByRole(pageBuilder, 'cent:childObject2');
         contentEditor = new ContentEditor();
         contentEditor.create();
+    });
+
+    it('shows insertion points for area with contribute types correctly', () => {
+        const modulePath = `${homePath}/page-with-text/area-main`;
+        let pageBuilder = JContent
+            .visit(siteKey, 'en', 'pages/home/page-with-text')
+            .switchToPageBuilder();
+
+        let module = pageBuilder.getModule(modulePath, false);
+        module.get().scrollIntoView();
+        module.get().click('bottomLeft', {force: true});
+
+        let createButtons = module.getAllCreateButtons();
+        createButtons.should('have.length', 2);
+
+        module.contextMenu().select('Edit');
+
+        let contentEditor = new ContentEditor();
+        contentEditor.toggleOption('jmix:contributeMode', 'Content type restrictions');
+        contentEditor.getField(MultipleLeftRightField, 'jmix:contributeMode_j:contributeTypes', true)
+            .addNewValue('Simple text');
+        contentEditor.save();
+
+        pageBuilder = JContent
+            .visit(siteKey, 'en', 'pages/home/page-with-text')
+            .switchToPageBuilder();
+
+        module = pageBuilder.getModule(modulePath, false);
+        module.get().scrollIntoView();
+        module.get().click('bottomLeft', {force: true});
+
+        // Test that we have two identical simple text buttons around the child
+        createButtons = module.getAllCreateButtons();
+        createButtons.should('have.length', 2);
+        createButtons.get().find('button[data-sel-role="jnt:text"]').should('have.length', 2).first().click();
+
+        contentEditor = new ContentEditor();
+        contentEditor.cancel();
+
+        createButtons.get().find('button[data-sel-role="jnt:text"]').should('have.length', 2).last().click();
+
+        contentEditor = new ContentEditor();
+        contentEditor.cancel();
+
+        // Test that empty value switches insertion point to editorialContent
+        module.contextMenu().select('Edit');
+
+        contentEditor = new ContentEditor();
+        contentEditor.getField(MultipleLeftRightField, 'jmix:contributeMode_j:contributeTypes', true)
+            .removeValue('Simple text');
+        contentEditor.save();
+
+        pageBuilder = JContent
+            .visit(siteKey, 'en', 'pages/home/page-with-text')
+            .switchToPageBuilder();
+
+        module = pageBuilder.getModule(modulePath, false);
+        module.get().scrollIntoView();
+        module.get().click('bottomLeft', {force: true});
+
+        createButtons = module.getAllCreateButtons();
+        createButtons.should('have.length', 2);
+        createButtons.get().find('button[data-sel-role="jmix:editorialContent"]').should('have.length', 2).first().click();
+        pageBuilder.getCreateContent().getContentTypeSelector().cancel();
+        createButtons.get().find('button[data-sel-role="jmix:editorialContent"]').should('have.length', 2).last().click();
+        pageBuilder.getCreateContent().getContentTypeSelector().cancel();
+
+        // Verify that setting toggle to off brings back create content insertion points
+        module.contextMenu().select('Edit');
+
+        contentEditor = new ContentEditor();
+        contentEditor.toggleOption('jmix:contributeMode', 'Content type restrictions');
+        contentEditor.save();
+
+        pageBuilder = JContent
+            .visit(siteKey, 'en', 'pages/home/page-with-text')
+            .switchToPageBuilder();
+
+        module = pageBuilder.getModule(modulePath, false);
+        module.get().scrollIntoView();
+        module.get().click('bottomLeft', {force: true});
+
+        createButtons = module.getAllCreateButtons();
+        createButtons.should('have.length', 2);
+        createButtons.get().find('button[data-sel-role="createContent"]').should('have.length', 2).first().click();
+        pageBuilder.getCreateContent().getContentTypeSelector().cancel();
+        createButtons.get().find('button[data-sel-role="createContent"]').should('have.length', 2).last().click();
+        pageBuilder.getCreateContent().getContentTypeSelector().cancel();
     });
 });
 

--- a/tests/cypress/page-object/fields/multipleLeftRightField.ts
+++ b/tests/cypress/page-object/fields/multipleLeftRightField.ts
@@ -7,7 +7,7 @@ export class MultipleLeftRightField extends Field {
     }
 
     removeValue(newValue: string, force = false) {
-        this.get().find('.moonstone-valueList_wrapper').last().contains(newValue).click({force});
+        this.get().find('li[role="right-list"]').contains(newValue).closest('li').find('.moonstone-listItem_iconEnd').click({force});
         return this;
     }
 }


### PR DESCRIPTION
### Description
Update how nodetypes are calculated for insertion points when contribute types are defined on the node. 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
