### PR TITLE
feat: Accordion customization options for context menu, columns

### DIFF
--- a/.chachalog/HKqkVPCe.md
+++ b/.chachalog/HKqkVPCe.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Added new `tableConfig` options for accordion items - `contextualMenu` to override the right-click menu, `header.showStatus` to hide the publication-status badge, and `columns` to control which table columns are shown. (#2491)

--- a/src/javascript/JContent.assignActionAndMenuTargets.js
+++ b/src/javascript/JContent.assignActionAndMenuTargets.js
@@ -39,6 +39,10 @@ const assignTargetsForActions = (targetActions, registry) => {
     });
 };
 
+export const addContextMenuTargetToActions = (targetName, actions) => {
+    assignTargetsForActions({[targetName]: actions}, registry);
+};
+
 const actionTargetAssignments = {
     '--contentActions': ['createPage', 'createNavMenuItemMenu', 'contentActionsSeparator1', 'createContent', 'replaceFile', 'locate', 'preview', 'createContentFolder', 'rename', 'edit', 'editPage', 'zip', 'editAdvanced', 'editSource', 'editPageAdvanced', 'unzip', 'openInPageBuilder', 'openInRepositoryExplorer', 'editImage', 'createFolder', 'downloadFile', 'copy', 'copyPageMenu', 'cut', 'paste', 'pasteReference', 'fileUpload', 'publishDeletion', 'delete', 'deletePermanently', 'undelete', 'exportPage', 'export', 'downloadAsZip', 'import', 'lock', 'unlock', 'clearAllLocks', 'publishMenu', 'flushPageCache', 'flushSiteCache', 'contentActionsSeparator2', 'subContents'],
     createMenuActions: [

--- a/src/javascript/JContent/ContentHeader/ContentHeader.jsx
+++ b/src/javascript/JContent/ContentHeader/ContentHeader.jsx
@@ -86,8 +86,10 @@ const ContentHeader = () => {
 
     const inSearchMode = JContentConstants.mode.SEARCH === mode || JContentConstants.mode.SQL2SEARCH === mode;
 
-    const viewSelector = registry.get('accordionItem', mode)?.tableConfig?.viewSelector;
-    const sortSelector = registry.get('accordionItem', mode)?.tableConfig?.sortSelector;
+    const tableConfig = registry.get('accordionItem', mode)?.tableConfig;
+    const viewSelector = tableConfig?.viewSelector;
+    const sortSelector = tableConfig?.sortSelector;
+    const showStatus = tableConfig?.header?.showStatus !== false;
 
     const {loading, node} = useNodeInfo({path, language, displayLanguage}, {
         getPrimaryNodeType: true,
@@ -114,7 +116,7 @@ const ContentHeader = () => {
             mainActions={<MainActionBar/>}
             breadcrumb={<ContentPath/>}
             contentType={nodeType && <Chip color="accent" label={nodeType.displayName || nodeType.name} icon={getNodeTypeIcon(nodeType.name)}/>}
-            status={<ContentStatuses node={node}/>}
+            status={showStatus && <ContentStatuses node={node}/>}
             toolbarLeft={<NarrowHeaderActions path={nodePath} previewSelection={previewSelection} selection={selection} clear={clear}/>}
             toolbarRight={<><ContentStatusSelector/>{sortSelector}{viewSelector}</>}
         />
@@ -124,7 +126,7 @@ const ContentHeader = () => {
             mainActions={<MainActionBar/>}
             breadcrumb={<ContentPath/>}
             contentType={nodeType && <Chip color="accent" label={nodeType.displayName || nodeType.name} icon={getNodeTypeIcon(nodeType.name)}/>}
-            status={<ContentStatuses node={node}/>}
+            status={showStatus && <ContentStatuses node={node}/>}
             toolbarLeft={
                 <>
                     {!previewSelection && selection.length > 0 && <SelectionActionsBar paths={selection} clear={clear}/>}

--- a/src/javascript/JContent/ContentHeader/ContentHeader.jsx
+++ b/src/javascript/JContent/ContentHeader/ContentHeader.jsx
@@ -125,6 +125,7 @@ const ContentHeader = () => {
             title={title}
             mainActions={<MainActionBar/>}
             breadcrumb={<ContentPath/>}
+            className="content-header"
             contentType={nodeType && <Chip color="accent" label={nodeType.displayName || nodeType.name} icon={getNodeTypeIcon(nodeType.name)}/>}
             status={showStatus && <ContentStatuses node={node}/>}
             toolbarLeft={

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/ContentTable.jsx
@@ -22,7 +22,7 @@ import {useTable} from 'react-table';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import {useExpandedControlled, useRowSelection, useSort} from './reactTable/plugins';
 import {ContentListHeader} from './ContentListHeader/ContentListHeader';
-import {mainColumnData, mediaColumnData, reducedColumnData, searchColumnData} from './reactTable/columns';
+import {allColumnData, mainColumnData, reducedColumnData, searchColumnData} from './reactTable/columns';
 import {ContentTableWrapper} from './ContentTableWrapper';
 import {flattenTree, isInSearchMode} from '../ContentLayout.utils';
 import {useKeyboardNavigation} from '../useKeyboardNavigation';
@@ -42,11 +42,18 @@ export const ContentTable = ({rows, isContentNotFound, totalCount, isLoading, is
             return propColumns;
         }
 
+        const configColumns = registry.get('accordionItem', mode)?.tableConfig?.columns;
+        if (configColumns) {
+            return configColumns
+                .map(c => typeof c === 'string' ? allColumnData.find(col => col.id === c) : c)
+                .filter(Boolean);
+        }
+
         if (isInSearchMode(mode)) {
             return searchColumnData;
         }
 
-        return mode === JContentConstants.mode.MEDIA ? mediaColumnData : mainColumnData;
+        return mainColumnData;
     }, [mode, propColumns]);
     const onSidePanelSelect = useCallback(_sidePanelSelection => dispatch(cmSetSidePanelSelection(_sidePanelSelection)), [dispatch]);
     const setCurrentPage = useCallback(page => dispatch(cmSetPage(page - 1)), [dispatch]);

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/Row.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/Row.jsx
@@ -52,6 +52,11 @@ export const Row = ({
         contextualMenu.current(event);
     };
 
+    let contextualMenuActionKey = tableConfig.contextualMenu ?? 'contentItemContextActionsMenu';
+    if (selection.length > 0) {
+        contextualMenuActionKey = selection.includes(node.path) ? 'selectedContentMenu' : 'notSelectedContentMenu';
+    }
+
     return (
         <TableRow {...rowProps}
                   ref={node => virtualizer.measureElement(node)} // Measure dynamic row height
@@ -84,10 +89,10 @@ export const Row = ({
         >
             <ContextualMenu
                 setOpenRef={contextualMenu}
-                actionKey={selection.length === 0 ? 'contentItemContextActionsMenu' : (selection.indexOf(node.path) === -1 ? 'notSelectedContentMenu' : 'selectedContentMenu')}
+                actionKey={contextualMenuActionKey}
                 currentPath={node.path}
-                path={selection.length === 0 || selection.indexOf(node.path) === -1 ? node.path : null}
-                paths={selection.length === 0 || selection.indexOf(node.path) === -1 ? null : selection}
+                path={selection.length === 0 || !selection.includes(node.path) ? node.path : null}
+                paths={selection.length === 0 || !selection.includes(node.path) ? null : selection}
                 node={node}
             />
             {row.cells.map(cell => <React.Fragment key={cell.column.id}>{cell.render('Cell')}</React.Fragment>)}
@@ -104,6 +109,7 @@ Row.propTypes = {
     onPreviewSelect: PropTypes.func,
     doubleClickNavigation: PropTypes.func,
     tableConfig: PropTypes.shape({
+        contextualMenu: PropTypes.string,
         dnd: PropTypes.shape({
             canDrag: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
             canDrop: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),

--- a/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/columns/columns.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/columns/columns.js
@@ -122,3 +122,4 @@ export const mainColumnData = [publicationStatus, selection, name, status, type,
 export const searchColumnData = [publicationStatus, selection, nameBigIcon, status, type, createdBy, lastModified, visibleActions];
 export const mediaColumnData = [publicationStatus, selection, nameBigIcon, status, usages, fileSize, mediaType, createdBy, lastModified, visibleActions];
 export const reducedColumnData = [publicationStatus, selection, name, status, createdBy, lastModified, visibleActions];
+export const allColumnData = [publicationStatus, selection, name, nameBigIcon, status, type, createdBy, lastModified, visibleActions, fileSize, usages];

--- a/src/javascript/JContent/JContent.accordion-items.jsx
+++ b/src/javascript/JContent/JContent.accordion-items.jsx
@@ -17,6 +17,7 @@ import {SearchQueryHandler} from '~/JContent/ContentRoute/ContentLayout/queryHan
 import {Sql2SearchQueryHandler} from '~/JContent/ContentRoute/ContentLayout/queryHandlers/Sql2SearchQueryHandler';
 import {SORT_CONTENT_TREE_BY_NAME_ASC} from '~/JContent/ContentTree/ContentTree.constants';
 import {booleanValue} from '~/JContent/JContent.utils';
+import {mediaColumnData} from '~/JContent/ContentRoute/ContentLayout/ContentTable/reactTable/columns';
 import {
     DeletionInfoQueryHandler
 } from '~/JContent/actions/deleteActions/Delete/InfoTable/queryHandlers/DeletionInfoQueryHandler';
@@ -194,6 +195,7 @@ export const jContentAccordionItems = registry => {
         },
         tableConfig: {
             queryHandler: FilesQueryHandler,
+            columns: mediaColumnData,
             typeFilter: ['jnt:file', 'jnt:folder'],
             viewSelector: <FileModeSelector/>,
             sortSelector: <SortSelector/>,

--- a/src/javascript/shared/index.js
+++ b/src/javascript/shared/index.js
@@ -1,3 +1,4 @@
+export {addContextMenuTargetToActions} from '../JContent.assignActionAndMenuTargets';
 export {default as ContentTree} from '../JContent/ContentTree';
 export {default as ContentNavigation} from '../JContent/ContentNavigation';
 export {default as SiteSwitcher} from '../JContent/ContentNavigation/NavigationHeader/SwitchersLayout/SiteSwitcher';
@@ -16,6 +17,7 @@ export {useLayoutQuery} from '../JContent/ContentRoute/ContentLayout/useLayoutQu
 export {NodeIcon} from '../utils/NodeIcon';
 export * as jcontentUtils from '../JContent/JContent.utils';
 export * as reactTable from '../JContent/ContentRoute/ContentLayout/ContentTable/reactTable';
+export * as columnDefinitions from '../JContent/ContentRoute/ContentLayout/ContentTable/reactTable/columns';
 export {FileCard, FileSize} from '../JContent/ContentRoute/ContentLayout/FilesGrid/FileCard';
 export * from '../JContent/ContentRoute/ContentLayout/queryHandlers';
 export * from '../JContent/dnd';

--- a/tests/assets/provisioning.yml
+++ b/tests/assets/provisioning.yml
@@ -7,7 +7,6 @@
 
 # This modules were added during the switch from using jahia-discovery to jahia-ee
 - installBundle:
-    - 'mvn:org.jahia.modules/legacy-default-components'
     - 'mvn:org.jahia.modules/dx-base-demo-core'
     - 'mvn:org.jahia.modules/dx-base-demo-components'
     - 'mvn:org.jahia.modules/dx-base-demo-templates'

--- a/tests/cypress/e2e/jcontent/shard2/accordionConfig.cy.ts
+++ b/tests/cypress/e2e/jcontent/shard2/accordionConfig.cy.ts
@@ -1,0 +1,84 @@
+import {createSite, deleteSite, enableModule} from '@jahia/cypress';
+import gql from 'graphql-tag';
+import {JContent} from '../../../page-object';
+
+describe('Accordion tableConfig', () => {
+    const siteKey = 'tableconfigtest';
+
+    before(() => {
+        createSite(siteKey, {
+            templateSet: 'dx-base-demo-templates',
+            serverName: 'localhost',
+            locale: 'en'
+        });
+        enableModule('jcontent-test-module', siteKey);
+        cy.apollo({mutation: gql`
+            mutation {
+                jcr {
+                    mutateNode(pathOrId: "/sites/${siteKey}/contents") {
+                        addChild(name: "test-child", primaryNodeType: "jnt:bigText") {
+                            uuid
+                        }
+                    }
+                }
+            }
+        `});
+        cy.loginAndStoreSession();
+    });
+
+    beforeEach(() => {
+        cy.login();
+    });
+
+    after(() => {
+        deleteSite(siteKey);
+        cy.logout();
+    });
+
+    describe('tableConfig.columns', () => {
+        it('shows columns specified in tableConfig', () => {
+            JContent.visit(siteKey, 'en', 'tableconfig-test/contents').switchToListMode();
+
+            cy.get('[data-cm-role="table-content-list-header-cell-name"]').should('exist');
+            cy.get('[data-cm-role="table-content-list-header-cell-type"]').should('exist');
+            cy.get('[data-cm-role="table-content-list-header-cell-lastModified"]').should('exist');
+        });
+
+        it('hides columns not specified in tableConfig', () => {
+            JContent.visit(siteKey, 'en', 'tableconfig-test/contents').switchToListMode();
+
+            cy.get('[data-cm-role="table-content-list-header-cell-status"]').should('not.exist');
+            cy.get('[data-cm-role="table-content-list-header-cell-createdBy"]').should('not.exist');
+        });
+    });
+
+    describe('tableConfig.contextualMenu', () => {
+        it('shows only actions registered for the custom context menu', () => {
+            const jcontent = JContent.visit(siteKey, 'en', 'tableconfig-test/contents').switchToListMode();
+
+            const menu = jcontent.getTable().getRowByName('test-child').contextMenu();
+            menu.shouldHaveItem('Edit');
+            menu.shouldHaveItem('Export');
+        });
+
+        it('does not show actions excluded from the custom context menu', () => {
+            const jcontent = JContent.visit(siteKey, 'en', 'tableconfig-test/contents').switchToListMode();
+
+            jcontent.getTable().getRowByName('test-child').contextMenu();
+            cy.get('#menuHolder .moonstone-menu:not(.moonstone-hidden)').should('not.contain.text', 'Delete');
+            cy.get('#menuHolder .moonstone-menu:not(.moonstone-hidden)').should('not.contain.text', 'Copy');
+        });
+    });
+
+    describe('tableConfig.header.showStatus', () => {
+        it('hides content status in the header when showStatus is false', () => {
+            JContent.visit(siteKey, 'en', 'tableconfig-test/contents').switchToListMode();
+            cy.get('.content-header [data-sel-role="content-status"]', {timeout: 10000}).should('not.exist');
+        });
+
+        it('shows content status in the header by default', () => {
+            JContent.visit(siteKey, 'en', 'pages/home').switchToListMode();
+            cy.get('.content-header [data-sel-role="content-status"]').should('be.visible');
+        });
+    });
+});

--- a/tests/cypress/page-object/accordionItem.ts
+++ b/tests/cypress/page-object/accordionItem.ts
@@ -1,4 +1,5 @@
-import {Accordion, BaseComponent, Menu, getComponentBySelector} from '@jahia/cypress';
+import {Accordion, BaseComponent, getComponentBySelector} from '@jahia/cypress';
+import {JContentMenu} from './jcontentMenu';
 import ClickOptions = Cypress.ClickOptions;
 
 export class AccordionItem {
@@ -81,8 +82,12 @@ export class TreeItem extends BaseComponent {
         });
     }
 
-    contextMenu(): Menu {
+    contextMenu(): JContentMenu {
         this.get().rightclick();
-        return getComponentBySelector(Menu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)');
+        // Park the cursor away from the menu after opening it. On CI the real
+        // mouse position can coincide with where the menu renders, leaving an
+        // item pre-hovered so that a subsequent realHover() fires no mouseenter.
+        cy.get('body').realHover({position: 'topLeft'});
+        return getComponentBySelector(JContentMenu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)');
     }
 }

--- a/tests/cypress/page-object/categoryManager.ts
+++ b/tests/cypress/page-object/categoryManager.ts
@@ -34,11 +34,12 @@ export class CategoryManager extends JContent {
         return this.getAccordionItem().getTreeItem(role);
     }
 
-    createCategoryNav(parentName: string, fields: {title?: string, name?: string}) {
+    createCategoryNav(parentName: string, fields: {title: string, name?: string}) {
         const accordionItem = this.getAccordionItem();
         accordionItem.getTreeItem(parentName).click();
         getComponentByRole(Button, 'jnt:category').click(); // New Category header menu
         this.editFields(fields).create();
+        this.getTable().getRowByName(fields.name || fields.title).should('be.visible');
     }
 
     editCategoryNav(name: string, fields: {title?: string, name?: string}, lang?: string) {

--- a/tests/jahia-module/jcontent-test-module/src/javascript/init.jsx
+++ b/tests/jahia-module/jcontent-test-module/src/javascript/init.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {registry} from '@jahia/ui-extender';
+import {addContextMenuTargetToActions} from '@jahia/jcontent';
 import {CustomBar} from './CustomBar';
 import i18next from 'i18next';
 import {PickerDialog} from './PickerDialog';
@@ -11,14 +12,38 @@ export default function () {
     registry.add('callback', 'accordion-config', {
         targets: ['jahiaApp-init:60'],
         callback: function () {
-            const pageAccordion = window.jahia.uiExtender.registry.get('accordionItem', 'pages');
-            window.jahia.uiExtender.registry.add('accordionItem', 'accordion-config', pageAccordion, {
+            const pageAccordion = registry.get('accordionItem', 'pages');
+            registry.add('accordionItem', 'accordion-config', pageAccordion, {
                 targets: ['jcontent:998'],
                 label: 'test1',
                 icon: window.jahia.moonstone.toIconComponent('<svg style="width:24px;height:24px" viewBox="0 0 24 24"><path fill="currentColor" d="M19 6V5A2 2 0 0 0 17 3H15A2 2 0 0 0 13 5V6H11V5A2 2 0 0 0 9 3H7A2 2 0 0 0 5 5V6H3V20H21V6M19 18H5V8H19Z" /></svg>'),
                 requireModuleInstalledOnSite: 'jcontent-test-module',
                 isEnabled: function (siteKey) {
                     return siteKey !== 'systemsite';
+                }
+            });
+
+            // Register a test accordion that exercises tableConfig features:
+            // contextualMenu, header.showStatus, and columns
+            const contextualMenu = 'tableConfigTestMenu';
+            const menuTarget = 'tableConfigTestMenuActions';
+            const menuActionWithRenderer = registry.get('action', 'menuAction');
+            registry.add('action', contextualMenu, menuActionWithRenderer, {
+                menuTarget,
+                menuItemProps: {isShowIcons: true}
+            });
+            addContextMenuTargetToActions(menuTarget, ['edit', 'export']);
+
+            const contentFoldersAccordion = registry.get('accordionItem', 'content-folders');
+            registry.add('accordionItem', 'tableconfig-test', contentFoldersAccordion, {
+                targets: ['jcontent:999'],
+                label: 'tableconfig-test',
+                isEnabled: siteKey => siteKey !== 'systemsite',
+                tableConfig: {
+                    ...contentFoldersAccordion.tableConfig,
+                    contextualMenu,
+                    header: {showStatus: false},
+                    columns: ['publicationStatus', 'selection', 'name', 'type', 'lastModified', 'visibleActions']
                 }
             });
         }

--- a/tests/jahia-module/jcontent-test-module/webpack.config.js
+++ b/tests/jahia-module/jcontent-test-module/webpack.config.js
@@ -114,6 +114,7 @@ module.exports = (env, argv) => {
                 },
                 remotes: {
                     '@jahia/app-shell': 'appShellRemote',
+                    '@jahia/jcontent': 'appShell.remotes.jcontent'
                 },
             }, Object.keys(packageJson.dependencies))),
             new CleanWebpackPlugin({


### PR DESCRIPTION
### Description

Added new tableConfig options for accordion items

contextualMenu to override the right-click menu
header.showStatus to hide the publication-status badge
columns to control which table columns are shown.

#### Test

Added new test suite `accordionConfig` to cover each scenario

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
