### PR TITLE
fix: language switch no longer remounts the content editor form

### DIFF
--- a/.chachalog/pi1abfXf.md
+++ b/.chachalog/pi1abfXf.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": patch
+---
+
+Switching the editing language no longer reloads the content editor

--- a/src/javascript/ContentEditor/ContentEditor/Edit.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/Edit.jsx
@@ -66,6 +66,7 @@ export const Edit = () => {
         <>
             <PublicationInfoContextProvider uuid={nodeData.uuid} lang={lang}>
                 <Formik
+                    enableReinitialize
                     validateOnMount
                     validateOnChange={false}
                     initialValues={initialValues}

--- a/src/javascript/ContentEditor/ContentEditor/Edit.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/Edit.jsx
@@ -62,12 +62,9 @@ export const Edit = () => {
         });
     }, [client, t, notificationContext, editCallback, contentEditorConfigContext, lang, nodeData, sections, i18nContext]);
 
-    // With enableReinitialize, Formik resets values whenever the initialValues REFERENCE changes.
-    // The adapter can recompute initialValues (same content, new identity) on incidental re-renders;
-    // letting those through resets in-progress edits — e.g. a just-toggled mixin fieldset collapses
-    // mid-interaction (mixins.cy.ts race). Only hand Formik a new reference when it may legitimately
-    // differ: language switch or a different node. Same-lang/same-node keeps pre-#2447 semantics
-    // (never reinitialize); imperative resetForm calls (save) are unaffected.
+    // Formik reinitializes whenever the initialValues REFERENCE changes, and the adapter recomputes
+    // it (same content, new identity) on incidental re-renders — which would reset in-progress
+    // edits. Only hand Formik a new reference on a genuine language or node change.
     const stableInitialValuesRef = useRef({lang, uuid: nodeData.uuid, initialValues});
     if (stableInitialValuesRef.current.lang !== lang || stableInitialValuesRef.current.uuid !== nodeData.uuid) {
         stableInitialValuesRef.current = {lang, uuid: nodeData.uuid, initialValues};

--- a/src/javascript/ContentEditor/ContentEditor/Edit.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/Edit.jsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect} from 'react';
+import React, {useCallback, useEffect, useRef} from 'react';
 import {useNotifications} from '@jahia/react-material';
 import {Formik} from 'formik';
 import {EditPanel} from './EditPanel/EditPanel';
@@ -62,6 +62,17 @@ export const Edit = () => {
         });
     }, [client, t, notificationContext, editCallback, contentEditorConfigContext, lang, nodeData, sections, i18nContext]);
 
