### PR TITLE
fix: Prevent non-deterministic field assignment when processing fieldsets

### DIFF
--- a/.chachalog/NrGR3rIg.md
+++ b/.chachalog/NrGR3rIg.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Fix issue where Content Editor fields are missing intermittently when using template mixins with inherited mixins (#2467)

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
@@ -372,6 +372,12 @@ public class EditorFormServiceImpl implements EditorFormService {
             }
         }
 
+        // If mixin A extends mixin B and both are in the list, remove B.
+        // A already carries B's properties via the supertype chain, so keeping both
+        // causes non-deterministic field assignment during fieldset merge.
+        res.removeIf(mixin -> res.stream()
+            .anyMatch(other -> !other.getName().equals(mixin.getName()) && other.isNodeType(mixin.getName())));
+
         return res;
     }
 

--- a/tests/cypress/e2e/selectorTypes/supertypeExtendMixinDedup.cy.ts
+++ b/tests/cypress/e2e/selectorTypes/supertypeExtendMixinDedup.cy.ts
@@ -1,0 +1,76 @@
+import {JContent} from '../../page-object';
+import {createSite, deleteSite, enableModule} from '@jahia/cypress';
+
+// Regression test for: non-deterministic field assignment when mixin B is both a supertype of
+// mixin A and independently present in getExtendMixins() results. The fix in
+// EditorFormServiceImpl removes the supertype (cemix:supertypeExtendMixin) from the list
+// when the subtype (cemix:subtypeExtendMixin) is also present, ensuring only the subtype
+// fieldset is created and its inherited fields are always visible.
+describe('Supertype extend mixin deduplication', () => {
+    const siteKey = 'supertypeExtendMixinSite';
+
+    before(() => {
+        createSite(siteKey);
+        enableModule('jcontent-test-module', siteKey);
+    });
+
+    after(() => {
+        deleteSite(siteKey);
+        cy.logout();
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession();
+    });
+
+    it('Supertype extend mixin is excluded from standalone fieldset list', () => {
+        const jcontent = JContent.visit(siteKey, 'en', 'pages');
+        const contentEditor = jcontent.editPage();
+
+        cy.log('cemix:supertypeExtendMixin must not appear as an independent dynamic fieldset — it is deduplicated because cemix:subtypeExtendMixin extends it');
+        contentEditor.getDynamicFieldset('cemix:supertypeExtendMixin').should('not.exist');
+
+        cy.log('cemix:subtypeExtendMixin should be present as the active dynamic fieldset');
+        contentEditor.getDynamicFieldset('cemix:subtypeExtendMixin').should('exist');
+
+        contentEditor.cancel();
+    });
+
+    it('Fields from supertype extend mixin are visible when subtype mixin is activated', () => {
+        const jcontent = JContent.visit(siteKey, 'en', 'pages');
+        const contentEditor = jcontent.editPage();
+
+        cy.log('Enable cemix:subtypeExtendMixin — its inherited fields from cemix:supertypeExtendMixin must appear');
+        contentEditor.toggleOption('cemix:subtypeExtendMixin');
+
+        cy.log('title and description (declared in cemix:supertypeExtendMixin) must be visible');
+        contentEditor.getSmallTextField('cemix:subtypeExtendMixin_title').assertVisible();
+        contentEditor.getSmallTextField('cemix:subtypeExtendMixin_description').assertVisible();
+
+        cy.log('pageType (declared in cemix:subtypeExtendMixin itself) must also be visible');
+        contentEditor.getSmallTextField('cemix:subtypeExtendMixin_pageType').assertVisible();
+
+        contentEditor.cancelAndDiscard();
+    });
+
+    it('Fields from supertype extend mixin persist after save', () => {
+        const jcontent = JContent.visit(siteKey, 'en', 'pages');
+        let contentEditor = jcontent.editPage();
+
+        cy.log('Activate the subtype mixin and save');
+        contentEditor.toggleOption('cemix:subtypeExtendMixin');
+        contentEditor.save();
+
+        cy.log('Re-open the page editor and verify the inherited fields are still visible');
+        contentEditor = jcontent.editPage();
+        contentEditor.switchToAdvancedMode();
+
+        contentEditor.getSmallTextField('cemix:subtypeExtendMixin_title').assertVisible();
+        contentEditor.getSmallTextField('cemix:subtypeExtendMixin_description').assertVisible();
+
+        cy.log('cemix:supertypeExtendMixin still must not appear as an independent fieldset');
+        contentEditor.getDynamicFieldset('cemix:supertypeExtendMixin').should('not.exist');
+
+        contentEditor.cancel();
+    });
+});

