### PR TITLE
fix: Add delay for showing loading context menu and increase duration

### DIFF
--- a/src/javascript/JContent/MenuLoadingContext.js
+++ b/src/javascript/JContent/MenuLoadingContext.js
@@ -1,3 +1,60 @@
-import {createContext} from 'react';
+import {createContext, useEffect, useRef, useState} from 'react';
 
 export const MenuLoadingContext = createContext(false);
+
+const LOADING_SHOW_DELAY_MS = 300;
+const SKELETON_MIN_DISPLAY_MS = 200;
+
+/**
+ * Hybrid loading delay for context menus.
+ *
+ * - Suppresses the menu entirely for the first 300ms of loading so fast loads never
+ *   flash a skeleton.
+ * - Once the skeleton is shown, keeps it visible for at least 200ms so it doesn't
+ *   flicker out immediately if data arrives just after the threshold.
+ * - If loading completes before the 300ms threshold the menu appears instantly with
+ *   real content; no skeleton is ever shown.
+ */
+export const useMenuLoadingDelay = (isOpen, isLoading) => {
+    const [showMenu, setShowMenu] = useState(false);
+    const [effectiveLoading, setEffectiveLoading] = useState(false);
+    const skeletonShownAtRef = useRef(null);
+
+    useEffect(() => {
+        if (!isOpen) {
+            setShowMenu(false);
+            setEffectiveLoading(false);
+            skeletonShownAtRef.current = null;
+            return;
+        }
+
+        if (!isLoading) {
+            if (skeletonShownAtRef.current === null) {
+                // Loaded before threshold — show immediately with real content, no skeleton ever shown
+                setShowMenu(true);
+            } else {
+                // Skeleton is visible — hold it for at least SKELETON_MIN_DISPLAY_MS to avoid flicker
+                const elapsed = Date.now() - skeletonShownAtRef.current;
+                const remaining = SKELETON_MIN_DISPLAY_MS - elapsed;
+                if (remaining > 0) {
+                    const timer = setTimeout(() => setEffectiveLoading(false), remaining);
+                    return () => clearTimeout(timer);
+                }
+
+                setEffectiveLoading(false);
+            }
+
+            return;
+        }
+
+        // Still loading: wait before showing skeletons to avoid flicker on fast loads
+        const timer = setTimeout(() => {
+            skeletonShownAtRef.current = Date.now();
+            setShowMenu(true);
+            setEffectiveLoading(true);
+        }, LOADING_SHOW_DELAY_MS);
+        return () => clearTimeout(timer);
+    }, [isOpen, isLoading]);
+
+    return {showMenu, effectiveLoading};
+};

--- a/src/javascript/JContent/MenuLoadingContext.js
+++ b/src/javascript/JContent/MenuLoadingContext.js
@@ -10,30 +10,27 @@ const SKELETON_MIN_DISPLAY_MS = 200;
  *
  * - Suppresses the menu entirely for the first 300ms of loading so fast loads never
  *   flash a skeleton.
