### PR TITLE
fix: Update z-index for New Folder dialog

### DIFF
--- a/.chachalog/f3WItMDu.md
+++ b/.chachalog/f3WItMDu.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Update z-index for New folder dialog (#2453)

--- a/.chachalog/f3WItMDu.md
+++ b/.chachalog/f3WItMDu.md
@@ -3,4 +3,4 @@
 "@jahia/jcontent": minor
 ---
 
-Update z-index for New folder dialog (#2453)
+Fixed an issue where the New Folder dialog was hidden behind other modal dialogs (#2453)

--- a/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.jsx
+++ b/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.jsx
@@ -66,7 +66,7 @@ export const CreateFolderDialog = ({path, contentType, onExit}) => {
     return (
         <Dialog open={open}
                 aria-labelledby="form-dialog-title"
-                classes={{paper: styles.root}}
+                classes={{paper: styles.root, root: styles.dialogRoot}}
                 onClose={handleCancel}
                 onExited={onExit}
         >

--- a/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.scss
+++ b/src/javascript/JContent/actions/createFolderAction/CreateFolderDialog/CreateFolderDialog.scss
@@ -2,6 +2,10 @@
     min-width: 600px;
 }
 
+.dialogRoot.dialogRoot {
+    z-index: var(--ce-dialog-z-index);
+}
+
 .error.error {
     color: var(--color-danger);
 }

--- a/tests/cypress/e2e/pickers/picker.cy.ts
+++ b/tests/cypress/e2e/pickers/picker.cy.ts
@@ -241,4 +241,26 @@ describe('Picker tests', () => {
         picker.getGrid().get().find('div[data-sel-role-card="allrealtylogo_light.png"]').dblclick({force: true});
         contentEditor.getPickerField(contentTypes.fileReference.fieldNodeType, contentTypes.fileReference.multiple).checkValue('allrealtylogo_light.png');
     });
+
+    it('opens the New folder dialog on top of the image picker', () => {
+        const contentEditor = jcontent.createContent(contentTypes.fileReference.typeName);
+        const picker = contentEditor
+            .getPickerField(contentTypes.fileReference.fieldNodeType, contentTypes.fileReference.multiple)
+            .open();
+
+        picker.getAccordionItem('picker-media').getTreeItem('files').shouldBeSelected();
+
+        cy.log('click New folder inside the picker');
+        picker.get().find('button[data-sel-role="createFolder"]').should('be.enabled').click();
+
+        cy.log('the Create folder dialog must be stacked above the picker (regression: it rendered behind it)');
+        // Typing without {force} enforces actionability and fails if the field is covered by the picker overlay
+        cy.get('#folder-name').should('be.visible').type('zindex-check');
+        cy.get('#folder-name').should('have.value', 'zindex-check');
+
+        cy.log('close without creating the folder');
+        cy.get('[data-cm-role="create-folder-as-cancel"]').click();
+        picker.cancel();
+        contentEditor.cancel();
+    });
 });


### PR DESCRIPTION
### Description
Update z-index so that create folder dialog appears on top of picker dialog.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
