### PR TITLE
fix: validation for fields that are empty initially

### DIFF
--- a/.chachalog/W5ookQ45.md
+++ b/.chachalog/W5ookQ45.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": patch
+---
+
+Fixed custom validation messages for fields with no default value.

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.jsx
@@ -157,9 +157,12 @@ export const Field = ({inputContext, idInput, selectorType, field}) => {
     const isMultipleField = field.multiple && !selectorType.supportMultiple;
     const seleniumFieldType = isMultipleField ? `GenericMultipleField${selectorType.key}` : (field.multiple ? `Multiple${selectorType.key}` : selectorType.key);
     const shouldDisplayErrors = errors[field.name];
-    const splitError = shouldDisplayErrors && errors[field.name].split('_');
-    const errorName = splitError && splitError.length > 0 && splitError[0];
-    const errorArgs = splitError && splitError.length > 1 ? splitError.splice(1) : [];
+    // The error value is "<errorName>_<message>" (e.g. "constraintViolation_<server message>").
+    // Split on the first underscore only, so messages containing underscores are not truncated.
+    const errorString = shouldDisplayErrors ? errors[field.name] : '';
+    const separatorIndex = errorString.indexOf('_');
+    const errorName = shouldDisplayErrors && (separatorIndex === -1 ? errorString : errorString.substring(0, separatorIndex));
+    const errorArgs = separatorIndex > -1 ? [errorString.substring(separatorIndex + 1)] : [];
     const hasMandatoryError = shouldDisplayErrors && errors[field.name] === 'required';
     const wipInfo = values[Constants.wip.fieldName];
     const pickerType = selectorType.pickerConfig?.key;

--- a/src/javascript/ContentEditor/utils/fields.utils.js
+++ b/src/javascript/ContentEditor/utils/fields.utils.js
@@ -62,7 +62,7 @@ const _adaptDecimalValues = (fieldType, value) => {
     return fieldType === 'DECIMAL' || fieldType === 'DOUBLE' ? value && value.replace(',', '.') : value;
 };
 
-function updateValue({field, value, lang, nodeData, sections, mixinsToMutate, propsToSave, propsToDelete, propFieldNameMapping, forceUpdate}) {
+function updateValue({field, value, lang, nodeData, sections, mixinsToMutate, propsToSave, propsToDelete, forceUpdate}) {
     if (value !== undefined && value !== null && value !== '') {
         const fieldType = field.requiredType;
 
@@ -108,8 +108,6 @@ function updateValue({field, value, lang, nodeData, sections, mixinsToMutate, pr
             });
         }
     }
-
-    propFieldNameMapping[field.propertyName] = field.name;
 }
 
 export function getDataToMutate({nodeData, formValues, i18nContext, sections, lang}) {
@@ -123,14 +121,23 @@ export function getDataToMutate({nodeData, formValues, i18nContext, sections, la
 
     const keys = new Set(Object.keys(formValues));
     Object.values(i18nContext).filter(ctx => ctx.values !== undefined).forEach(ctx => Object.keys(ctx.values).forEach(k => keys.add(k)));
-    const fields = sections && getFields(sections).filter(field => !nodeData || !field.readOnly);
+    const allFields = sections ? getFields(sections) : [];
+    const fields = allFields.filter(field => !nodeData || !field.readOnly);
     const mixinsToMutate = getMixinsToMutate(nodeData, formValues, sections);
+
+    // Map every field's property name to its form field name, regardless of whether it currently
+    // holds a value. Server-side constraint violations (e.g. custom validators) reference the
+    // property name, and must be resolvable to a field even when the field is empty and has no
+    // default value (and is therefore absent from formValues).
+    allFields.forEach(field => {
+        propFieldNameMapping[field.propertyName] = field.name;
+    });
 
     keys.forEach(key => {
         const field = fields.find(field => field.name === key);
         if (field) {
             const value = formValues[key];
-            updateValue({field, value, lang, nodeData, sections, mixinsToMutate, propsToSave, propsToDelete, propFieldNameMapping});
+            updateValue({field, value, lang, nodeData, sections, mixinsToMutate, propsToSave, propsToDelete});
 
             if (field.i18n) {
                 Object.keys(i18nContext).filter(i18nLang => i18nLang !== lang && i18nLang !== 'shared' && i18nLang !== 'memo').forEach(i18nLang => {
@@ -148,7 +155,6 @@ export function getDataToMutate({nodeData, formValues, i18nContext, sections, la
                             mixinsToMutate,
                             propsToSave,
                             propsToDelete,
-                            propFieldNameMapping,
                             forceUpdate
                         });
                     }

--- a/src/javascript/ContentEditor/utils/fields.utils.spec.js
+++ b/src/javascript/ContentEditor/utils/fields.utils.spec.js
@@ -695,19 +695,24 @@ describe('EditPanel utils', () => {
     const lang = 'fr';
 
     describe('getDataToMutate', () => {
-        testCases.forEach(({name, nodeData, formValues, ExpectedPropsToSave, ExpectedPropsToDelete, skipCreate, expectedPropsFieldMapping, newExpectedPropsToSave, newExpectedPropsFieldMapping}) => {
+        // Every field's property name maps to its form field name in propFieldNameMapping,
+        // regardless of whether the field currently holds a value, so server-side constraint
+        // violations can always be resolved to a field. It is therefore the same for every case.
+        const fullPropFieldNameMapping = getFields(sections).reduce((acc, field) => ({...acc, [field.propertyName]: field.name}), {});
+
+        testCases.forEach(({name, nodeData, formValues, ExpectedPropsToSave, ExpectedPropsToDelete, skipCreate, newExpectedPropsToSave}) => {
             it(`Existing ${name}`, () => {
                 const {propsToSave, propsToDelete, propFieldNameMapping} = getDataToMutate({nodeData, formValues, sections, lang, i18nContext: {}});
                 expect(propsToSave).toEqual(ExpectedPropsToSave || []);
                 expect(propsToDelete).toEqual(ExpectedPropsToDelete || []);
-                expect(propFieldNameMapping).toEqual(expectedPropsFieldMapping || {});
+                expect(propFieldNameMapping).toEqual(fullPropFieldNameMapping);
             });
             if (!skipCreate) {
                 it(`New ${name}`, () => {
                     const {propsToSave, propsToDelete, propFieldNameMapping} = getDataToMutate({formValues, sections, lang, i18nContext: {}});
                     expect(propsToSave).toEqual(newExpectedPropsToSave || ExpectedPropsToSave || []);
                     expect(propsToDelete).toEqual(ExpectedPropsToDelete || []);
-                    expect(propFieldNameMapping).toEqual(newExpectedPropsFieldMapping || expectedPropsFieldMapping || {});
+                    expect(propFieldNameMapping).toEqual(fullPropFieldNameMapping);
                 });
             }
         });

--- a/tests/cypress/e2e/selectorTypes/validation.cy.ts
+++ b/tests/cypress/e2e/selectorTypes/validation.cy.ts
@@ -57,5 +57,19 @@ describe('Test the text field initializer', {testIsolation: false}, () => {
         ce.getField(SmallTextField, 'cent:textFieldInitializer_defaultI18nString', false).addNewValue('12345');
         ce.save();
     });
+
+    // Regression test for jcontent#2374: a custom validator constraint on a property with no
+    // default value (so the field is absent from the create form's initial values) must still
+    // surface its message on the field, including a custom validator message.
+    it('should display the custom validator message on a field with no default value', () => {
+        const ce = jcontent.createContent('cent:noDefaultValidator');
+        ce.getField(SmallTextField, 'nt:base_ce:systemName', false).addNewValue('test-validator-nodefault');
+        ce.createUnchecked();
+        ce.getField(SmallTextField, 'cent:noDefaultValidator_noDefaultString', false)
+            .getErrorMessage()
+            .should('contain', 'noDefaultString must not be empty');
+        ce.getField(SmallTextField, 'cent:noDefaultValidator_noDefaultString', false).addNewValue('a value');
+        ce.create();
+    });
 });
 

--- a/tests/cypress/page-object/fields/field.ts
+++ b/tests/cypress/page-object/fields/field.ts
@@ -27,4 +27,8 @@ export class Field extends BaseComponent {
     getTranslateFieldAction(): Cypress.Chainable {
         return this.get().scrollIntoView().parent().find('[data-sel-role="translate-field"]');
     }
+
+    getErrorMessage(): Cypress.Chainable {
+        return this.get().scrollIntoView().find('[data-sel-error]');
+    }
 }

--- a/tests/jahia-module/jcontent-test-module/src/main/java/org/jahia/modules/textfieldinitializer/CustomValidators.java
+++ b/tests/jahia-module/jcontent-test-module/src/main/java/org/jahia/modules/textfieldinitializer/CustomValidators.java
@@ -12,6 +12,7 @@ public class CustomValidators extends JCRNodeValidatorDefinition {
     public Map<String, Class> getValidators() {
         Map<String, Class> nodeTypeValidatorMap = new java.util.HashMap<>();
         nodeTypeValidatorMap.put("cent:textFieldInitializer", TestNodeValidator.class);
+        nodeTypeValidatorMap.put("cent:noDefaultValidator", NoDefaultValidator.class);
         nodeTypeValidatorMap.put("jnt:file", UploadErrorValidator.class);
         return nodeTypeValidatorMap;
     }

--- a/tests/jahia-module/jcontent-test-module/src/main/java/org/jahia/modules/textfieldinitializer/NoDefaultValidator.java
+++ b/tests/jahia-module/jcontent-test-module/src/main/java/org/jahia/modules/textfieldinitializer/NoDefaultValidator.java
@@ -1,0 +1,25 @@
+package org.jahia.modules.textfieldinitializer;
+
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.content.decorator.validation.JCRNodeValidator;
+
+import javax.validation.constraints.NotEmpty;
+
+/**
+ * Validator for cent:noDefaultValidator. Validates a property that has no default value, using a
+ * custom validation message (regression test for jcontent#2374).
+ */
+public class NoDefaultValidator implements JCRNodeValidator {
+
+    private JCRNodeWrapper node;
+
+    public NoDefaultValidator(JCRNodeWrapper node) {
+        this.node = node;
+    }
+
+    @NotEmpty(message = "noDefaultString must not be empty")
+    public String getNoDefaultString() {
+        return node.getPropertyAsString("noDefaultString");
+    }
+
+}

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -24,6 +24,12 @@
  - moduleI18nRBAutocreatedString (string) = resourceBundle('kiss') autocreated internationalized
  - moduleClassInitString (string) = useClass(org.jahia.modules.textfieldinitializer.InitTextValue)
 
+// Regression test type for jcontent#2374: a property with NO default value, validated by a
+// custom OSGi validator. Because it has no default value it is absent from the create form's
+// initial values, which used to prevent its constraint violation from being mapped to the field.
+[cent:noDefaultValidator] > jnt:content, jmix:basicContent, jmix:editorialContent, mix:title
+ - noDefaultString (string)
+
 [cent:testTextField] > jnt:content, mix:title, jmix:basicContent, jmix:editorialContent, jmix:autoPublish
 
 [cent:defaultValueTest] > jnt:content, jmix:basicContent, jmix:editorialContent, mix:title noquery


### PR DESCRIPTION
### Description
This PR fixes the following problem: if a field has no default value, it will not show custom error message when validated.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
