### PR TITLE
feat: support node type resolver in form generation

### DIFF
--- a/.chachalog/nodeTypeResolver.md
+++ b/.chachalog/nodeTypeResolver.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Added support for custom node-type resolution in form generation via the new `NodeTypeResolver` interface. This allows external modules to control which mixins are considered active and how type membership is evaluated, decoupling form structure from the current state of a JCR node. Enables use cases like generating forms for historical node snapshots without modifying the live node data.

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormService.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormService.java
@@ -26,6 +26,8 @@ package org.jahia.modules.contenteditor.api.forms;
 import org.jahia.modules.contenteditor.api.forms.model.FieldValueConstraint;
 import org.jahia.modules.contenteditor.api.forms.model.Form;
 import org.jahia.modules.contenteditor.graphql.api.types.ContextEntryInput;
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.content.nodetypes.ExtendedNodeType;
 
 import java.util.List;
 import java.util.Locale;
@@ -61,6 +63,25 @@ public interface EditorFormService {
      * @throws EditorFormException if there was an error during the generation of the form.
      */
     Form getEditForm(String uuidOrPath, Locale uiLocale, Locale locale) throws EditorFormException;
+
+    /**
+     * Retrieves a form editor structure for an existing node, with node-type resolution
+     * controlled by the supplied {@link NodeTypeResolver}. This allows callers, typically
+     * in external modules, to drive dynamic fieldset activation and mixin-conditional
+     * visibility from a source other than the current JCR node (e.g. a historical snapshot).
+     *
+     * @param primaryNodeType  the primary node type of the node
+     * @param existingNode     the node being edited (used for site, session, and permissions)
+     * @param parentNode       the parent node
+     * @param nodeTypeResolver strategy that controls which mixins are considered active and
+     *                         how type membership is evaluated
+     * @param uiLocale         the locale used to display labels
+     * @param locale           the locale used to get node data
+     * @return the generated form structure
+     * @throws EditorFormException if there was an error during form generation
+     * @see JcrNodeTypeResolver
+     */
+    Form getEditorForm(ExtendedNodeType primaryNodeType, JCRNodeWrapper existingNode, JCRNodeWrapper parentNode, NodeTypeResolver nodeTypeResolver, Locale uiLocale, Locale locale) throws EditorFormException;
 
     /**
      * Retrieve field constraints for given node

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
@@ -106,16 +106,25 @@ public class EditorFormServiceImpl implements EditorFormService {
         }
     }
 
+
+
     private Form getEditorForm(ExtendedNodeType primaryNodeType, JCRNodeWrapper existingNode, JCRNodeWrapper parentNode, Locale uiLocale, Locale locale) throws EditorFormException {
+        return getEditorForm(primaryNodeType, existingNode, parentNode,
+            existingNode != null ? new JcrNodeTypeResolver(existingNode) : null,
+            uiLocale, locale);
+    }
+
+    @Override
+    public Form getEditorForm(ExtendedNodeType primaryNodeType, JCRNodeWrapper existingNode, JCRNodeWrapper parentNode, NodeTypeResolver nodeTypeResolver, Locale uiLocale, Locale locale) throws EditorFormException {
         final String mode = existingNode == null ? CREATE : EDIT;
         final JCRNodeWrapper currentNode = EDIT.equals(mode) ? existingNode : parentNode;
 
         try {
             final JCRSiteNode site = currentNode.getResolveSite();
 
-            // Get all currently applied mixins if node exists, otherwise get all supertypes for the primary node type being created.
+            // Get all applied mixins from the node type resolver or supertypes when creating.
             Collection<ExtendedNodeType> nodeTypes = (existingNode != null) ?
-                Arrays.asList(existingNode.getMixinNodeTypes()) : primaryNodeType.getSupertypeSet();
+                nodeTypeResolver.getAppliedMixins() : primaryNodeType.getSupertypeSet();
 
             // Gather all nodetypes and get associated forms
             Set<String> processedNodeTypes = new HashSet<>();
@@ -130,9 +139,9 @@ public class EditorFormServiceImpl implements EditorFormService {
                 addFormNodeType(extendMixin, site, mergeSet, locale, true, processedNodeTypes, nodeTypes);
             }
 
-            // Mixins added on node
-            if (existingNode != null) {
-                for (ExtendedNodeType mixinNodeType : existingNode.getMixinNodeTypes()) {
+            // Mixins added on node (from the node type resolver)
+            if (nodeTypeResolver != null) {
+                for (ExtendedNodeType mixinNodeType : nodeTypeResolver.getAppliedMixins()) {
                     addFormNodeType(mixinNodeType, site, mergeSet, locale, false, processedNodeTypes, nodeTypes);
                 }
             }
@@ -183,7 +192,7 @@ public class EditorFormServiceImpl implements EditorFormService {
                         boolean isExtend = !nodeType.getMixinExtends().isEmpty() && !primaryNodeType.isNodeType(nodeType.getName());
                         if (isExtend) {
                             fieldSet.setDynamic(true);
-                            boolean isActivated = existingNode != null && existingNode.isNodeType(fieldSet.getName());
+                            boolean isActivated = existingNode != null && nodeTypeResolver.isNodeType(fieldSet.getName());
                             boolean isAlwaysActivated = fieldSet.isAlwaysActivated() != null && fieldSet.isAlwaysActivated();
                             boolean isActivatedOnCreate = fieldSet.isActivatedOnCreate() != null && fieldSet.isActivatedOnCreate();
                             fieldSet.setActivated(isActivated || isAlwaysActivated || existingNode == null && isActivatedOnCreate);

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
@@ -122,8 +122,8 @@ public class EditorFormServiceImpl implements EditorFormService {
         try {
             final JCRSiteNode site = currentNode.getResolveSite();
 
-            // Get all applied mixins from the node type resolver or supertypes when creating.
-            Collection<ExtendedNodeType> nodeTypes = (existingNode != null) ?
+            // Get all applied mixins from the node type resolver or supertypes if no resolver is provided.
+            Collection<ExtendedNodeType> nodeTypes = (nodeTypeResolver != null) ?
                 nodeTypeResolver.getAppliedMixins() : primaryNodeType.getSupertypeSet();
 
             // Gather all nodetypes and get associated forms
@@ -139,7 +139,7 @@ public class EditorFormServiceImpl implements EditorFormService {
                 addFormNodeType(extendMixin, site, mergeSet, locale, true, processedNodeTypes, nodeTypes);
             }
 
-            // Mixins added on node (from the node type resolver)
+            // Mixins added on node (retrieved from the node type resolver)
             if (nodeTypeResolver != null) {
                 for (ExtendedNodeType mixinNodeType : nodeTypeResolver.getAppliedMixins()) {
                     addFormNodeType(mixinNodeType, site, mergeSet, locale, false, processedNodeTypes, nodeTypes);
@@ -192,7 +192,7 @@ public class EditorFormServiceImpl implements EditorFormService {
                         boolean isExtend = !nodeType.getMixinExtends().isEmpty() && !primaryNodeType.isNodeType(nodeType.getName());
                         if (isExtend) {
                             fieldSet.setDynamic(true);
-                            boolean isActivated = existingNode != null && nodeTypeResolver.isNodeType(fieldSet.getName());
+                            boolean isActivated = nodeTypeResolver != null && nodeTypeResolver.isNodeType(fieldSet.getName());
                             boolean isAlwaysActivated = fieldSet.isAlwaysActivated() != null && fieldSet.isAlwaysActivated();
                             boolean isActivatedOnCreate = fieldSet.isActivatedOnCreate() != null && fieldSet.isActivatedOnCreate();
                             fieldSet.setActivated(isActivated || isAlwaysActivated || existingNode == null && isActivatedOnCreate);

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/JcrNodeTypeResolver.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/JcrNodeTypeResolver.java
@@ -1,0 +1,32 @@
+package org.jahia.modules.contenteditor.api.forms;
+
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.content.nodetypes.ExtendedNodeType;
+
+import javax.jcr.RepositoryException;
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * {@link NodeTypeResolver} backed by a live JCR node. Both {@link #getAppliedMixins()} and
+ * {@link #isNodeType(String)} delegate directly to the underlying {@link JCRNodeWrapper},
+ * so the form reflects the current state of a given node in the repository.
+ */
+public class JcrNodeTypeResolver implements NodeTypeResolver {
+
+    private final JCRNodeWrapper node;
+
+    JcrNodeTypeResolver(JCRNodeWrapper node) {
+        this.node = node;
+    }
+
+    @Override
+    public Collection<ExtendedNodeType> getAppliedMixins() throws RepositoryException {
+        return Arrays.asList(node.getMixinNodeTypes());
+    }
+
+    @Override
+    public boolean isNodeType(String typeName) throws RepositoryException {
+        return node.isNodeType(typeName);
+    }
+}

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/JcrNodeTypeResolver.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/JcrNodeTypeResolver.java
@@ -6,6 +6,7 @@ import org.jahia.services.content.nodetypes.ExtendedNodeType;
 import javax.jcr.RepositoryException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 
 /**
  * {@link NodeTypeResolver} backed by a live JCR node. Both {@link #getAppliedMixins()} and
@@ -17,6 +18,7 @@ public class JcrNodeTypeResolver implements NodeTypeResolver {
     private final JCRNodeWrapper node;
 
     JcrNodeTypeResolver(JCRNodeWrapper node) {
+        Objects.requireNonNull(node, "node cannot be null");
         this.node = node;
     }
 

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/NodeTypeResolver.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/NodeTypeResolver.java
@@ -1,0 +1,35 @@
+package org.jahia.modules.contenteditor.api.forms;
+
+import org.jahia.services.content.nodetypes.ExtendedNodeType;
+
+import javax.jcr.RepositoryException;
+import java.util.Collection;
+
+/**
+ * Strategy for resolving applied mixin types and performing node-type checks during form
+ * generation. Providing a custom implementation gives callers full control over which mixins
+ * are considered active and how type membership is evaluated, decoupling form structure
+ * from the current state of any particular JCR node.
+ *
+ * <p>The default implementation, {@link JcrNodeTypeResolver}, delegates directly to a
+ * {@code JCRNodeWrapper} and reflects the current state of the node in the repository.
+ * External modules can supply alternative implementations and pass them via
+ * {@link EditorFormService#getEditorForm}.
+ */
+public interface NodeTypeResolver {
+
+    /**
+     * Returns the mixin types that should be treated as applied for this context.
+     * Mirrors {@code JCRNodeWrapper.getMixinNodeTypes()} — returns directly applied mixins only,
+     * not their supertypes.
+     */
+    Collection<ExtendedNodeType> getAppliedMixins() throws RepositoryException;
+
+    /**
+     * Returns {@code true} if the resolved type set includes {@code typeName} or any of its
+     * supertypes. Mirrors {@code JCRNodeWrapper.isNodeType(String)}.
+     *
+     * @param typeName the name of a node type.
+     */
+    boolean isNodeType(String typeName) throws RepositoryException;
+}

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/NodeTypeResolver.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/NodeTypeResolver.java
@@ -1,9 +1,11 @@
 package org.jahia.modules.contenteditor.api.forms;
 
+import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.nodetypes.ExtendedNodeType;
 
 import javax.jcr.RepositoryException;
 import java.util.Collection;
+import java.util.Locale;
 
 /**
  * Strategy for resolving applied mixin types and performing node-type checks during form
@@ -14,7 +16,7 @@ import java.util.Collection;
  * <p>The default implementation, {@link JcrNodeTypeResolver}, delegates directly to a
  * {@code JCRNodeWrapper} and reflects the current state of the node in the repository.
  * External modules can supply alternative implementations and pass them via
- * {@link EditorFormService#getEditorForm}.
+ * {@link EditorFormService#getEditorForm(ExtendedNodeType, JCRNodeWrapper, JCRNodeWrapper, NodeTypeResolver, Locale, Locale)}.
  */
 public interface NodeTypeResolver {
 

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/GqlEditorForms.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/GqlEditorForms.java
@@ -90,7 +90,7 @@ public class GqlEditorForms {
 
     @GraphQLField
     @GraphQLName("editForm")
-    @GraphQLDescription("Get a editor form from a locale and an existing node")
+    @GraphQLDescription("Get an editor form from a locale and an existing node")
     public GqlEditorForm getEditForm(
         @GraphQLName("uiLocale") @GraphQLNonNull @GraphQLDescription("A string representation of a locale, in IETF BCP 47 language tag format, ie en_US, en, fr, fr_CH, ...") String uiLocale,
         @GraphQLName("locale") @GraphQLNonNull @GraphQLDescription("A string representation of a locale, in IETF BCP 47 language tag format, ie en_US, en, fr, fr_CH, ...") String locale,


### PR DESCRIPTION
Closes https://github.com/Jahia/content-versioning/issues/76.

### Description

Adds `NodeTypeResolver` interface to decouple form structure from JCR node state, enabling external modules to control mixin activation and type checks. Useful for generating forms for historical snapshots or other custom contexts.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