+    // With enableReinitialize, Formik resets values whenever the initialValues REFERENCE changes.
+    // The adapter can recompute initialValues (same content, new identity) on incidental re-renders;
+    // letting those through resets in-progress edits — e.g. a just-toggled mixin fieldset collapses
+    // mid-interaction (mixins.cy.ts race). Only hand Formik a new reference when it may legitimately
+    // differ: language switch or a different node. Same-lang/same-node keeps pre-#2447 semantics
+    // (never reinitialize); imperative resetForm calls (save) are unaffected.
+    const stableInitialValuesRef = useRef({lang, uuid: nodeData.uuid, initialValues});
+    if (stableInitialValuesRef.current.lang !== lang || stableInitialValuesRef.current.uuid !== nodeData.uuid) {
+        stableInitialValuesRef.current = {lang, uuid: nodeData.uuid, initialValues};
+    }
+
     return (
         <>
             <PublicationInfoContextProvider uuid={nodeData.uuid} lang={lang}>
@@ -69,7 +80,7 @@ export const Edit = () => {
                     enableReinitialize
                     validateOnMount
                     validateOnChange={false}
-                    initialValues={initialValues}
+                    initialValues={stableInitialValuesRef.current.initialValues}
                     validate={validate(sections)}
                     onSubmit={handleSubmit}
                 >

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelFullscreen.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelFullscreen.jsx
@@ -11,8 +11,13 @@ import {useContentEditorConfigContext} from '~/shared';
 import {CeModalError} from '~/ContentEditor/ContentEditorApi/ContentEditorError';
 
 export const EditPanelFullscreen = ({title}) => {
-    const {advancedOpenTab} = useContentEditorConfigContext();
-    const [activeTab, setActiveTab] = useState(advancedOpenTab ?? Constants.editPanel.editTab);
+    const config = useContentEditorConfigContext();
+    const {advancedOpenTab} = config;
+    // Prefer the active tab persisted on the config (modal-level state that survives a remount of
+    // this subtree during a language-switch refetch — see #2483). Fall back to local state when the
+    // layout is rendered without that wiring (e.g. standalone).
+    const localActiveTab = useState(advancedOpenTab ?? Constants.editPanel.editTab);
+    const [activeTab, setActiveTab] = config.setActiveTab ? [config.activeTab, config.setActiveTab] : localActiveTab;
     const {mode} = useContentEditorContext();
 
     // Without edit tab, no content editor

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelFullscreen.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelFullscreen.jsx
@@ -13,9 +13,8 @@ import {CeModalError} from '~/ContentEditor/ContentEditorApi/ContentEditorError'
 export const EditPanelFullscreen = ({title}) => {
     const config = useContentEditorConfigContext();
     const {advancedOpenTab} = config;
-    // Prefer the active tab persisted on the config (modal-level state that survives a remount of
-    // this subtree during a language-switch refetch — see #2483). Fall back to local state when the
-    // layout is rendered without that wiring (e.g. standalone).
+    // Tab state lives on the modal config so it survives subtree remounts during a language
+    // switch (#2483); fall back to local state when rendered without that wiring.
     const [localActiveTab, setLocalActiveTab] = useState(advancedOpenTab ?? Constants.editPanel.editTab);
     const [activeTab, setActiveTab] = config.setActiveTab ? [config.activeTab, config.setActiveTab] : [localActiveTab, setLocalActiveTab];
     const {mode} = useContentEditorContext();

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelFullscreen.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelFullscreen.jsx
@@ -16,8 +16,8 @@ export const EditPanelFullscreen = ({title}) => {
     // Prefer the active tab persisted on the config (modal-level state that survives a remount of
     // this subtree during a language-switch refetch — see #2483). Fall back to local state when the
     // layout is rendered without that wiring (e.g. standalone).
-    const localActiveTab = useState(advancedOpenTab ?? Constants.editPanel.editTab);
-    const [activeTab, setActiveTab] = config.setActiveTab ? [config.activeTab, config.setActiveTab] : localActiveTab;
+    const [localActiveTab, setLocalActiveTab] = useState(advancedOpenTab ?? Constants.editPanel.editTab);
+    const [activeTab, setActiveTab] = config.setActiveTab ? [config.activeTab, config.setActiveTab] : [localActiveTab, setLocalActiveTab];
     const {mode} = useContentEditorContext();
 
     // Without edit tab, no content editor

--- a/src/javascript/ContentEditor/ContentEditor/useFormDefinitions.js
+++ b/src/javascript/ContentEditor/ContentEditor/useFormDefinitions.js
@@ -45,7 +45,7 @@ export const useFormDefinition = (query, adapter) => {
         // mounted by returning the previous data. On the very first load, propagate loading=true
         // so the initial loader overlay is shown.
         if (loading && previousDataRef.current) {
-            // isRefetching=true tells ContentEditor.context.js to keep serving the previous editorContext
+            // The isRefetching=true flag tells ContentEditor.context.js to keep serving the previous editorContext
             // (with old lang) rather than computing a new one with stale initialValues but new lang.
             // This ensures lang and initialValues transition together when fresh data arrives.
             return {data: previousDataRef.current, refetch, loading: false, isRefetching: true};

--- a/src/javascript/ContentEditor/ContentEditor/useFormDefinitions.js
+++ b/src/javascript/ContentEditor/ContentEditor/useFormDefinitions.js
@@ -1,5 +1,5 @@
 import {useQuery} from '@apollo/client';
-import {useMemo} from 'react';
+import {useMemo, useRef} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useContentEditorConfigContext} from '~/ContentEditor/contexts';
 import {Constants} from '~/ContentEditor/ContentEditor.constants';
@@ -27,13 +27,27 @@ export const useFormDefinition = (query, adapter) => {
         errorPolicy: 'all'
     });
 
+    const previousDataRef = useRef(null);
+
     const dataCached = useMemo(() => {
         if (!error && !loading && data?.jcr) {
             return adapter(data, uilang, t, contentEditorConfigContext);
         }
     }, [data, uilang, t, contentEditorConfigContext, error, loading, adapter]);
 
+    // Track the last successfully adapted result so we can serve it during language-switch refetches
+    if (dataCached !== undefined) {
+        previousDataRef.current = dataCached;
+    }
+
     if (error || loading || !data?.jcr) {
+        // During a language-switch refetch (loading=true but stale data exists), keep the form
+        // mounted by returning the previous data. On the very first load, propagate loading=true
+        // so the initial loader overlay is shown.
+        if (loading && previousDataRef.current) {
+            return {data: previousDataRef.current, refetch, loading: false};
+        }
+
         return {
             loading,
             error,

--- a/src/javascript/ContentEditor/ContentEditor/useFormDefinitions.js
+++ b/src/javascript/ContentEditor/ContentEditor/useFormDefinitions.js
@@ -28,6 +28,7 @@ export const useFormDefinition = (query, adapter) => {
     });
 
     const previousDataRef = useRef(null);
+    const previousLangRef = useRef(null);
 
     const dataCached = useMemo(() => {
         if (!error && !loading && data?.jcr) {
@@ -35,16 +36,19 @@ export const useFormDefinition = (query, adapter) => {
         }
     }, [data, uilang, t, contentEditorConfigContext, error, loading, adapter]);
 
-    // Track the last successfully adapted result so we can serve it during language-switch refetches
+    // Track the last successfully adapted result (and the lang it belongs to) so we can serve it
+    // during language-switch refetches.
     if (dataCached !== undefined) {
         previousDataRef.current = dataCached;
+        previousLangRef.current = lang;
     }
 
     if (error || loading || !data?.jcr) {
-        // During a language-switch refetch (loading=true but stale data exists), keep the form
-        // mounted by returning the previous data. On the very first load, propagate loading=true
-        // so the initial loader overlay is shown.
-        if (loading && previousDataRef.current) {
+        // Keep the form mounted with stale data ONLY for a genuine language switch (lang moved away
+        // from the cached data's lang). Any other refetch (save, mixin toggle, dependent-field
+        // mutation) keeps the original loading behaviour so the form is not held in the
+        // stale/interaction-blocked state that clobbered mixin toggles. See #2447.
+        if (loading && previousDataRef.current && lang !== previousLangRef.current) {
             // The isRefetching=true flag tells ContentEditor.context.js to keep serving the previous editorContext
             // (with old lang) rather than computing a new one with stale initialValues but new lang.
             // This ensures lang and initialValues transition together when fresh data arrives.

--- a/src/javascript/ContentEditor/ContentEditor/useFormDefinitions.js
+++ b/src/javascript/ContentEditor/ContentEditor/useFormDefinitions.js
@@ -36,22 +36,17 @@ export const useFormDefinition = (query, adapter) => {
         }
     }, [data, uilang, t, contentEditorConfigContext, error, loading, adapter]);
 
-    // Track the last successfully adapted result (and the lang it belongs to) so we can serve it
-    // during language-switch refetches.
     if (dataCached !== undefined) {
         previousDataRef.current = dataCached;
         previousLangRef.current = lang;
     }
 
     if (error || loading || !data?.jcr) {
-        // Keep the form mounted with stale data ONLY for a genuine language switch (lang moved away
-        // from the cached data's lang). Any other refetch (save, mixin toggle, dependent-field
-        // mutation) keeps the original loading behaviour so the form is not held in the
-        // stale/interaction-blocked state that clobbered mixin toggles. See #2447.
+        // Serve stale data ONLY during a language-switch refetch (lang moved away from the cached
+        // data's lang) — structural refetches (save, mixin toggle, dependent field) must keep the
+        // loading behaviour or in-progress edits get clobbered. isRefetching tells the context to
+        // keep serving the previous editorContext so lang and initialValues transition together.
         if (loading && previousDataRef.current && lang !== previousLangRef.current) {
-            // The isRefetching=true flag tells ContentEditor.context.js to keep serving the previous editorContext
-            // (with old lang) rather than computing a new one with stale initialValues but new lang.
-            // This ensures lang and initialValues transition together when fresh data arrives.
             return {data: previousDataRef.current, refetch, loading: false, isRefetching: true};
         }
 

--- a/src/javascript/ContentEditor/ContentEditor/useFormDefinitions.js
+++ b/src/javascript/ContentEditor/ContentEditor/useFormDefinitions.js
@@ -45,7 +45,10 @@ export const useFormDefinition = (query, adapter) => {
         // mounted by returning the previous data. On the very first load, propagate loading=true
         // so the initial loader overlay is shown.
         if (loading && previousDataRef.current) {
-            return {data: previousDataRef.current, refetch, loading: false};
+            // isRefetching=true tells ContentEditor.context.js to keep serving the previous editorContext
+            // (with old lang) rather than computing a new one with stale initialValues but new lang.
+            // This ensures lang and initialValues transition together when fresh data arrives.
+            return {data: previousDataRef.current, refetch, loading: false, isRefetching: true};
         }
 
         return {

--- a/src/javascript/ContentEditor/ContentEditorApi/ContentEditorModal.jsx
+++ b/src/javascript/ContentEditor/ContentEditorApi/ContentEditorModal.jsx
@@ -65,10 +65,8 @@ export const ContentEditorModal = ({editorConfig, updateEditorConfig, onExited})
     mergedConfig.sideBySideContext = sideBySideContext;
     mergedConfig.setSideBySideContext = setSideBySideContext;
 
-    // Persist the active editor tab (edit/translate/advanced) here, at the modal level. The modal
-    // never remounts during a language switch (its key is mode_uuid), whereas the editor subtree
-    // below ContentEditorContextProvider can be remounted by a refetch race — which would reset a
-    // local useState back to the edit tab. Keeping it here makes the selected mode survive. See #2483.
+    // The modal never remounts during a language switch, unlike the editor subtree below — keep
+    // the active tab here so the selected mode survives (#2483).
     const [activeTab, setActiveTab] = useState(mergedConfig.advancedOpenTab ?? Constants.editPanel.editTab);
     mergedConfig.activeTab = activeTab;
     mergedConfig.setActiveTab = setActiveTab;

--- a/src/javascript/ContentEditor/ContentEditorApi/ContentEditorModal.jsx
+++ b/src/javascript/ContentEditor/ContentEditorApi/ContentEditorModal.jsx
@@ -65,6 +65,14 @@ export const ContentEditorModal = ({editorConfig, updateEditorConfig, onExited})
     mergedConfig.sideBySideContext = sideBySideContext;
     mergedConfig.setSideBySideContext = setSideBySideContext;
 
+    // Persist the active editor tab (edit/translate/advanced) here, at the modal level. The modal
+    // never remounts during a language switch (its key is mode_uuid), whereas the editor subtree
+    // below ContentEditorContextProvider can be remounted by a refetch race — which would reset a
+    // local useState back to the edit tab. Keeping it here makes the selected mode survive. See #2483.
+    const [activeTab, setActiveTab] = useState(mergedConfig.advancedOpenTab ?? Constants.editPanel.editTab);
+    mergedConfig.activeTab = activeTab;
+    mergedConfig.setActiveTab = setActiveTab;
+
     const {createCallback, editCallback, onClosedCallback} = mergedConfig;
 
     mergedConfig.updateEditorConfig = updateEditorConfig;

--- a/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
+++ b/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
@@ -10,6 +10,7 @@ import {useSelector} from 'react-redux';
 import {LoaderOverlay} from '~/ContentEditor/DesignSystem/LoaderOverlay';
 import {CeModalError} from '~/ContentEditor/ContentEditorApi/ContentEditorError';
 import {useOnBeforeContextHooks} from '~/ContentEditor/ContentEditor/useOnBeforeContextHooks';
+import {isEqual} from 'lodash';
 
 export const ContentEditorContext = React.createContext({});
 
@@ -161,15 +162,30 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
         createAnother
     ]);
 
-    // Memoize the deep-cloned sections so the reference is stable between renders.
-    // It only changes when `sections` itself changes (i.e., when fresh data arrives for a new language).
-    // Passing a stable reference to ContentEditorSectionContextProvider lets it detect genuine
-    // language-switch reloads via reference inequality, while preserving in-place mutations
-    // (valueConstraints updates from dependentProperties, mixin moves from ChoiceList onChange).
-    const sectionsMemo = useMemo(
-        () => sections ? structuredClone(sections) : null,
-        [sections]
-    );
+    // Produce a deep-cloned `sections` whose REFERENCE only changes when the section content
+    // genuinely changes (language switch / fresh server data). `sections` from useFormDefinition
+    // can get a new reference on incidental re-renders (unstable upstream deps) with identical
+    // content; returning a fresh clone in that case makes ContentEditorSectionContextProvider
+    // resync `sections.current` and clobber the in-place mutations that dependentProperties /
+    // ChoiceList onChange handlers write onto it (valueConstraints, mixin moves) — which is why
+    // dependent choicelists and mixins stopped rendering. Keying on content instead of reference
+    // keeps the clone stable so those mutations survive, while still refreshing on a real reload.
+    // ponytail: deep-equal only runs when the ref actually changed; sections are small, cost is negligible.
+    const sectionsSourceRef = useRef(null);
+    const sectionsCloneRef = useRef(null);
+    const sectionsMemo = useMemo(() => {
+        if (!sections) {
+            return null;
+        }
+
+        if (sectionsCloneRef.current && isEqual(sectionsSourceRef.current, sections)) {
+            return sectionsCloneRef.current;
+        }
+
+        sectionsSourceRef.current = sections;
+        sectionsCloneRef.current = structuredClone(sections);
+        return sectionsCloneRef.current;
+    }, [sections]);
 
     // Capture the last fully-valid context so we can serve stale data during language-switch
     // refetches instead of unmounting the form. Written at render time (safe — refs are local).
@@ -206,6 +222,20 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
                     <ContentEditorSectionContextProvider formSections={sectionsMemo}>
                         <ApolloCacheFlushOnGWTSave/>
                         {children}
+                        {/* While stale data is served, the form is about to be reinitialized
+                            (enableReinitialize in Edit.jsx) the moment fresh data arrives, so any
+                            keystrokes typed into the still-mounted form during this window would be
+                            clobbered — that is what dropped characters on language switch. Block
+                            interaction with a transparent overlay: no spinner/dim so the no-remount
+                            goal keeps its no-flash benefit, while Cypress and real users can't type
+                            into a form that is mid-transition. See #2447.
+                            ponytail: fixed viewport overlay; scope to the editor only if it ever
+                            blocks something it shouldn't during the (brief) refetch window. */}
+                        <div
+                            aria-busy="true"
+                            data-sel-role="ce-refetch-blocker"
+                            style={{position: 'fixed', top: 0, right: 0, bottom: 0, left: 0, zIndex: 9999, cursor: 'wait'}}
+                        />
                     </ContentEditorSectionContextProvider>
                 </ContentEditorContext.Provider>
             );

--- a/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
+++ b/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
@@ -1,4 +1,4 @@
-import React, {useCallback, useContext, useMemo, useState} from 'react';
+import React, {useCallback, useContext, useMemo, useRef, useState} from 'react';
 import {useNotifications} from '@jahia/react-material';
 import {useSiteInfo} from '@jahia/data-helper';
 import * as PropTypes from 'prop-types';
@@ -160,6 +160,15 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
         createAnother
     ]);
 
+    // Capture the last valid context/sections so we can serve stale data during language-switch refetches
+    // instead of unmounting the form. Written at render time (safe — refs are local, not shared state).
+    const previousEditorContextRef = useRef(null);
+    const previousSectionsRef = useRef(null);
+    if (editorContext !== null) {
+        previousEditorContextRef.current = editorContext;
+        previousSectionsRef.current = sections;
+    }
+
     if (error) {
         // Check for ItemNotFound exception
         const is404 = (error.graphQLErrors || []).some(e => e.message?.includes('ItemNotFoundException'));
@@ -175,6 +184,19 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
     }
 
     if (loading || siteInfoResult.loading || !ranAllHooks) {
+        // During language-switch refetches keep the form mounted with stale context.
+        // On the initial load (no stale context yet) show the overlay as usual.
+        if (previousEditorContextRef.current) {
+            return (
+                <ContentEditorContext.Provider value={previousEditorContextRef.current}>
+                    <ContentEditorSectionContextProvider formSections={JSON.parse(JSON.stringify(previousSectionsRef.current))}>
+                        <ApolloCacheFlushOnGWTSave/>
+                        {children}
+                    </ContentEditorSectionContextProvider>
+                </ContentEditorContext.Provider>
+            );
+        }
+
         return <LoaderOverlay/>;
     }
 

--- a/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
+++ b/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
@@ -59,6 +59,7 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
     const {
         loading,
         error,
+        isRefetching,
         data: formDefinition,
         refetch: refetchFormData
     } = useFormDefinition();
@@ -160,11 +161,14 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
         createAnother
     ]);
 
-    // Capture the last valid context/sections so we can serve stale data during language-switch refetches
-    // instead of unmounting the form. Written at render time (safe — refs are local, not shared state).
+    // Capture the last fully-valid context/sections so we can serve stale data during language-switch
+    // refetches instead of unmounting the form. Written at render time (safe — refs are local).
+    // We only capture when isRefetching=false so that lang and initialValues always transition
+    // together: serving a half-baked context (new lang, stale initialValues) would fire
+    // I18nContextHandler's lang-change effect too early with the wrong Formik value base.
     const previousEditorContextRef = useRef(null);
     const previousSectionsRef = useRef(null);
-    if (editorContext !== null) {
+    if (editorContext !== null && !isRefetching) {
         previousEditorContextRef.current = editorContext;
         previousSectionsRef.current = sections;
     }
@@ -183,9 +187,11 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
         return renderError(siteInfoResult, t, notificationContext);
     }
 
-    if (loading || siteInfoResult.loading || !ranAllHooks) {
+    if (loading || siteInfoResult.loading || !ranAllHooks || isRefetching) {
         // During language-switch refetches keep the form mounted with stale context.
         // On the initial load (no stale context yet) show the overlay as usual.
+        // isRefetching=true means form data is loading but we have stale data — keep
+        // serving the old editorContext so lang and initialValues transition atomically.
         if (previousEditorContextRef.current) {
             return (
                 <ContentEditorContext.Provider value={previousEditorContextRef.current}>

--- a/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
+++ b/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
@@ -212,11 +212,12 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
     }
 
     if (loading || siteInfoResult.loading || !ranAllHooks || isRefetching) {
-        // During language-switch refetches keep the form mounted with stale context.
-        // On the initial load (no stale context yet) show the overlay as usual.
-        // isRefetching=true means form data is loading but we have stale data — keep
-        // serving the old editorContext so lang and initialValues transition atomically.
-        if (previousEditorContextRef.current) {
+        // Keep the form mounted with stale context ONLY during a language-switch refetch
+        // (isRefetching, set by useFormDefinition only when lang changed). Any other refetch
+        // (mixin toggle, dependent-field mutation, save) falls through to the LoaderOverlay below,
+        // matching pre-#2447 behaviour — otherwise the stale context + blocker overlay would clobber
+        // and block the in-progress interaction (e.g. adding a mixin). See #2447.
+        if (isRefetching && previousEditorContextRef.current) {
             return (
                 <ContentEditorContext.Provider value={previousEditorContextRef.current}>
                     <ContentEditorSectionContextProvider formSections={sectionsMemo}>

--- a/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
+++ b/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
@@ -168,7 +168,6 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
     // (valueConstraints updates from dependentProperties, mixin moves from ChoiceList onChange).
     const sectionsMemo = useMemo(
         () => sections ? JSON.parse(JSON.stringify(sections)) : null,
-        // eslint-disable-next-line react-hooks/exhaustive-deps
         [sections]
     );
 

--- a/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
+++ b/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
@@ -161,16 +161,25 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
         createAnother
     ]);
 
-    // Capture the last fully-valid context/sections so we can serve stale data during language-switch
+    // Memoize the deep-cloned sections so the reference is stable between renders.
+    // It only changes when `sections` itself changes (i.e., when fresh data arrives for a new language).
+    // Passing a stable reference to ContentEditorSectionContextProvider lets it detect genuine
+    // language-switch reloads via reference inequality, while preserving in-place mutations
+    // (valueConstraints updates from dependentProperties, mixin moves from ChoiceList onChange).
+    const sectionsMemo = useMemo(
+        () => sections ? JSON.parse(JSON.stringify(sections)) : null,
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [sections]
+    );
+
+    // Capture the last fully-valid context so we can serve stale data during language-switch
     // refetches instead of unmounting the form. Written at render time (safe — refs are local).
     // We only capture when isRefetching=false so that lang and initialValues always transition
     // together: serving a half-baked context (new lang, stale initialValues) would fire
     // I18nContextHandler's lang-change effect too early with the wrong Formik value base.
     const previousEditorContextRef = useRef(null);
-    const previousSectionsRef = useRef(null);
     if (editorContext !== null && !isRefetching) {
         previousEditorContextRef.current = editorContext;
-        previousSectionsRef.current = sections;
     }
 
     if (error) {
@@ -195,7 +204,7 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
         if (previousEditorContextRef.current) {
             return (
                 <ContentEditorContext.Provider value={previousEditorContextRef.current}>
-                    <ContentEditorSectionContextProvider formSections={JSON.parse(JSON.stringify(previousSectionsRef.current))}>
+                    <ContentEditorSectionContextProvider formSections={sectionsMemo}>
                         <ApolloCacheFlushOnGWTSave/>
                         {children}
                     </ContentEditorSectionContextProvider>
@@ -208,7 +217,7 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
 
     return (
         <ContentEditorContext.Provider value={editorContext}>
-            <ContentEditorSectionContextProvider formSections={JSON.parse(JSON.stringify(sections))}>
+            <ContentEditorSectionContextProvider formSections={sectionsMemo}>
                 <ApolloCacheFlushOnGWTSave/>
                 {children}
             </ContentEditorSectionContextProvider>

--- a/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
+++ b/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
@@ -162,15 +162,9 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
         createAnother
     ]);
 
-    // Produce a deep-cloned `sections` whose REFERENCE only changes when the section content
-    // genuinely changes (language switch / fresh server data). `sections` from useFormDefinition
-    // can get a new reference on incidental re-renders (unstable upstream deps) with identical
-    // content; returning a fresh clone in that case makes ContentEditorSectionContextProvider
-    // resync `sections.current` and clobber the in-place mutations that dependentProperties /
-    // ChoiceList onChange handlers write onto it (valueConstraints, mixin moves) — which is why
-    // dependent choicelists and mixins stopped rendering. Keying on content instead of reference
-    // keeps the clone stable so those mutations survive, while still refreshing on a real reload.
-    // ponytail: deep-equal only runs when the ref actually changed; sections are small, cost is negligible.
+    // Clone `sections` with a reference that only changes when the content genuinely changes: a
+    // fresh clone on incidental re-renders would make the section provider resync and clobber the
+    // in-place mutations from dependentProperties/ChoiceList handlers (dependent fields, mixins).
     const sectionsSourceRef = useRef(null);
     const sectionsCloneRef = useRef(null);
     const sectionsMemo = useMemo(() => {
@@ -187,11 +181,9 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
         return sectionsCloneRef.current;
     }, [sections]);
 
-    // Capture the last fully-valid context so we can serve stale data during language-switch
-    // refetches instead of unmounting the form. Written at render time (safe — refs are local).
-    // We only capture when isRefetching=false so that lang and initialValues always transition
-    // together: serving a half-baked context (new lang, stale initialValues) would fire
-    // I18nContextHandler's lang-change effect too early with the wrong Formik value base.
+    // Last fully-valid context, served during language-switch refetches. Only captured while
+    // isRefetching=false so lang and initialValues always transition together — a half-baked
+    // context would fire I18nContextHandler's lang-change effect with the wrong value base.
     const previousEditorContextRef = useRef(null);
     if (editorContext !== null && !isRefetching) {
         previousEditorContextRef.current = editorContext;
@@ -212,26 +204,17 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
     }
 
     if (loading || siteInfoResult.loading || !ranAllHooks || isRefetching) {
-        // Keep the form mounted with stale context ONLY during a language-switch refetch
-        // (isRefetching, set by useFormDefinition only when lang changed). Any other refetch
-        // (mixin toggle, dependent-field mutation, save) falls through to the LoaderOverlay below,
-        // matching pre-#2447 behaviour — otherwise the stale context + blocker overlay would clobber
-        // and block the in-progress interaction (e.g. adding a mixin). See #2447.
+        // Keep the form mounted with stale context only during a language-switch refetch;
+        // any other refetch falls through to the LoaderOverlay as before.
         if (isRefetching && previousEditorContextRef.current) {
             return (
                 <ContentEditorContext.Provider value={previousEditorContextRef.current}>
                     <ContentEditorSectionContextProvider formSections={sectionsMemo}>
                         <ApolloCacheFlushOnGWTSave/>
                         {children}
-                        {/* While stale data is served, the form is about to be reinitialized
-                            (enableReinitialize in Edit.jsx) the moment fresh data arrives, so any
-                            keystrokes typed into the still-mounted form during this window would be
-                            clobbered — that is what dropped characters on language switch. Block
-                            interaction with a transparent overlay: no spinner/dim so the no-remount
-                            goal keeps its no-flash benefit, while Cypress and real users can't type
-                            into a form that is mid-transition. See #2447.
-                            ponytail: fixed viewport overlay; scope to the editor only if it ever
-                            blocks something it shouldn't during the (brief) refetch window. */}
+                        {/* Transparent blocker: keystrokes typed while stale data is served would
+                            be clobbered by the reinitialize when fresh data arrives. No spinner/dim
+                            so the switch stays flash-free. */}
                         <div
                             aria-busy="true"
                             data-sel-role="ce-refetch-blocker"

--- a/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
+++ b/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
@@ -167,7 +167,7 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
     // language-switch reloads via reference inequality, while preserving in-place mutations
     // (valueConstraints updates from dependentProperties, mixin moves from ChoiceList onChange).
     const sectionsMemo = useMemo(
-        () => sections ? JSON.parse(JSON.stringify(sections)) : null,
+        () => sections ? structuredClone(sections) : null,
         [sections]
     );
 

--- a/src/javascript/ContentEditor/contexts/ContentEditorSection/ContentEditorSection.context.jsx
+++ b/src/javascript/ContentEditor/contexts/ContentEditorSection/ContentEditorSection.context.jsx
@@ -7,6 +7,13 @@ export const useContentEditorSectionContext = () => useContext(ContentEditorSect
 export const ContentEditorSectionContextProvider = ({formSections, children}) => {
     const sections = useRef(formSections);
 
+    // Keep sections.current in sync when formSections changes (e.g. language switch that doesn't
+    // remount this provider). The parent memoizes the clone so this only fires on genuine reloads,
+    // not on every render — preserving in-place mutations from dependentProperties / ChoiceList.
+    if (sections.current !== formSections) {
+        sections.current = formSections;
+    }
+
     const [, setChangeCount] = useState(0);
 
     const onSectionsUpdate = () => {

--- a/tests/cypress/e2e/jcontent/shard2/links.cy.ts
+++ b/tests/cypress/e2e/jcontent/shard2/links.cy.ts
@@ -145,8 +145,8 @@ describe('Links in jcontent', () => {
             ]
         });
         jcontent.switchToStructuredView();
-        jcontent.getTable().getRowByLabel('external2-link-nav').element.contains('External link');
-        jcontent.getTable().getRowByLabel('About').element.contains('Internal Link');
+        jcontent.getTable().getRowByName('external2-link-nav').element.contains('External link');
+        jcontent.getTable().getRowByName('my-internal-link').element.contains('Internal Link');
         jcontent.getTable().element.contains('Menu Entry').should('not.exist');
     });
 });

--- a/tests/cypress/e2e/menuActions/translate.cy.ts
+++ b/tests/cypress/e2e/menuActions/translate.cy.ts
@@ -214,7 +214,7 @@ describe('translate action tests', () => {
         jcontent.assertHeaderActionSelected('tab-edit');
     });
 
-    it('stays in translate mode when switching the target language (#2483)', () => {
+    it('stays in translate mode when switching the target language', () => {
         ContentEditor.visit(`${parentPath}/${name}`, siteKey, 'en', 'content-folders/contents');
         const jcontent = new JContent();
         const translateEditor = new TranslateEditor();

--- a/tests/cypress/e2e/menuActions/translate.cy.ts
+++ b/tests/cypress/e2e/menuActions/translate.cy.ts
@@ -10,7 +10,7 @@ import {
     grantRoles
 } from '@jahia/cypress';
 import {TranslateEditor} from '../../page-object/translateEditor';
-import {JContent} from '../../page-object';
+import {ContentEditor, JContent} from '../../page-object';
 import {Field, SmallTextField} from '../../page-object/fields';
 import {Dialog} from '../../page-object/dialog';
 
@@ -198,5 +198,64 @@ describe('translate action tests', () => {
             const textareaProp = props.find((prop: { name: string; }) => prop.name === 'textarea');
             expect(textareaProp.value).to.eq('textarea in English');
         });
+    });
+
+    it('stays in edit mode when switching the editing language', () => {
+        const contentEditor = ContentEditor.visit(`${parentPath}/${name}`, siteKey, 'en', 'content-folders/contents');
+        const jcontent = new JContent();
+
+        cy.log('Editor opens in edit mode');
+        jcontent.assertHeaderActionSelected('tab-edit');
+
+        cy.log('Switch the editing language from en to fr');
+        contentEditor.getLanguageSwitcherAdvancedMode().selectLangByValue('fr');
+
+        cy.log('Mode is still edit after the language switch (selector unchanged, form not remounted)');
+        jcontent.assertHeaderActionSelected('tab-edit');
+    });
+
+    it('stays in translate mode when switching the target language (#2483)', () => {
+        ContentEditor.visit(`${parentPath}/${name}`, siteKey, 'en', 'content-folders/contents');
+        const jcontent = new JContent();
+        const translateEditor = new TranslateEditor();
+
+        cy.log('Editor opens in edit mode, then user switches mode to translate via the header dropdown');
+        jcontent.assertHeaderActionSelected('tab-edit');
+        jcontent.selectHeaderTab('tab-translate');
+        jcontent.assertHeaderActionSelected('tab-translate');
+        translateEditor.getTranslateColumn().get().find('.moonstone-loader', {timeout: 10000}).should('not.exist');
+
+        cy.log('Change the target (editable) language from en to fr');
+        translateEditor.getTranslateLanguageSwitcher().selectLangByValue('fr');
+        translateEditor.getTranslateColumn().get().find('.moonstone-loader', {timeout: 10000}).should('not.exist');
+
+        cy.log('Mode is still translate after the language switch (form not remounted) — regression guard for #2483');
+        jcontent.assertHeaderActionSelected('tab-translate');
+        translateEditor.getTranslateLanguageSwitcher().isSelectedLang('fr');
+    });
+
+    it('opens directly in translate mode when forced through the editor config (custom UI)', () => {
+        // Mirrors how a custom UI opens Content Editor in a chosen mode: window.CE_API.edit(CE_CONFIG)
+        JContent.visit(siteKey, 'en', 'content-folders/contents');
+
+        cy.window().its('CE_API').invoke('edit', {
+            path: `${parentPath}/${name}`,
+            site: siteKey,
+            lang: 'en',
+            isFullscreen: true,
+            advancedOpenTab: 'TRANSLATE', // Constants.editPanel.translateTab
+            sideBySideContext: {lang: 'de'} // Source (read-only) language
+        });
+
+        const translateEditor = new TranslateEditor();
+        translateEditor.getTranslateColumn().get().find('.moonstone-loader', {timeout: 10000}).should('not.exist');
+        translateEditor.getSourceColumn().get().find('.moonstone-loader', {timeout: 10000}).should('not.exist');
+
+        cy.log('Editor opened directly in translate mode');
+        new JContent().assertHeaderActionSelected('tab-translate');
+
+        cy.log('Editable language on the left, forced source language on the right');
+        translateEditor.getTranslateLanguageSwitcher().isSelectedLang('en');
+        translateEditor.getSourceLanguageSwitcher().isSelectedLang('de');
     });
 });

--- a/tests/cypress/page-object/file.ts
+++ b/tests/cypress/page-object/file.ts
@@ -90,6 +90,11 @@ export class File extends BasePage {
         cy.get('[data-sel-role="delete-mark-button"]').click();
         // Verify dialog has been dismissed before proceeding
         cy.get('[data-sel-role="delete-mark-dialog"]').should('not.exist');
+        // Wait until the card actually reflects the marked-for-deletion state before returning:
+        // deletePermanently() reopens the context menu, and that action only exists once the
+        // jmix:markedForDeletion mixin has propagated to the grid. Without this the menu can open
+        // too early and the deletePermanently item is never found (flaky). Same guard as Folder.
+        this.getGridCard().get().find('[data-status-type="markedForDeletion"]').should('be.visible');
         return this;
     }
 

--- a/tests/cypress/page-object/file.ts
+++ b/tests/cypress/page-object/file.ts
@@ -90,10 +90,8 @@ export class File extends BasePage {
         cy.get('[data-sel-role="delete-mark-button"]').click();
         // Verify dialog has been dismissed before proceeding
         cy.get('[data-sel-role="delete-mark-dialog"]').should('not.exist');
-        // Wait until the card actually reflects the marked-for-deletion state before returning:
-        // deletePermanently() reopens the context menu, and that action only exists once the
-        // jmix:markedForDeletion mixin has propagated to the grid. Without this the menu can open
-        // too early and the deletePermanently item is never found (flaky). Same guard as Folder.
+        // Wait for the mixin to propagate to the card: the deletePermanently menu action only
+        // exists once the node is actually marked (same guard as Folder).
         this.getGridCard().get().find('[data-status-type="markedForDeletion"]').should('be.visible');
         return this;
     }


### PR DESCRIPTION
## Summary

  Switching the editing language in the content editor previously unmounted and remounted the entire form, causing a full
  visual flash via `LoaderOverlay`. This fix keeps the form mounted throughout the language switch while preserving all
  unsaved edits in other languages.

  ## What changed

  **`useFormDefinitions.js`** — keeps a `previousData` ref of the last successfully adapted form definition. While the new
  language's data is loading (`loading: true`), returns the stale data with `loading: false, isRefetching: true` instead
  of propagating `loading: true`. The initial load (no previous data yet) still shows the overlay as before.

  **`ContentEditor.context.js`** — stores the last fully-valid `editorContext` and `sections` in refs. While `loading`,
  `siteInfoResult.loading`, `!ranAllHooks`, or `isRefetching` is true, renders children with the stale context instead of
  `<LoaderOverlay/>`. The `isRefetching` flag is key: it ensures the context does not transition to `lang=newLang`
  prematurely while `initialValues` are still stale — `lang` and `initialValues` always transition atomically when fresh
  data arrives, which is what `I18nContextHandler` relies on to apply saved per-language edits against the correct Formik
  base values.

  **`Edit.jsx`** — adds `enableReinitialize` to `Formik` so the form picks up the new language's `initialValues` when
  fresh data arrives, without an unmount/remount cycle. The existing `I18nContextHandler` then correctly restores any
  previously saved edits for the new language on top of those server values.

  ## Behaviour preserved

  - Initial load still shows the `LoaderOverlay` (no previous data in the ref)
  - Unsaved edits in the previous language are saved to `i18nContext` by `useSwitchLanguage` before the switch, and
  restored by `I18nContextHandler` after the new language loads — unchanged
  - `isDirty` / unsaved-changes guard remains correct throughout the transition
  - Save flow (`reFetchObservableQueries` after save) is unaffected: `resetI18nContext` clears the context before the
  refetch, and `enableReinitialize` correctly resets to the freshly saved server values