### PR TITLE
test: move testClickLeftMenuFromContentEditor selenium test to cypress

### DIFF
--- a/tests/cypress/e2e/contentEditor/shard2/editContent.cy.ts
+++ b/tests/cypress/e2e/contentEditor/shard2/editContent.cy.ts
@@ -120,6 +120,22 @@ describe('Create content tests', () => {
         cy.url().should('contain', '?param=test');
     });
 
+    it('should close CE when clicking outside modal', () => {
+        // Open CE with no changes, click outside to close
+        jcontent.editComponentByRowName('My simple text');
+        cy.get(ContentEditor.defaultSelector).parent().click(10, 10);
+        cy.get(ContentEditor.defaultSelector).should('not.exist');
+        cy.get('h1').should('contain', 'contents');
+
+        // Open CE, make a change, click outside to trigger unsaved changes dialog, discard
+        jcontent.editComponentByRowName('My simple text');
+        const contentEditor = new ContentEditor();
+        contentEditor.getSmallTextField('jnt:text_text').addNewValue('some change');
+        cy.get(ContentEditor.defaultSelector).parent().click(10, 10);
+        contentEditor.discard();
+        cy.get(ContentEditor.defaultSelector).should('not.exist');
+    });
+
     it('should display the on-change div', () => {
         const contentEditor = jcontent.editComponentByRowName('On change text');
         contentEditor.switchToAdvancedMode();

--- a/tests/cypress/page-object/contentEditor.ts
+++ b/tests/cypress/page-object/contentEditor.ts
@@ -129,6 +129,10 @@ export class ContentEditor extends BasePage {
         getComponentByRole(Button, 'backButton').get().should('not.exist', {timeout: 5000});
     }
 
+    discard() {
+        getComponentByRole(Button, 'close-dialog-discard').click();
+    }
+
     addAnotherContent() {
         cy.get('#createAnother').check();
         cy.get('#createAnother').should('have.attr', 'aria-checked', 'true');


### PR DESCRIPTION
### Description
Move Selenium test testClickLeftMenuFromContentEditor to Cypress.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
