### PR TITLE
fix: Adjust warning label position

### DIFF
--- a/.chachalog/YVyX7Vaf.md
+++ b/.chachalog/YVyX7Vaf.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Adjust warning label position on save button in content editor (#2454)

--- a/src/javascript/ContentEditor/utils/getButtonRenderer.jsx
+++ b/src/javascript/ContentEditor/utils/getButtonRenderer.jsx
@@ -40,13 +40,17 @@ export const getButtonRenderer = ({labelStyle, defaultButtonProps, noIcon} = {})
             />
         );
 
+        if (!hasWarningBadge) {
+            return button;
+        }
+
+        // Wrap the button and badge in a positioned container so the absolutely
+        // positioned badge anchors to the button instead of the page.
         return (
-            <>
+            <div className={styles.pastilleWrapper}>
                 {button}
-                {hasWarningBadge && (
-                    <Report size="big" data-sel-role={`${actionKey}_pastille`} className={styles.warningBadge}/>
-                )}
-            </>
+                <Report size="big" data-sel-role={`${actionKey}_pastille`} className={styles.warningBadge}/>
+            </div>
         );
     };
 

--- a/src/javascript/ContentEditor/utils/getButtonRenderer.scss
+++ b/src/javascript/ContentEditor/utils/getButtonRenderer.scss
@@ -12,4 +12,6 @@
 
 .pastilleWrapper {
     position: relative;
+
+    display: flex;
 }


### PR DESCRIPTION
### Description
Adjust warning label position on save button in content editor. Split jcontent and content editor tests in two to speed up test runs.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
