### PR TITLE
fix: exclude supertype extend mixins from fieldset processing to prev…

### DIFF
--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
@@ -359,6 +359,12 @@ public class EditorFormServiceImpl implements EditorFormService {
             }
         }
 
+        // If mixin A extends mixin B and both are in the list, remove B.
+        // A already carries B's properties via the supertype chain, so keeping both
+        // causes non-deterministic field assignment during fieldset merge.
+        res.removeIf(mixin -> res.stream()
+            .anyMatch(other -> !other.getName().equals(mixin.getName()) && other.isNodeType(mixin.getName())));
+
         return res;
     }
 


### PR DESCRIPTION
### Description

When two mixins both declare `extends = jnt:page` (or any shared target type) and one is a supertype of the other, `getExtendMixins()` returns both. Because the underlying collection iterates over a `HashMap`, processing order is non-deterministic. Depending on which mixin is processed first, `findAndRemoveField()` during fieldset merge moves properties from the correct activated fieldset into an inactive one, causing fields to silently disappear from the Content Editor form.

**Fix:** after collecting the extend mixin list, filter out any entry that is a supertype of another entry in the same list. The more specific mixin already carries all supertype properties via inheritance, so the supertype entry is redundant.

Discovered while investigating a customer case (ARKEMA-1813) where `akmmix:sampleCartPage > jmix:templateMixin, akmmix:sampleCartHeader` — both having `extends = jnt:page` — caused `title` and `description` from `akmmix:sampleCartHeader` to intermittently not appear in Content Editor after the `addMixin` mechanism applied `akmmix:sampleCartPage`.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [x] I've updated the parent issue with required manual validations

**Manual validation:** define two mixins where one extends the other and both have `extends = jnt:page`. Map the more specific mixin via `addMixin`. Create a page using that template and confirm all inherited properties appear in Content Editor consistently across multiple attempts.