### PR TITLE
chore: Rename changelog related to new `NodeTypeResolver`

### DIFF
--- a/.chachalog/hokG_S5B.md
+++ b/.chachalog/hokG_S5B.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Added support for custom node-type resolution in form generation via the new `NodeTypeResolver` interface. This allows external modules to control which mixins are considered active and how type membership is evaluated, decoupling form structure from the current state of a JCR node. Enables use cases like generating forms for historical node snapshots without modifying the live node data. The `org.jahia.modules.contenteditor.api.forms` and `org.jahia.modules.contenteditor.api.forms.model` packages are exported so external modules can consume the interface and the form model.

--- a/.chachalog/nodeTypeResolver.md
+++ b/.chachalog/nodeTypeResolver.md
@@ -1,6 +1,0 @@
----
-# Allowed version bumps: patch, minor, major
-"@jahia/jcontent": minor
----
-
-Added support for custom node-type resolution in form generation via the new `NodeTypeResolver` interface. This allows external modules to control which mixins are considered active and how type membership is evaluated, decoupling form structure from the current state of a JCR node. Enables use cases like generating forms for historical node snapshots without modifying the live node data. The `org.jahia.modules.contenteditor.api.forms` and `org.jahia.modules.contenteditor.api.forms.model` packages are exported so external modules can consume the interface and the form model.


### PR DESCRIPTION
### Description
The changelog entry added in https://github.com/Jahia/jcontent/pull/2479 was wrongly named.
Renamed it to align with the other changelog entries.


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
