### PR TITLE
fix: Make sure that notFound returns true only when request found nothing.

### DIFF
--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/DefaultPickerConfig.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/DefaultPickerConfig.js
@@ -23,7 +23,7 @@ const usePickerInputData = uuids => {
         fetchPolicy: 'network-only'
     });
 
-    if (loading || error || !data || !data.jcr || !uuids) {
+    if (loading || error || !data?.jcr || !uuids) {
         return {error, loading, notFound: false};
     }
 

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/DefaultPickerConfig.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/DefaultPickerConfig.js
@@ -23,8 +23,13 @@ const usePickerInputData = uuids => {
         fetchPolicy: 'network-only'
     });
 
-    if (loading || error || !data || !data.jcr || !uuids || (data.jcr.result.length === 0 && uuids.length > 0)) {
-        return {error, loading, notFound: Boolean(uuids)};
+    if (loading || error || !data || !data.jcr || !uuids) {
+        return {error, loading, notFound: false};
+    }
+
+    // Make sure that notFound is true only if request did not return anything
+    if (data.jcr.result.length === 0 && uuids.length > 0) {
+        return {error, loading, notFound: true};
     }
 
     const fieldData = data.jcr.result.map(contentData => ({

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/DefaultPickerConfig.spec.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/DefaultPickerConfig.spec.js
@@ -39,7 +39,7 @@ describe('ContentPicker config', () => {
 
         it('should return no data, no error when loading', () => {
             useQuery.mockImplementation(() => ({loading: true}));
-            expect(usePickerInputData('uuid', {lang: 'fr'})).toEqual({loading: true, notFound: true});
+            expect(usePickerInputData('uuid', {lang: 'fr'})).toEqual({loading: true, notFound: false});
         });
 
         it('should return no data when there is no uuid given', () => {
@@ -49,12 +49,12 @@ describe('ContentPicker config', () => {
 
         it('should return error when there is error', () => {
             useQuery.mockImplementation(() => ({loading: false, error: 'oops'}));
-            expect(usePickerInputData('uuid', {lang: 'fr'})).toEqual({loading: false, error: 'oops', notFound: true});
+            expect(usePickerInputData('uuid', {lang: 'fr'})).toEqual({loading: false, error: 'oops', notFound: false});
         });
 
         it('should return not found when the resource has been removed', () => {
-            useQuery.mockImplementation(() => ({loading: false, data: undefined, error: undefined}));
-            expect(usePickerInputData('uuid', {lang: 'fr'})).toEqual({loading: false, notFound: true});
+            useQuery.mockImplementation(() => ({loading: false, data: {jcr: {result: []}}, error: undefined}));
+            expect(usePickerInputData('uuid', {lang: 'fr'})).toEqual({loading: false, error: undefined, notFound: true});
         });
 
         it('should adapt data when graphql return some data', () => {

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/mediaPicker/useMediaPickerInputData.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/mediaPicker/useMediaPickerInputData.js
@@ -19,8 +19,13 @@ export const useMediaPickerInputData = uuids => {
         fetchPolicy: 'network-only'
     });
 
-    if (loading || error || !data || !data.jcr || !uuids || (data.jcr.result.length === 0 && uuids.length > 0)) {
-        return {error, loading, notFound: Boolean(uuids)};
+    if (loading || error || !data || !data.jcr || !uuids) {
+        return {error, loading, notFound: false};
+    }
+
+    // Make sure that notFound is true only if request did not return anything
+    if (data.jcr.result.length === 0 && uuids.length > 0) {
+        return {error, loading, notFound: true};
     }
 
     const fieldData = data.jcr.result.map(imageData => {

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/mediaPicker/useMediaPickerInputData.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/mediaPicker/useMediaPickerInputData.js
@@ -19,7 +19,7 @@ export const useMediaPickerInputData = uuids => {
         fetchPolicy: 'network-only'
     });
 
-    if (loading || error || !data || !data.jcr || !uuids) {
+    if (loading || error || !data?.jcr || !uuids) {
         return {error, loading, notFound: false};
     }
 

--- a/src/javascript/ContentEditor/SelectorTypes/Picker/configs/mediaPicker/useMediaPickerInputData.spec.js
+++ b/src/javascript/ContentEditor/SelectorTypes/Picker/configs/mediaPicker/useMediaPickerInputData.spec.js
@@ -29,7 +29,7 @@ describe('useMediaPickerInputData', () => {
 
     it('should return no data, no error when loading', () => {
         setQueryResponseMock({loading: true});
-        expect(useMediaPickerInputData('uuid', {lang: 'fr'})).toEqual({loading: true, notFound: true});
+        expect(useMediaPickerInputData('uuid', {lang: 'fr'})).toEqual({loading: true, notFound: false});
     });
 
     it('should return no data when there is no uuid given', () => {
@@ -39,12 +39,12 @@ describe('useMediaPickerInputData', () => {
 
     it('should return error when there is error', () => {
         setQueryResponseMock({loading: false, error: 'oops'});
-        expect(useMediaPickerInputData('uuid', {lang: 'fr'})).toEqual({loading: false, error: 'oops', notFound: true});
+        expect(useMediaPickerInputData('uuid', {lang: 'fr'})).toEqual({loading: false, error: 'oops', notFound: false});
     });
 
     it('should return not found when the resource has been removed', () => {
-        setQueryResponseMock({loading: false, data: undefined, error: undefined});
-        expect(useMediaPickerInputData('uuid', {lang: 'fr'})).toEqual({loading: false, notFound: true});
+        setQueryResponseMock({loading: false, data: {jcr: {result: []}}, error: undefined});
+        expect(useMediaPickerInputData('uuid', {lang: 'fr'})).toEqual({loading: false, error: undefined, notFound: true});
     });
 
     it('should adapt data when graphql return some data', () => {


### PR DESCRIPTION
### Description
Make sure that notFound returns true only when request for picker data found nothing. This avoids a false positive which leads to incorrect error message shown.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
