### PR TITLE
fix: Add constraints on BoxesContextMenu

### DIFF
--- a/.chachalog/RX6gPpKZ.md
+++ b/.chachalog/RX6gPpKZ.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": patch
+---
+
+Prevent context menu from showing on page target in Page Builder (#2445)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ The repo extends `@jahia/eslint-config` (`.eslintrc.json`). Key rules to always 
 - Destructure props and state where it improves readability.
 - Boolean prop names must match `^((is|has)[A-Z]([A-Za-z0-9]?)+|allow|hide|show)` (per `react/boolean-prop-naming`).
 - React hooks: respect `react-hooks/exhaustive-deps` — list every reactive value used in a hook in its dependency array.
+- **For `data-*` attributes, use the `.dataset` API, never `getAttribute`/`setAttribute`** (per `prefer-dom-node-dataset`). Read with `element.dataset.jahiaPath`, write with `element.dataset.jahiaPath = value` — not `element.getAttribute('data-jahia-path')`. The kebab-case attribute (`data-jahia-path`) maps to the camelCase dataset key (`jahiaPath`). `getAttribute`/`setAttribute` remain correct for non-`data-` attributes (e.g. `jahiatype`, `path`).
 
 ## React conventions
 

--- a/src/javascript/JContent/EditFrame/Boxes/BoxesContextMenu.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/BoxesContextMenu.jsx
@@ -3,6 +3,58 @@ import {ContextualMenu} from '@jahia/ui-extender';
 import PropTypes from 'prop-types';
 import {useHoverContext} from '~/JContent/EditFrame/Boxes/HoverContext';
 
+// Right-clicks on a breadcrumb/dropdown item are handled specially (and never open the content menu).
+// Returns true when the event was a breadcrumb click and has been handled.
+const handleBreadcrumbFooter = event => {
+    if (!event.target?.closest('[data-sel-role="pagebuilder-itempath-dropdown"]')) {
+        return false;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    // Ctrl + click counts as a right click and triggers contextmenu; forward it as a real click.
+    if (event.ctrlKey) {
+        event.target.dispatchEvent(new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+            ctrlKey: true,
+            detail: 1,
+            screenX: event.screenX,
+            screenY: event.screenY,
+            clientX: event.clientX,
+            clientY: event.clientY
+        }));
+    }
+
+    return true;
+};
+
+// Resolve the element actually under the cursor at right-click time. Relying on the hovered path is
+// unsafe: it goes stale (e.g. when moving onto the page without a hover-out firing), which used to open
+// the menu for the wrong element or fall back to selecting the whole page. The box body overlay is
+// pointer-events:none, so event.target there is whatever shows through (sometimes a page gap with no
+// module). Inspecting the whole stack under the cursor pierces pointer-events:none, and the topmost
+// element resolving to a data-jahia-path wins (content modules and their box overlays both expose it).
+const resolveTargetPath = (frameDocument, event) => {
+    const stack = Array.from(frameDocument.elementsFromPoint?.(event.clientX, event.clientY) ?? [event.target]);
+    return stack
+        .map(element => element?.closest?.('[data-jahia-path]'))
+        .find(Boolean)
+        ?.getAttribute('data-jahia-path');
+};
+
+// Build the ContextualMenu target props for a given path, honoring the current selection.
+const buildMenuProps = (targetPath, selection, nodes) => {
+    const node = nodes?.[targetPath];
+    if (selection.length > 0 && selection.includes(targetPath)) {
+        const scope = selection.length === 1 ? {path: selection[0], paths: undefined} : {path: undefined, paths: selection};
+        return {...scope, actionKey: 'selectedContentMenu', currentPath: targetPath, node};
+    }
+
+    const actionKey = selection.length > 0 ? 'notSelectedContentMenu' : 'contentItemContextActionsMenu';
+    return {path: targetPath, paths: undefined, actionKey, currentPath: targetPath, node};
+};
+
 /**
  * @deprecated since version 3.4.0 https://github.com/Jahia/jcontent/pull/1879
  * This component will be removed in version 4.0.0.
@@ -26,43 +78,11 @@ const BoxesContextMenu = ({currentFrameRef, currentDocument, selection, nodes}) 
 
     useEffect(() => {
         currentDocument.documentElement.querySelector('body').addEventListener('contextmenu', event => {
-            // Detects element to be a breadcrumb item or list item found in dropdown menus
-            const clickInBreadcrumbFooter = Boolean(event.target?.closest('[data-sel-role="pagebuilder-itempath-dropdown"]'));
-
-            // Prevent showing contextual menu if clicked on breadcrumb, note that ctrl + click counts as right click and triggers contextmenu
-            if (clickInBreadcrumbFooter) {
-                event.preventDefault();
-                event.stopPropagation();
-                // Ignore for right click and other button + click combinations
-                if (event.ctrlKey) {
-                    const clickEvent = new MouseEvent('click', {
-                        bubbles: true,
-                        cancelable: true,
-                        ctrlKey: true,
-                        detail: 1,
-                        screenX: event.screenX,
-                        screenY: event.screenY,
-                        clientX: event.clientX,
-                        clientY: event.clientY
-                    });
-                    event.target.dispatchEvent(clickEvent);
-                }
-
+            if (handleBreadcrumbFooter(event)) {
                 return;
             }
 
-            // Resolve the element actually under the cursor at right-click time. Relying on the hovered
-            // path is unsafe: it goes stale (e.g. when moving onto the page without a hover-out fires),
-            // which used to open the menu for the wrong element or fall back to selecting the whole page.
-            // The box body overlay is pointer-events:none, so event.target there is whatever shows through
-            // (sometimes a page gap with no module). Inspect the whole stack under the cursor, which pierces
-            // pointer-events:none, and use the topmost element resolving to a data-jahia-path (content
-            // modules and their box overlays both expose it).
-            const stack = Array.from(currentDocument.elementsFromPoint?.(event.clientX, event.clientY) || [event.target]);
-            const targetPath = stack
-                .map(element => element?.closest?.('[data-jahia-path]'))
-                .find(Boolean)
-                ?.getAttribute('data-jahia-path');
+            const targetPath = resolveTargetPath(currentDocument, event);
 
             // Nothing selectable under the cursor (e.g. empty area / page background): do not open a menu
             // for a stale target or fall back to the page.
@@ -71,21 +91,7 @@ const BoxesContextMenu = ({currentFrameRef, currentDocument, selection, nodes}) 
                 return;
             }
 
-            // Target the element under the cursor, mirroring the selection-aware action keys below.
-            const currentSelection = selectionRef.current;
-            let menuProps;
-            if (currentSelection.length > 1 && currentSelection.includes(targetPath)) {
-                menuProps = {path: undefined, paths: currentSelection, actionKey: 'selectedContentMenu'};
-            } else if (currentSelection.includes(targetPath)) {
-                menuProps = {path: targetPath, paths: undefined, actionKey: 'selectedContentMenu'};
-            } else if (currentSelection.length > 0) {
-                menuProps = {path: targetPath, paths: undefined, actionKey: 'notSelectedContentMenu'};
-            } else {
-                menuProps = {path: targetPath, paths: undefined, actionKey: 'contentItemContextActionsMenu'};
-            }
-
-            menuProps.currentPath = targetPath;
-            menuProps.node = nodesRef.current?.[targetPath];
+            const menuProps = buildMenuProps(targetPath, selectionRef.current, nodesRef.current);
 
             // Show context menu for the resolved target
             const rect = currentFrameRef.current.getBoundingClientRect();
@@ -99,25 +105,11 @@ const BoxesContextMenu = ({currentFrameRef, currentDocument, selection, nodes}) 
         });
     }, [currentDocument, currentFrameRef]);
 
-    let pathObject = {};
-    if (selection.length > 0) {
-        if (selection.includes(currentPath)) {
-            pathObject = selection.length === 1 ? {path: selection[0]} : {paths: selection};
-            pathObject.actionKey = 'selectedContentMenu';
-        } else {
-            pathObject = {path: currentPath, actionKey: 'notSelectedContentMenu'};
-        }
-    } else {
-        pathObject = {path: currentPath, actionKey: 'contentItemContextActionsMenu'};
-    }
-
     return (
         <ContextualMenu
             setOpenRef={contextualMenu}
-            currentPath={currentPath}
             documentElement={currentDocument.documentElement}
-            node={nodes?.[currentPath]}
-            {...pathObject}
+            {...buildMenuProps(currentPath, selection, nodes)}
         />
     );
 };

--- a/src/javascript/JContent/EditFrame/Boxes/BoxesContextMenu.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/BoxesContextMenu.jsx
@@ -17,6 +17,13 @@ const BoxesContextMenu = ({currentFrameRef, currentDocument, selection, nodes}) 
     const contextualMenu = useRef();
     const {hoveredPath: currentPath} = useHoverContext();
 
+    // The contextmenu listener below is registered once and is long-lived, so it would otherwise
+    // capture stale values. Mirror the latest selection/nodes into refs so the handler reads fresh data.
+    const selectionRef = useRef(selection);
+    selectionRef.current = selection;
+    const nodesRef = useRef(nodes);
+    nodesRef.current = nodes;
+
     useEffect(() => {
         currentDocument.documentElement.querySelector('body').addEventListener('contextmenu', event => {
             // Detects element to be a breadcrumb item or list item found in dropdown menus
@@ -44,14 +51,50 @@ const BoxesContextMenu = ({currentFrameRef, currentDocument, selection, nodes}) 
                 return;
             }
 
-            // Show context menu
+            // Resolve the element actually under the cursor at right-click time. Relying on the hovered
+            // path is unsafe: it goes stale (e.g. when moving onto the page without a hover-out fires),
+            // which used to open the menu for the wrong element or fall back to selecting the whole page.
+            // The box body overlay is pointer-events:none, so event.target there is whatever shows through
+            // (sometimes a page gap with no module). Inspect the whole stack under the cursor, which pierces
+            // pointer-events:none, and use the topmost element resolving to a data-jahia-path (content
+            // modules and their box overlays both expose it).
+            const stack = Array.from(currentDocument.elementsFromPoint?.(event.clientX, event.clientY) || [event.target]);
+            const targetPath = stack
+                .map(element => element?.closest?.('[data-jahia-path]'))
+                .find(Boolean)
+                ?.getAttribute('data-jahia-path');
+
+            // Nothing selectable under the cursor (e.g. empty area / page background): do not open a menu
+            // for a stale target or fall back to the page.
+            if (!targetPath) {
+                event.preventDefault();
+                return;
+            }
+
+            // Target the element under the cursor, mirroring the selection-aware action keys below.
+            const currentSelection = selectionRef.current;
+            let menuProps;
+            if (currentSelection.length > 1 && currentSelection.includes(targetPath)) {
+                menuProps = {path: undefined, paths: currentSelection, actionKey: 'selectedContentMenu'};
+            } else if (currentSelection.includes(targetPath)) {
+                menuProps = {path: targetPath, paths: undefined, actionKey: 'selectedContentMenu'};
+            } else if (currentSelection.length > 0) {
+                menuProps = {path: targetPath, paths: undefined, actionKey: 'notSelectedContentMenu'};
+            } else {
+                menuProps = {path: targetPath, paths: undefined, actionKey: 'contentItemContextActionsMenu'};
+            }
+
+            menuProps.currentPath = targetPath;
+            menuProps.node = nodesRef.current?.[targetPath];
+
+            // Show context menu for the resolved target
             const rect = currentFrameRef.current.getBoundingClientRect();
             const dup = new MouseEvent(event.type, {
                 ...event,
                 clientX: event.clientX + rect.x,
                 clientY: event.clientY + rect.y
             });
-            contextualMenu.current(dup);
+            contextualMenu.current(dup, menuProps);
             event.preventDefault();
         });
     }, [currentDocument, currentFrameRef]);

--- a/src/javascript/JContent/EditFrame/Boxes/BoxesContextMenu.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/BoxesContextMenu.jsx
@@ -40,7 +40,7 @@ const resolveTargetPath = (frameDocument, event) => {
     return stack
         .map(element => element?.closest?.('[data-jahia-path]'))
         .find(Boolean)
-        ?.getAttribute('data-jahia-path');
+        ?.dataset.jahiaPath;
 };
 
 // Build the ContextualMenu target props for a given path, honoring the current selection.

--- a/tests/cypress/e2e/pageBuilder/contentManipulation.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/contentManipulation.cy.ts
@@ -75,4 +75,26 @@ describe('Page builder - content manipulation', () => {
         cy.log('Verify no error occurred and the main area is still visible');
         jcontent.getModule(areaPath).get().should('be.visible');
     });
+
+    /**
+     * Right-clicking an empty area (no selectable content under the cursor) must not open a context
+     * menu for the page or for a stale, previously-hovered element. It previously fell back to the
+     * page, so "Delete" removed the whole page. The target is now resolved from the element actually
+     * under the cursor, so a stale hover no longer leaks into the menu.
+     */
+    it('Does not target the page or a stale hovered element when right-clicking an empty area', () => {
+        cy.get('[data-sel-role="selection-infos"]').should('not.exist');
+
+        cy.log('Hover a content element so a hovered target exists, then right-click empty page space');
+        jcontent.getModule(contentListPath).hover();
+
+        cy.log('Right-click the page area where no content is under the cursor');
+        jcontent.getMainModule(homePath).get().rightclick('topLeft', {force: true});
+
+        cy.log('No context menu must open - it must not fall back to the page or the stale hovered element');
+        cy.get('#menuHolder .moonstone-menu:not(.moonstone-hidden)').should('not.exist');
+
+        cy.log('And nothing must become selected');
+        cy.get('[data-sel-role="selection-infos"]').should('not.exist');
+    });
 });

