### PR TITLE
fix: preview style parsing for template with head attrs

### DIFF
--- a/src/javascript/JContent/preview/viewers/IframeViewer/IframeViewer.jsx
+++ b/src/javascript/JContent/preview/viewers/IframeViewer/IframeViewer.jsx
@@ -70,14 +70,14 @@ function extractInlineResourceTags(html, collectAssets = true) {
  * (Bootstrap, fonts, site theme) with the module-rendered component body.
  *
  * @param {string} pageHtml - full page renderedContent output
- * @returns {string} - content between <head> and </head>, or empty string
+ * @returns {string} - the full <head>...</head> element including opening tag attributes, or empty string
  */
 function extractPageHead(pageHtml) {
     if (!pageHtml) {
         return '';
     }
 
-    const match = /<head>([\s\S]*?)<\/head>/i.exec(pageHtml);
+    const match = /(<head[^>]*>[\s\S]*?<\/head>)/i.exec(pageHtml);
     return match ? match[1] : '';
 }
 
@@ -97,7 +97,7 @@ export const IframeViewer = ({previewContext, data, onContentNotFound, nodeData 
     } else if (isHybrid) {
         // In hybrid rendering, the page CSS is injected into the iframe via <link> elements.
         const pageHead = extractPageHead(pageCssHtml);
-        displayValue = `<html><head>${pageHead}</head><body>${cleanHtml}</body></html>`;
+        displayValue = `<html>${pageHead}<body>${cleanHtml}</body></html>`;
     } else {
         displayValue = cleanHtml;
     }

--- a/tests/cypress/e2e/jcontent/preview.cy.ts
+++ b/tests/cypress/e2e/jcontent/preview.cy.ts
@@ -1,14 +1,23 @@
 import {ContentEditor, JContent, SidePanel} from '../../page-object';
-import {addNode, deleteNode, enableModule} from '@jahia/cypress';
+import {addNode, createSite, deleteNode, deleteSite, enableModule} from '@jahia/cypress';
 
 describe('JContent preview tests', () => {
     const siteKey = 'jcontentSite';
     const sidePanel = new SidePanel();
 
     before(() => {
-        cy.executeGroovy('jcontent/createSite.groovy', {SITEKEY: siteKey});
-        cy.apollo({mutationFile: 'jcontent/createContent.graphql'});
+        createSite(siteKey, {
+            serverName: 'jahia',
+            locale: 'en',
+            templateSet: 'jcontent-test-template'
+        });
         enableModule('jcontent-test-module', siteKey);
+        enableModule('event', siteKey);
+        enableModule('bootstrap3-components', siteKey);
+        enableModule('article', siteKey);
+        enableModule('news', siteKey);
+
+        cy.apollo({mutationFile: 'jcontent/createContent.graphql'});
 
         addNode({
             parentPathOrId: `/sites/${siteKey}/contents`,
@@ -27,6 +36,24 @@ describe('JContent preview tests', () => {
             primaryNodeType: 'jnt:person',
             properties: [{name: 'firstname', value: 'Preview'}, {name: 'lastname', value: 'Person'}]
         });
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/home`,
+            name: 'head-attr-test-page',
+            primaryNodeType: 'jnt:page',
+            properties: [
+                {name: 'jcr:title', value: 'Head Attr Test Page', language: 'en'},
+                {name: 'j:templateName', type: 'STRING', value: 'home'}
+            ],
+            children: [{
+                name: 'pagecontent',
+                primaryNodeType: 'jnt:contentList',
+                children: [{
+                    name: 'head-attr-news',
+                    primaryNodeType: 'jnt:news',
+                    properties: [{name: 'jcr:title', value: 'Head Attr News', language: 'en'}]
+                }]
+            }]
+        });
     });
 
     beforeEach(() => {
@@ -35,7 +62,7 @@ describe('JContent preview tests', () => {
 
     after(() => {
         cy.logout();
-        cy.executeGroovy('jcontent/deleteSite.groovy', {SITEKEY: siteKey});
+        deleteSite(siteKey);
     });
 
     it('should honor the j:view property when previewing content', () => {
@@ -124,6 +151,22 @@ describe('JContent preview tests', () => {
         cy.contains('This list is empty and cannot be previewed').should('be.visible');
 
         deleteNode(`/sites/${siteKey}/home/jcontent-empty-list-test`);
+    });
+
+    it('should preserve <head> element attributes in hybrid iframe srcDoc', () => {
+        // Jcontent-test-template renders <head data-stub="test"> — verifies that extractPageHead
+        // captures the full opening tag so attributes are not lost when IframeViewer builds srcDoc.
+        const jcontent = JContent.visit(siteKey, 'en', 'pages/home/head-attr-test-page');
+        jcontent.switchToListMode();
+        jcontent.getTable().getRowByName('head-attr-news').click();
+        sidePanel.switchToTab('tab-preview');
+
+        cy.get('iframe[data-sel-role="edit-preview-frame"]').should('be.visible');
+        cy.get('iframe[data-sel-role="edit-preview-frame"]').should($iframe => {
+            const head = $iframe[0].contentDocument.querySelector('head');
+            expect(head, 'iframe should have a head element').to.exist;
+            expect(head.getAttribute('data-stub'), '<head data-stub> attribute should be preserved from page template').to.equal('test');
+        });
     });
 
     it('should reflect edit workspace changes in preview', () => {

--- a/tests/jahia-module/jcontent-test-template/src/main/resources/jnt_template/html/template.jcontent-test-template.jsp
+++ b/tests/jahia-module/jcontent-test-template/src/main/resources/jnt_template/html/template.jcontent-test-template.jsp
@@ -14,7 +14,7 @@
 <%--@elvariable id="currentResource" type="org.jahia.services.render.Resource"--%>
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
-<head>
+<head data-stub="test">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
     <title>${fn:escapeXml(renderContext.mainResource.node.displayableName)}</title>


### PR DESCRIPTION
### Description

Fix html regex parsing issue on preview when generated page template has head attributes.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
