### PR TITLE
fix: Update logic for limiting child nodes on create

### DIFF
--- a/src/javascript/ContentEditor/actions/jcontent/createContent/createContent.utils.js
+++ b/src/javascript/ContentEditor/actions/jcontent/createContent/createContent.utils.js
@@ -12,7 +12,7 @@ export const useCreatableNodetypesTree = ({nodeTypes, childNodeName, includeSubT
         fetchPolicy: 'cache-and-network',
         notifyOnNetworkStatusChange: true,
         variables: {
-            nodeTypes: (nodeTypes && nodeTypes.length) > 0 ? nodeTypes : undefined,
+            nodeTypes: nodeTypes,
             childNodeName,
             includeSubTypes,
             uilang,

--- a/src/javascript/JContent/EditFrame/InsertionPoints.jsx
+++ b/src/javascript/JContent/EditFrame/InsertionPoints.jsx
@@ -4,6 +4,14 @@ import PropTypes from 'prop-types';
 import {useButtonsData} from '~/JContent/EditFrame/Boxes/dataHooks/useButtonsData';
 import {useSelector} from 'react-redux';
 import {usePasteData} from '~/JContent/EditFrame/Boxes/dataHooks/usePasteData';
+import {JahiaRenderedModulesUtil} from '../JContent.utils';
+
+/**
+ * Resolves the parent module's JCR path from a child element's data-jahia-parent attribute.
+ */
+const resolveParentPath = e => {
+    return e.dataset.jahiaParent && e.ownerDocument.getElementById(e.dataset.jahiaParent)?.getAttribute('path');
+};
 
 /**
  * This function helps resolve required nodetypes for insertion points.
@@ -30,46 +38,15 @@ import {usePasteData} from '~/JContent/EditFrame/Boxes/dataHooks/usePasteData';
  * 4. There is a placeholder child with path="*" AND nodetype info defined then we use this nodetype info (see comment above).
  * 5. There is also potential for the case when there is placehoder with nodetype info and one without, in which case we want to get data for nodetypes from both locations.
  */
-const getNodeTypes = e => {
+const getPlaceholderNodeTypes = (e, parentPath) => {
     // The element is placeholder with nodetypes defined, it gives us all the info we need.
     const ownNt = e.getAttribute('nodetypes');
-    if (ownNt && e.getAttribute('type') === 'placeholder') {
+    if (ownNt) {
         return ownNt.split(' ');
     }
 
-    const parentId = e.dataset.jahiaParent;
-    if (!parentId) {
-        return [];
-    }
-
-    const parent = e.ownerDocument.getElementById(parentId);
-    if (!parent) {
-        return [];
-    }
-
-    // If the element is not a placeholder with nodetypes on it, we need to extract nodetype info from existing placeholders on the parent module or the parent module.
-    // There can be different cases. The idea is to determine if placeholders provide all the info we need (they do if they all have nodetypes attribute) or if we need to use a
-    // combination of placeholder-parent or just parent.
-    const parentNt = parent.getAttribute('nodetypes');
-    const parentTypes = parentNt ? parentNt.split(' ') : [];
-
-    // Check for wildcard placeholders (path="*") — their nodetypes take priority
-    const wildcardPlaceholders = [...parent.querySelectorAll(
-        `[type="placeholder"][path="*"][data-jahia-parent="${parentId}"]`
-    )];
-
-    // No placeholders found, nothing to insert
-    if (wildcardPlaceholders.length === 0) {
-        return [];
-    }
-
-    // If any wildcard placeholder has no nodetypes, include parent types as well
-    const hasUntypedWildcard = wildcardPlaceholders.some(wp => !wp.getAttribute('nodetypes'));
-    const wildcardTypes = wildcardPlaceholders
-        .flatMap(wp => wp.getAttribute('nodetypes')?.split(' ') ?? []);
-
-    const merged = hasUntypedWildcard ? [...parentTypes, ...wildcardTypes] : wildcardTypes;
-    return [...new Set(merged)];
+    // Fallback: resolve wildcard placeholder nodetypes from pre-computed module info
+    return JahiaRenderedModulesUtil.resolveNodeTypes(parentPath);
 };
 
 const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCallback, onSaved}) => {
@@ -77,22 +54,28 @@ const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCal
     const clickedPath = clickedElement.element.getAttribute('path');
 
     const originalInsertionButtons = [...currentDocument.querySelectorAll(`[type="placeholder"][data-jahia-parent=${clickedElement.element.id}]`)]
-        .map(e => ({
-            element: e,
-            node: nodes?.[e.dataset.jahiaParent && e.ownerDocument.getElementById(e.dataset.jahiaParent).getAttribute('path')],
-            attributes: {nodeTypes: getNodeTypes(e)}
-        }))
+        .map(e => {
+            const parentPath = resolveParentPath(e);
+            return {
+                element: e,
+                node: nodes?.[parentPath],
+                attributes: {nodeTypes: getPlaceholderNodeTypes(e, parentPath)}
+            };
+        })
         .filter(({node}) => node !== null && node !== undefined);
 
     // Get all children of the clicked element that are [type="existingNode"] and add insertion points for each (insertion points appear on top)
     const childrenElem = [...currentDocument.querySelectorAll(`[data-jahia-parent=${clickedElement.element.id}]`)]
         // Need to make sure that existingNode is not a weakreference but a subnode, which we can do by checking subpath
         .filter(e => e.getAttribute('path')?.startsWith(clickedPath) && e.getAttribute('type') !== 'placeholder')
-        .map(e => ({
-            element: e,
-            node: nodes?.[e.dataset.jahiaParent && e.ownerDocument.getElementById(e.dataset.jahiaParent).getAttribute('path')],
-            attributes: {nodeTypes: getNodeTypes(e)}
-        }))
+        .map(e => {
+            const parentPath = resolveParentPath(e);
+            return {
+                element: e,
+                node: nodes?.[parentPath],
+                attributes: {nodeTypes: JahiaRenderedModulesUtil.resolveNodeTypes(parentPath)}
+            };
+        })
         .filter(({node, attributes}) => node !== null && node !== undefined && attributes.nodeTypes.length > 0);
 
     // Check only first two elements to know alignment.

--- a/src/javascript/JContent/EditFrame/InsertionPoints.jsx
+++ b/src/javascript/JContent/EditFrame/InsertionPoints.jsx
@@ -76,7 +76,7 @@ const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCal
                 attributes: {nodeTypes: JahiaRenderedModulesUtil.resolveNodeTypes(parentPath)}
             };
         })
-        .filter(({node, attributes}) => node !== null && node !== undefined && attributes.nodeTypes.length > 0);
+        .filter(({node, attributes}) => node !== null && node !== undefined && attributes?.nodeTypes?.length > 0);
 
     // Check only first two elements to know alignment.
     const isVertical = childrenElem.length > 1 && childrenElem[1].element.getBoundingClientRect().left > childrenElem[0].element.getBoundingClientRect().left;

--- a/src/javascript/JContent/EditFrame/InsertionPoints.jsx
+++ b/src/javascript/JContent/EditFrame/InsertionPoints.jsx
@@ -58,8 +58,9 @@ const getNodeTypes = e => {
         `[type="placeholder"][path="*"][data-jahia-parent="${parentId}"]`
     )];
 
