### PR TITLE
fix: Fix NPE when there if no selector options

### DIFF
--- a/.chachalog/qqtDcpca.md
+++ b/.chachalog/qqtDcpca.md
@@ -3,4 +3,4 @@
 "@jahia/jcontent": minor
 ---
 
-Fix ceontent creation when no selector options are available (#2470)
+Fix content creation when no selector options are available (#2470)

--- a/.chachalog/qqtDcpca.md
+++ b/.chachalog/qqtDcpca.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Fix ceontent creation when no selector options are available (#2470)

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
@@ -307,7 +307,11 @@ public class EditorFormServiceImpl implements EditorFormService {
 
     private List<FieldValueConstraint> getValueConstraints(ExtendedNodeType primaryNodeType, Field editorFormField, JCRNodeWrapper existingNode, JCRNodeWrapper parentNode, Locale locale, Map<String, Object> extendContext) throws RepositoryException {
         ExtendedPropertyDefinition propertyDefinition = editorFormField.getExtendedPropertyDefinition();
-        Map<String, Object> selectorOptions = editorFormField.getSelectorOptionsMap();
+        // selectorOptionsMap is null when a field has no selector options set (consistent with the
+        // null checks in getEditorForm and Field.mergeWith); normalize to an empty map to avoid NPEs.
+        Map<String, Object> selectorOptions = editorFormField.getSelectorOptionsMap() != null ?
+                editorFormField.getSelectorOptionsMap() :
+                Collections.emptyMap();
         if (propertyDefinition != null && (propertyDefinition.getSelector() == SelectorType.CHOICELIST || selectorOptions.containsKey("choicelist"))) {
             Map<String, ChoiceListInitializer> initializers = choiceListInitializerService.getInitializers();
 

--- a/tests/cypress/e2e/contentEditor/createEditContentType.cy.ts
+++ b/tests/cypress/e2e/contentEditor/createEditContentType.cy.ts
@@ -1,0 +1,52 @@
+import {JContent} from '../../page-object';
+import {enableModule} from '@jahia/cypress';
+
+describe('Create and edit content type', () => {
+    let jcontent: JContent;
+    const siteKey = 'expertContentSite';
+    const systemName = 'my-expert';
+
+    before(() => {
+        cy.executeGroovy('contentEditor/createSite.groovy', {SITEKEY: siteKey});
+        enableModule('jcontent-test-module', siteKey);
+    });
+
+    after(() => {
+        cy.logout();
+        cy.executeGroovy('contentEditor/deleteSite.groovy', {SITEKEY: siteKey});
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession();
+        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+    });
+
+    // Regression test for https://github.com/Jahia/jcontent/issues/2392
+    it('creates a cent:expert and edits it', () => {
+        // --- Create ---
+        const contentEditor = jcontent.createContent('cent:expert');
+        cy.get('#contenteditor-dialog-title').should('be.visible');
+
+        // Deterministic system name so the node can be located afterwards
+        contentEditor.openSection('options').get().find('input[type="text"]').clear().type(systemName);
+
+        contentEditor.openSection('content');
+        contentEditor.getSmallTextField('cent:expert_name').addNewValue('Original name');
+
+        contentEditor.create();
+        jcontent.getTable().getRowByName(systemName).should('exist');
+
+        // --- Edit ---
+        const editor = jcontent.editComponentByRowName(systemName);
+        editor.switchToAdvancedMode();
+
+        // Value persisted from creation
+        cy.get('input[name="cent:expert_name"]').should('have.value', 'Original name');
+
+        // Update the field and save
+        editor.getSmallTextField('cent:expert_name').addNewValue('Updated name');
+        editor.save();
+
+        cy.get('input[name="cent:expert_name"]').should('have.value', 'Updated name');
+    });
+});

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -283,4 +283,11 @@
 [cent:checkboxChoiceList] > jnt:content, jmix:basicContent, jmix:editorialContent, mix:title
  - checkboxes (string, choicelist) = 'choice1' multiple < 'choice1', 'choice2', 'choice3'
 
+[cent:expert] > jnt:content, jmix:droppableContent
+ - name (string)
+
+[cemix:expertMix] > jmix:mainResource mixin
+ extends = cent:expert
+ - test1 (string)
+
 


### PR DESCRIPTION
### Description
Fix NPE when there is no selector options, this prevent content editor from failing to open when such content is created on the page.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