--- a/tests/cypress/e2e/pageBuilder/contentManipulation.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/contentManipulation.cy.ts
@@ -77,24 +77,22 @@ describe('Page builder - content manipulation', () => {
     });
 
     /**
-     * Right-clicking an empty area (no selectable content under the cursor) must not open a context
-     * menu for the page or for a stale, previously-hovered element. It previously fell back to the
-     * page, so "Delete" removed the whole page. The target is now resolved from the element actually
-     * under the cursor, so a stale hover no longer leaks into the menu.
+     * Right-clicking an empty area (nothing selected, no selectable content under the cursor)
+     * must not fall back to the page. It previously opened a context menu targeting the page,
+     * so "Delete" removed the whole page. Desired behavior: if nothing is selected or selectable,
+     * the page should not be selected by default.
      */
-    it('Does not target the page or a stale hovered element when right-clicking an empty area', () => {
+    it('Does not target the page when right-clicking an empty area with nothing selected', () => {
+        cy.log('Nothing is selected initially');
         cy.get('[data-sel-role="selection-infos"]').should('not.exist');
 
-        cy.log('Hover a content element so a hovered target exists, then right-click empty page space');
-        jcontent.getModule(contentListPath).hover();
-
-        cy.log('Right-click the page area where no content is under the cursor');
+        cy.log('Right-click the page area without hovering or selecting any content');
         jcontent.getMainModule(homePath).get().rightclick('topLeft', {force: true});
 
-        cy.log('No context menu must open - it must not fall back to the page or the stale hovered element');
+        cy.log('The context menu must not open (it used to target the page)');
         cy.get('#menuHolder .moonstone-menu:not(.moonstone-hidden)').should('not.exist');
 
-        cy.log('And nothing must become selected');
+        cy.log('And the page must not become selected');
         cy.get('[data-sel-role="selection-infos"]').should('not.exist');
     });
 });


### PR DESCRIPTION
### Description
Add constraints on BoxesContextMenu to prevent it from showing on jnt:page targets.
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