+    // No placeholders found, nothing to insert
     if (wildcardPlaceholders.length === 0) {
-        return parentTypes;
+        return [];
     }
 
     // If any wildcard placeholder has no nodetypes, include parent types as well
@@ -92,7 +93,7 @@ const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCal
             node: nodes?.[e.dataset.jahiaParent && e.ownerDocument.getElementById(e.dataset.jahiaParent).getAttribute('path')],
             attributes: {nodeTypes: getNodeTypes(e)}
         }))
-        .filter(({node}) => node !== null && node !== undefined);
+        .filter(({node, attributes}) => node !== null && node !== undefined && attributes.nodeTypes.length > 0);
 
     // Check only first two elements to know alignment.
     const isVertical = childrenElem.length > 1 && childrenElem[1].element.getBoundingClientRect().left > childrenElem[0].element.getBoundingClientRect().left;

--- a/src/javascript/JContent/JContent.utils.js
+++ b/src/javascript/JContent/JContent.utils.js
@@ -381,22 +381,25 @@ export const JahiaRenderedModulesUtil = {
     resolveNodeTypes: function (path) {
         const moduleInfo = this.getModule(path);
         const placeholderNodeTypes = [];
-        const moduleNodeTypes = [];
         let containsAnyNodeTypeWildCard = false;
 
         moduleInfo?.forEach(item => {
-            if (item.path === '*' && item.nodeTypes?.length > 0) {
-                if (item.placeholder) {
-                    placeholderNodeTypes.push(...item.nodeTypes);
-                } else {
-                    moduleNodeTypes.push(...item.nodeTypes);
-                }
-            } else if (item.path === '*' && !item.nodeTypes && item.placeholder) {
+            if (item.placeholder && item.path === '*' && item.nodeTypes?.length > 0) {
+                placeholderNodeTypes.push(...item.nodeTypes);
+            } else if (item.placeholder && item.path === '*' && !item.nodeTypes) {
                 containsAnyNodeTypeWildCard = true;
             }
         });
 
-        return containsAnyNodeTypeWildCard ? [...moduleNodeTypes, ...placeholderNodeTypes] : placeholderNodeTypes;
+        if (containsAnyNodeTypeWildCard) {
+            // Wildcard placeholder without nodetypes means "accept parent's types too"
+            const parentTypes = moduleInfo
+                ?.filter(item => !item.placeholder && item.path === '*' && item.nodeTypes?.length > 0)
+                .flatMap(item => item.nodeTypes) || [];
+            return [...parentTypes, ...placeholderNodeTypes];
+        }
+
+        return placeholderNodeTypes;
     },
     extractModuleInfoFromRenderedPage: function (pagePath, language, template) {
         const renderMode = 'editframe';

--- a/src/javascript/JContent/JContent.utils.js
+++ b/src/javascript/JContent/JContent.utils.js
@@ -380,6 +380,11 @@ export const JahiaRenderedModulesUtil = {
     // This simply collects all placeholder nodetypes for a module, it uses module nodetypes if wildcard placeholder without nodetypes is found.
     resolveNodeTypes: function (path) {
         const moduleInfo = this.getModule(path);
+
+        if (!moduleInfo) {
+            return undefined;
+        }
+
         const placeholderNodeTypes = [];
         let containsAnyNodeTypeWildCard = false;
 

--- a/src/javascript/JContent/JContent.utils.js
+++ b/src/javascript/JContent/JContent.utils.js
@@ -419,8 +419,11 @@ export const JahiaRenderedModulesUtil = {
         }).then(resp => {
             const dom = new DOMParser().parseFromString(resp, 'text/html');
 
+            // Placeholder per module information extraction
+            const placeholdersByParent = {};
+
             // Area-specific information extraction
-            dom.querySelectorAll('[jahiatype="module"]:not([type="placeholder"])').forEach(element => {
+            dom.querySelectorAll('[jahiatype="module"]').forEach(element => {
                 const modulePath = element.getAttribute('path');
                 const elemType = element.getAttribute('type');
                 const nodeTypes = element.getAttribute('nodetypes')?.split(' ');
@@ -429,31 +432,28 @@ export const JahiaRenderedModulesUtil = {
                 if (modulePath !== '*' && modulePath !== pagePath && (elemType === 'area' || elemType === 'absoluteArea')) {
                     this.addArea(modulePath, {elemType, nodeTypes, limit: Number(limit)});
                 }
-            });
 
-            // Placeholder per module information extraction
-            const placeholdersByParent = {};
-            dom.querySelectorAll('[jahiatype="module"][type="placeholder"]').forEach(placeholder => {
-                const ancestor = placeholder.parentElement?.closest('[jahiatype="module"]');
-                const ancestorPath = ancestor?.getAttribute('path');
-                if (ancestorPath) {
-                    if (!placeholdersByParent[ancestorPath]) {
-                        placeholdersByParent[ancestorPath] = [];
-                        const ancestorNt = ancestor.getAttribute('nodetypes')?.split(' ');
-                        if (ancestorNt) {
-                            placeholdersByParent[ancestorPath].push({
+                if (elemType === 'placeholder') {
+                    const ancestor = element.parentElement?.closest('[jahiatype="module"]');
+                    const ancestorPath = ancestor?.getAttribute('path');
+                    if (ancestorPath) {
+                        placeholdersByParent[ancestorPath].push({
+                            path: element.getAttribute('path'),
+                            nodeTypes: element.getAttribute('nodetypes')?.split(' '),
+                            placeholder: true
+                        });
+                    }
+                } else {
+                    if (!placeholdersByParent[modulePath]) {
+                        placeholdersByParent[modulePath] = [];
+                        if (nodeTypes) {
+                            placeholdersByParent[modulePath].push({
                                 path: '*',
-                                nodeTypes: ancestorNt,
+                                nodeTypes: nodeTypes,
                                 placeholder: false
                             });
                         }
                     }
-
-                    placeholdersByParent[ancestorPath].push({
-                        path: placeholder.getAttribute('path'),
-                        nodeTypes: placeholder.getAttribute('nodetypes')?.split(' '),
-                        placeholder: true
-                    });
                 }
             });
 

--- a/src/javascript/JContent/JContent.utils.js
+++ b/src/javascript/JContent/JContent.utils.js
@@ -378,6 +378,7 @@ export const JahiaRenderedModulesUtil = {
         return this.jahiaAreas[path];
     },
     // This simply collects all placeholder nodetypes for a module, it uses module nodetypes if wildcard placeholder without nodetypes is found.
+    // It's supposed to return undefined if module is not found and an empty list if no wildcard placeholder is found.
     resolveNodeTypes: function (path) {
         const moduleInfo = this.getModule(path);
 
@@ -422,7 +423,6 @@ export const JahiaRenderedModulesUtil = {
             // Placeholder per module information extraction
             const placeholdersByParent = {};
 
-            // Area-specific information extraction
             dom.querySelectorAll('[jahiatype="module"]').forEach(element => {
                 const modulePath = element.getAttribute('path');
                 const elemType = element.getAttribute('type');
@@ -437,22 +437,24 @@ export const JahiaRenderedModulesUtil = {
                     const ancestor = element.parentElement?.closest('[jahiatype="module"]');
                     const ancestorPath = ancestor?.getAttribute('path');
                     if (ancestorPath) {
+                        if (!placeholdersByParent[ancestorPath]) {
+                            placeholdersByParent[ancestorPath] = [];
+                        }
+
                         placeholdersByParent[ancestorPath].push({
                             path: element.getAttribute('path'),
                             nodeTypes: element.getAttribute('nodetypes')?.split(' '),
                             placeholder: true
                         });
                     }
-                } else {
-                    if (!placeholdersByParent[modulePath]) {
-                        placeholdersByParent[modulePath] = [];
-                        if (nodeTypes) {
-                            placeholdersByParent[modulePath].push({
-                                path: '*',
-                                nodeTypes: nodeTypes,
-                                placeholder: false
-                            });
-                        }
+                } else if (!placeholdersByParent[modulePath]) {
+                    placeholdersByParent[modulePath] = [];
+                    if (nodeTypes) {
+                        placeholdersByParent[modulePath].push({
+                            path: '*',
+                            nodeTypes,
+                            placeholder: false
+                        });
                     }
                 }
             });

--- a/tests/cypress/e2e/contentEditor/createContentConstraints.cy.ts
+++ b/tests/cypress/e2e/contentEditor/createContentConstraints.cy.ts
@@ -56,6 +56,25 @@ describe('Create content constraints', () => {
         });
 
         addNode({
+            name: 'page-one-multiple-limit',
+            parentPathOrId: homePath,
+            primaryNodeType: 'jnt:page',
+            properties: [
+                {name: 'jcr:title', value: 'One Multiple Limit Two Page', language: 'en'},
+                {name: 'j:templateName', value: 'simple'}
+            ],
+            children: [{
+                name: 'area-main',
+                primaryNodeType: 'jnt:contentList',
+                mixins: ['jmix:isAreaList'],
+                children: [{
+                    name: 'test-one-multiple-limit',
+                    primaryNodeType: 'cent:oneMultipleWithLimitTwo'
+                }]
+            }]
+        });
+
+        addNode({
             name: 'page-two-multiple-named',
             parentPathOrId: homePath,
             primaryNodeType: 'jnt:page',
@@ -196,5 +215,32 @@ describe('Create content constraints', () => {
         contextMenu.shouldHaveItem('New childObject1');
         contextMenu.shouldHaveItem('New childObject2');
     });
-});
 
+    it('resolves create actions correctly for single wildcard type that can be created multiple times with a limit', () => {
+        const jcontent = JContent
+            .visit(siteKey, 'en', 'pages/home/page-one-multiple-limit')
+            .switchToStructuredView();
+
+        // The single wildcard child type should be available
+        let contextMenu = jcontent.getTable().getRowByLabel('test-one-multiple-limit').contextMenu();
+        contextMenu.shouldHaveItem('New childObject1');
+
+        // Create childObject1
+        contextMenu.select('New childObject1');
+        let contentEditor = new ContentEditor();
+        contentEditor.create();
+
+        // Verify it is still available after creation (wildcard allows multiple)
+        contextMenu = jcontent.getTable().getRowByLabel('test-one-multiple-limit').contextMenu();
+        contextMenu.shouldHaveItem('New childObject1');
+
+        // Create another childObject1
+        contextMenu.select('New childObject1');
+        contentEditor = new ContentEditor();
+        contentEditor.create();
+
+        // Verify it is still available
+        contextMenu = jcontent.getTable().getRowByLabel('test-one-multiple-limit').contextMenu();
+        contextMenu.shouldNotHaveItem('New childObject1');
+    });
+});

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -271,6 +271,10 @@
  + * (cent:childObject1)
  + * (cent:childObject2)
 
+[cent:oneMultipleWithLimitTwo] > jnt:content, jmix:basicContent, jmix:editorialContent
+ - someProperty (string)
+ + * (cent:childObject1)
+
 [cent:twoMultipleOneNamed] > jnt:content, jmix:basicContent, jmix:editorialContent
  - someProperty (string)
  + * (cent:childObject1)

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/cent_oneMultipleWithLimitTwo/html/oneMultipleWithLimitTwo.jsp
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/cent_oneMultipleWithLimitTwo/html/oneMultipleWithLimitTwo.jsp
@@ -1,0 +1,35 @@
+<%@ page language="java" contentType="text/html;charset=UTF-8" %>
+<%@ taglib prefix="template" uri="http://www.jahia.org/tags/templateLib" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="jcr" uri="http://www.jahia.org/tags/jcr" %>
+<%@ taglib prefix="ui" uri="http://www.jahia.org/tags/uiComponentsLib" %>
+<%@ taglib prefix="functions" uri="http://www.jahia.org/tags/functions" %>
+<%@ taglib prefix="query" uri="http://www.jahia.org/tags/queryLib" %>
+<%@ taglib prefix="utility" uri="http://www.jahia.org/tags/utilityLib" %>
+<%@ taglib prefix="s" uri="http://www.jahia.org/tags/search" %>
+<%--@elvariable id="currentNode" type="org.jahia.services.content.JCRNodeWrapper"--%>
+<%--@elvariable id="out" type="java.io.PrintWriter"--%>
+<%--@elvariable id="script" type="org.jahia.services.render.scripting.Script"--%>
+<%--@elvariable id="scriptInfo" type="java.lang.String"--%>
+<%--@elvariable id="workspace" type="java.lang.String"--%>
+<%--@elvariable id="renderContext" type="org.jahia.services.render.RenderContext"--%>
+<%--@elvariable id="currentResource" type="org.jahia.services.render.Resource"--%>
+<%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
+oneMultipleWithLimitTwo
+
+<c:set var="children1" value="${jcr:getChildrenOfType(currentNode, 'cent:childObject1')}"/>
+
+<c:if test="${renderContext.editMode}">
+    <c:forEach var="child" items="${children1}">
+        <template:module node="${child}"/>
+    </c:forEach>
+    <c:if test="${fn:length(children1) lt 2}">
+        <div>
+            <div>
+                <template:module path="*" nodeTypes="cent:childObject1"/>
+            </div>
+        </div>
+    </c:if>
+</c:if>


### PR DESCRIPTION
### Description
Update logic and tests. I reuse module utils where possible as the logic is almost exactly the same. I added some edge case fixes for when module is not found and no placeholders can be resolved and when module is found but contains no active placeholders in which case we dan't want to display anything.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
