### PR TITLE
fix: Prevent NPE

### DIFF
--- a/.chachalog/4zMsqdBN.md
+++ b/.chachalog/4zMsqdBN.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Prevent NPE when reordering hav menu items (#2419)

--- a/src/javascript/JContent/dnd/useNodeDrop.jsx
+++ b/src/javascript/JContent/dnd/useNodeDrop.jsx
@@ -179,7 +179,12 @@ export function useNodeDrop({dropTarget, orderable, entries, onSaved, pos, refet
                 if (onSaved) {
                     onSaved();
                 } else {
-                    const moveResults = Object.fromEntries(data.jcr.mutateNodes.map(n => [n.node.uuid, n.node]));
+                    let moveResults = [];
+
+                    if (data?.jcr?.mutateNodes) {
+                        moveResults = Object.fromEntries(data.jcr.mutateNodes.map(n => [n.node.uuid, n.node]));
+                    }
+
                     refreshTree(destParent.path, nodes, moveResults);
                 }
 


### PR DESCRIPTION
### Description
Prevent NPE if no data is available from the mutateNodes when reordering a menu entry. This data is normally available only when moving nodes.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
