### PR TITLE
fix: preview width in Firefox

### DIFF
--- a/src/javascript/JContent/SidePanel/SidePanel.scss
+++ b/src/javascript/JContent/SidePanel/SidePanel.scss
@@ -1,5 +1,5 @@
 .root {
-    width: stretch;
+    width: 100%;
     height: 100%;
 }
 


### PR DESCRIPTION
### Description

Fix issue with current side panel styling not working in Firefox:

<img width="1411" height="835" alt="image" src="https://github.com/user-attachments/assets/830148df-ee98-4856-b034-d9d8f6867ea6" />