--- a/tests/cypress/page-object/contentEditor.ts
+++ b/tests/cypress/page-object/contentEditor.ts
@@ -297,9 +297,13 @@ export class ContentEditor extends BasePage {
         return r;
     }
 
+    getDynamicFieldset(mixinType: string): Cypress.Chainable<JQuery<HTMLElement>> {
+        return cy.get(`span[data-sel-role-dynamic-fieldset="${mixinType}"]`);
+    }
+
     toggleOption(optionType: string, optionFieldName?: string) {
-        cy.get(`span[data-sel-role-dynamic-fieldset="${optionType}"]`).scrollIntoView({offset: {left: 0, top: -100}});
-        cy.get(`span[data-sel-role-dynamic-fieldset="${optionType}"]`).find('input').click({force: true});
+        this.getDynamicFieldset(optionType).scrollIntoView({offset: {left: 0, top: -100}});
+        this.getDynamicFieldset(optionType).find('input').click({force: true});
         if (optionFieldName) {
             cy.contains(optionFieldName, {timeout: 30000}).should('exist');
         }

--- a/tests/cypress/page-object/fields/field.ts
+++ b/tests/cypress/page-object/fields/field.ts
@@ -14,6 +14,12 @@ export class Field extends BaseComponent {
         // Empty method
     }
 
+    assertVisible() {
+        this.get().scrollIntoView({offset: {top: -200, left: 0}});
+        this.get().should('be.visible');
+        return this;
+    }
+
     hasMandatory() {
         this.get().scrollIntoView().find('[data-sel-content-editor-field-mandatory]')
             .should('be.visible')

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -290,4 +290,15 @@
  extends = cent:expert
  - test1 (string)
 
+// https://github.com/Jahia/jcontent/issues/2412
+// Regression test types for non-deterministic field assignment when mixin B
+// is both a supertype of mixin A and in the extend mixins list for jnt:page.
+[cemix:supertypeExtendMixin] mixin
+ extends = jnt:page
+ - title (string) internationalized
+ - description (string) internationalized
+
+[cemix:subtypeExtendMixin] > cemix:supertypeExtendMixin mixin
+ extends = jnt:page
+ - pageType (string)
 


### PR DESCRIPTION
### Description

When two mixins both declare `extends = jnt:page` (or any shared target type) and one is a supertype of the other, `getExtendMixins()` returns both. Because the underlying collection iterates over a `HashMap`, processing order is non-deterministic. Depending on which mixin is processed first, `findAndRemoveField()` during fieldset merge moves properties from the correct activated fieldset into an inactive one, causing fields to silently disappear from the Content Editor form.

**Fix:** after collecting the extend mixin list, filter out any entry that is a supertype of another entry in the same list. The more specific mixin already carries all supertype properties via inheritance, so the supertype entry is redundant.

Discovered while investigating a customer case (ARKEMA-1813) where `akmmix:sampleCartPage > jmix:templateMixin, akmmix:sampleCartHeader` — both having `extends = jnt:page` — caused `title` and `description` from `akmmix:sampleCartHeader` to intermittently not appear in Content Editor after the `addMixin` mechanism applied `akmmix:sampleCartPage`.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [x] I've updated the parent issue with required manual validations

**Manual validation:** define two mixins where one extends the other and both have `extends = jnt:page`. Map the more specific mixin via `addMixin`. Create a page using that template and confirm all inherited properties appear in Content Editor consistently across multiple attempts.