### PR TITLE
feat: export editor-form API packages for external modules

### DIFF
--- a/.chachalog/Zx7Ke2Qp.md
+++ b/.chachalog/Zx7Ke2Qp.md
@@ -1,6 +1,0 @@
----
-# Allowed version bumps: patch, minor, major
-"@jahia/jcontent": minor
----
-
-Export the editor-form API packages (`org.jahia.modules.contenteditor.api.forms` and `org.jahia.modules.contenteditor.api.forms.model`) so external modules can implement the `NodeTypeResolver` extension point (#2479) and generate editor forms through `EditorFormService`. Previously only `graphql.api.forms` was exported, so these types were unreachable across bundles. (#2479)

--- a/.chachalog/Zx7Ke2Qp.md
+++ b/.chachalog/Zx7Ke2Qp.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Export the editor-form API packages (`org.jahia.modules.contenteditor.api.forms` and `org.jahia.modules.contenteditor.api.forms.model`) so external modules can implement the `NodeTypeResolver` extension point (#2479) and generate editor forms through `EditorFormService`. Previously only `graphql.api.forms` was exported, so these types were unreachable across bundles. (#2479)

--- a/.chachalog/nodeTypeResolver.md
+++ b/.chachalog/nodeTypeResolver.md
@@ -3,4 +3,4 @@
 "@jahia/jcontent": minor
 ---
 
-Added support for custom node-type resolution in form generation via the new `NodeTypeResolver` interface. This allows external modules to control which mixins are considered active and how type membership is evaluated, decoupling form structure from the current state of a JCR node. Enables use cases like generating forms for historical node snapshots without modifying the live node data.
+Added support for custom node-type resolution in form generation via the new `NodeTypeResolver` interface. This allows external modules to control which mixins are considered active and how type membership is evaluated, decoupling form structure from the current state of a JCR node. Enables use cases like generating forms for historical node snapshots without modifying the live node data. The `org.jahia.modules.contenteditor.api.forms` and `org.jahia.modules.contenteditor.api.forms.model` packages are exported so external modules can consume the interface and the form model.

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,8 @@
             org.jahia.modules.contenteditor.graphql.api.definitions,
             org.jahia.modules.contenteditor.graphql.api.forms,
             org.jahia.modules.contenteditor.graphql.api.types,
+            org.jahia.modules.contenteditor.api.forms,
+            org.jahia.modules.contenteditor.api.forms.model,
         </export-package>
         <sonar.sources>src/javascript</sonar.sources>
     </properties>


### PR DESCRIPTION
## What

Export two Content Editor API packages from jContent so external modules can consume them at runtime:

- `org.jahia.modules.contenteditor.api.forms` — `EditorFormService`, `NodeTypeResolver`, `EditorFormException`
- `org.jahia.modules.contenteditor.api.forms.model` — `Form`

Only `org.jahia.modules.contenteditor.graphql.api.forms` was exported before, so these types could be compiled against but **not OSGi-wired** from another bundle.

## Why

#2479 introduced `NodeTypeResolver` as an extension point explicitly *"for external modules [to] supply alternative implementations … via `EditorFormService.getEditorForm(...)`"*. But the packages holding that interface (and the `Form` return type) aren't exported, so a separate bundle cannot import them — it stays `INSTALLED` / never `ACTIVE` at deploy.

Concretely this blocks **Jahia/content-versioning#135**: a `versionHistoryEditorForm` GraphQL field that builds a Content Editor form for a historical version via a `SnapshotNodeTypeResolver implements NodeTypeResolver`, delegating to `EditorFormService`. It compiles, but the content-versioning bundle can't resolve until these packages are exported.

## Change

Two lines added to `<export-package>` — no code change.

Refs #2479
Unblocks Jahia/content-versioning#135