- * - Once the skeleton is shown, keeps it visible for at least 200ms so it doesn't
- *   flicker out immediately if data arrives just after the threshold.
- * - If loading completes before the 300ms threshold the menu appears instantly with
- *   real content; no skeleton is ever shown.
+ * - Once skeletons are shown, keeps them visible for at least 200ms to avoid a
+ *   flash when loading completes just after the 300ms threshold.
+ * - If loading completes before 300ms the menu appears instantly with real content;
+ *   no skeleton is ever shown.
  */
 export const useMenuLoadingDelay = (isOpen, isLoading) => {
-    const [showMenu, setShowMenu] = useState(false);
+    const [timerExpired, setTimerExpired] = useState(false);
     const [effectiveLoading, setEffectiveLoading] = useState(false);
     const skeletonShownAtRef = useRef(null);
 
     useEffect(() => {
         if (!isOpen) {
-            setShowMenu(false);
+            setTimerExpired(false);
             setEffectiveLoading(false);
             skeletonShownAtRef.current = null;
             return;
         }
 
         if (!isLoading) {
-            if (skeletonShownAtRef.current === null) {
-                // Loaded before threshold — show immediately with real content, no skeleton ever shown
-                setShowMenu(true);
-            } else {
-                // Skeleton is visible — hold it for at least SKELETON_MIN_DISPLAY_MS to avoid flicker
+            if (skeletonShownAtRef.current !== null) {
+                // Skeletons are visible — hold for at least SKELETON_MIN_DISPLAY_MS to avoid flicker
                 const elapsed = Date.now() - skeletonShownAtRef.current;
                 const remaining = SKELETON_MIN_DISPLAY_MS - elapsed;
                 if (remaining > 0) {
@@ -50,11 +47,18 @@ export const useMenuLoadingDelay = (isOpen, isLoading) => {
         // Still loading: wait before showing skeletons to avoid flicker on fast loads
         const timer = setTimeout(() => {
             skeletonShownAtRef.current = Date.now();
-            setShowMenu(true);
+            setTimerExpired(true);
             setEffectiveLoading(true);
         }, LOADING_SHOW_DELAY_MS);
         return () => clearTimeout(timer);
     }, [isOpen, isLoading]);
+
+    /*
+     * 'showMenu' is derived directly from isOpen (not state) so the menu closes instantly
+     * with no async render lag — preventing race conditions when a menu is closed and
+     * reopened in quick succession.
+     */
+    const showMenu = isOpen && (!isLoading || timerExpired);
 
     return {showMenu, effectiveLoading};
 };

--- a/src/javascript/JContent/MenuRenderer.jsx
+++ b/src/javascript/JContent/MenuRenderer.jsx
@@ -1,26 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Menu} from '@jahia/moonstone';
-import {MenuLoadingContext} from './MenuLoadingContext';
+import {MenuLoadingContext, useMenuLoadingDelay} from './MenuLoadingContext';
 
-export const MenuRenderer = ({isSubMenu, anchor, isOpen, isLoading, onClose, onExited, onMouseEnter, onMouseLeave, children, menuKey, ...otherProps}) => (
-    <Menu
-        {...anchor}
-        data-sel-role={'jcontent-' + menuKey}
-        style={{zIndex: isSubMenu ? 9001 : 9000}}
-        hasOverlay={isOpen && !isSubMenu}
-        isDisplayed={isOpen}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        onClose={onClose}
-        onExited={onExited}
-        {...otherProps}
-    >
-        <MenuLoadingContext.Provider value={isLoading}>
-            {children}
-        </MenuLoadingContext.Provider>
-    </Menu>
-);
+export const MenuRenderer = ({isSubMenu, anchor, isOpen, isLoading, onClose, onExited, onMouseEnter, onMouseLeave, children, menuKey, ...otherProps}) => {
+    const {showMenu, effectiveLoading} = useMenuLoadingDelay(isOpen, isLoading);
+
+    return (
+        <Menu
+            {...anchor}
+            data-sel-role={'jcontent-' + menuKey}
+            style={{zIndex: isSubMenu ? 9001 : 9000}}
+            hasOverlay={showMenu && !isSubMenu}
+            isDisplayed={showMenu}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+            onClose={onClose}
+            onExited={onExited}
+            {...otherProps}
+        >
+            <MenuLoadingContext.Provider value={effectiveLoading}>
+                {children}
+            </MenuLoadingContext.Provider>
+        </Menu>
+    );
+};
 
 MenuRenderer.propTypes = {
     /**

--- a/tests/cypress/e2e/menuActions/contextMenuVisibility.cy.ts
+++ b/tests/cypress/e2e/menuActions/contextMenuVisibility.cy.ts
@@ -2,6 +2,8 @@ import {JContent} from '../../page-object';
 import {addNode, createSite, deleteSite, getComponent, Menu, uploadFile} from '@jahia/cypress';
 import {GraphqlUtils} from '../../utils/graphqlUtils';
 
+const FAST_QUERY_DELAY_MS = 100;
+const JUST_OVER_THRESHOLD_MS = 350;
 const SLOW_QUERY_DELAY_MS = 2000;
 const MENU_VISIBILITY_THRESHOLD_MS = 1500;
 
@@ -69,6 +71,65 @@ describe('Context menu visiblity', () => {
             cy.get('#menuHolder .moonstone-menu:not(.moonstone-hidden)')
                 .find('[data-sel-role="menu-item-skeleton"]')
                 .should('not.exist');
+        });
+
+        it('should not show menu or skeletons when GQL resolves under 300ms', () => {
+            const jcontent = JContent.visit(siteKey, 'en', `content-folders/contents/${folderName}`);
+            jcontent.switchToListMode();
+            jcontent.getTable().getRowByName(childFolderName).get().should('be.visible');
+
+            cy.intercept('POST', '/modules/graphql', req => {
+                req.reply(res => {
+                    res.setDelay(FAST_QUERY_DELAY_MS);
+                });
+            }).as('fastGql');
+
+            jcontent.getTable().getRowByName(childFolderName).get().rightclick();
+
+            // Menu must be hidden during the suppression window
+            cy.get('#menuHolder .moonstone-menu:not(.moonstone-hidden)').should('not.exist');
+
+            // After GQL resolves the menu appears immediately with real items — no skeleton ever shown
+            cy.wait('@fastGql');
+            cy.get('#menuHolder .moonstone-menu:not(.moonstone-hidden)', {
+                timeout: MENU_VISIBILITY_THRESHOLD_MS
+            }).should('be.visible')
+                .find('[data-sel-role="menu-item-skeleton"]')
+                .should('not.exist');
+        });
+
+        it('should keep skeleton visible for at least 200ms when GQL resolves just after the 300ms threshold', () => {
+            const jcontent = JContent.visit(siteKey, 'en', `content-folders/contents/${folderName}`);
+            jcontent.switchToListMode();
+            jcontent.getTable().getRowByName(childFolderName).get().should('be.visible');
+
+            // GQL resolves at ~350ms: skeleton appears at 300ms but load finishes only 50ms later,
+            // which is under the 200ms minimum hold — skeletons must still be visible at that point
+            cy.intercept('POST', '/modules/graphql', req => {
+                req.reply(res => {
+                    res.setDelay(JUST_OVER_THRESHOLD_MS);
+                });
+            }).as('justOverThresholdGql');
+
+            jcontent.getTable().getRowByName(childFolderName).get().rightclick();
+
+            // Skeleton appears after the 300ms show-delay
+            cy.get('#menuHolder .moonstone-menu:not(.moonstone-hidden)', {
+                timeout: MENU_VISIBILITY_THRESHOLD_MS
+            }).should('be.visible')
+                .find('[data-sel-role="menu-item-skeleton"]')
+                .should('have.length.greaterThan', 0);
+
+            // GQL finishes — skeleton has been visible < 200ms, so it must still be shown
+            cy.wait('@justOverThresholdGql');
+            cy.get('#menuHolder .moonstone-menu:not(.moonstone-hidden)')
+                .find('[data-sel-role="menu-item-skeleton"]')
+                .should('exist');
+
+            // After the minimum hold elapses, real items replace the skeletons
+            cy.get('#menuHolder .moonstone-menu:not(.moonstone-hidden)', {
+                timeout: MENU_VISIBILITY_THRESHOLD_MS
+            }).find('[data-sel-role="menu-item-skeleton"]').should('not.exist');
         });
     });
 

--- a/tests/cypress/e2e/menuActions/copyCutPaste.cy.ts
+++ b/tests/cypress/e2e/menuActions/copyCutPaste.cy.ts
@@ -217,6 +217,7 @@ describe('Copy Cut and Paste tests with jcontent', () => {
             const menu = contextMenu.submenu('Copy', 'jcontent-copyPageMenu');
             menu.should('be.visible');
             menu.select(copyActionName);
+            cy.get('#message-id').contains('is in the clipboard');
         };
 
         // Failing on hover to submenu but ok with other tests; skipping for now

--- a/tests/cypress/page-object/fields/toggleChoiceList.ts
+++ b/tests/cypress/page-object/fields/toggleChoiceList.ts
@@ -55,7 +55,9 @@ export class CheckboxChoiceList extends ToggleChoiceList {
     }
 
     contextMenu() {
-        getComponentByRole(Button, 'content-editor/field/Choicelist', this).click();
+        const contextMenuBtn = getComponentByRole(Button, 'content-editor/field/Choicelist', this);
+        contextMenuBtn.get().scrollIntoView();
+        contextMenuBtn.click();
         return getComponentBySelector(Menu, `#menuHolder ${Menu.defaultSelector}`);
     }
 }


### PR DESCRIPTION
### Description

To avoid flicker of loading state, introduce a delay to loading state only after a certain threshold. This should avoid showing loading state entirely for users with good enough connections. Once loading state is shown for slow connections, also add a bit of delay to avoid the flicker and provide a transition gap.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
