### PR TITLE
fix: Add UI overlay for empty bounded component

### DIFF
--- a/.chachalog/jK9EAjm-.md
+++ b/.chachalog/jK9EAjm-.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Show empty content overlay in Page Builder when a bound component has no content to display (#2517)

--- a/.chachalog/upc21tuP.md
+++ b/.chachalog/upc21tuP.md
@@ -1,6 +1,0 @@
----
-# Allowed version bumps: patch, minor, major
-"@jahia/jcontent": minor
----
-
-Make sure bindable components can be selected in page builder when empty (#2330)

--- a/src/javascript/JContent/EditFrame/Box/Box.jsx
+++ b/src/javascript/JContent/EditFrame/Box/Box.jsx
@@ -249,7 +249,15 @@ export const Box = React.memo(({
     });
 
     isHeaderDisplayed = !isSomethingSelected && (isBarAlwaysDisplayed || isHeaderDisplayed);
-    if (!isHeaderDisplayed && !isHovered && !isSelected && !isStatusHighlighted) {
+
+    const isBindableEmpty = element.getAttribute('bindable') === 'true' &&
+        (!element.hasChildNodes() || !element.textContent?.trim());
+
+    if (isBindableEmpty) {
+        element.style['min-height'] = '100px';
+    }
+
+    if (!isHeaderDisplayed && !isHovered && !isSelected && !isStatusHighlighted && !isBindableEmpty) {
         return false;
     }
 
@@ -313,7 +321,7 @@ export const Box = React.memo(({
     const boxStyle = !isAnythingDragging && isClicked && breadcrumbs.length > 0 ? styles.withHeaderAndFooter : styles.withHeader;
     const hasNoTranslationOverlay = displayStatuses.has('noTranslation') &&
         !isMarkedForDeletionRoot &&
-        !element.hasChildNodes();
+        (!element.hasChildNodes() || !element.textContent?.trim());
 
     return (
         <div ref={rootDiv}
@@ -333,7 +341,7 @@ export const Box = React.memo(({
                 (isSelected || isClicked) && !isAnythingDragging ? styles.boxSelected : '',
                 (isStatusHighlighted) && styles.boxHighlighted,
                 displayStatuses.has('notVisible') && styles.boxNotVisible,
-                (hasNoTranslationOverlay) && styles.noDisplayOverlay)}
+                (hasNoTranslationOverlay || isBindableEmpty) && styles.noDisplayOverlay)}
                  style={{
                      '--jcontent-borderColor': borderColor
                  }}
@@ -341,7 +349,7 @@ export const Box = React.memo(({
                 {isHeaderDisplayed && Header}
                 {BoxStatus}
 
-                {hasNoTranslationOverlay &&
+                {(hasNoTranslationOverlay || isBindableEmpty) &&
                     <div className={styles.overlayLabel} style={{height: currentOffset.height}}>
                         {t('label.contentManager.pageBuilder.emptyContent')}
                     </div>}

--- a/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/Boxes.jsx
@@ -254,12 +254,6 @@ export const Boxes = ({currentDocument, currentFrameRef, currentDndInfo, addInte
                     element.dataset.jahiaPath = `${parent.dataset.jahiaPath}/${modulePath}`;
                 }
 
-                // If component is bindable (boostrap Pager for example) it can be the case that nothing is bound to it, as result it may be empty and difficult to edit.
-                // We need to make sure it is large enough to be selectable. This mimics what was previously done in page composer.
-                if (element.offsetHeight === 0 && element.getAttribute('bindable') === 'true') {
-                    element.style['min-height'] = '28px';
-                }
-
                 _modules.push(element);
             }
         });

--- a/src/javascript/JContent/EditFrame/Boxes/BoxesContextMenu.jsx
+++ b/src/javascript/JContent/EditFrame/Boxes/BoxesContextMenu.jsx
@@ -55,16 +55,6 @@ const buildMenuProps = (targetPath, selection, nodes) => {
     return {path: targetPath, paths: undefined, actionKey, currentPath: targetPath, node};
 };
 
-/**
- * @deprecated since version 3.4.0 https://github.com/Jahia/jcontent/pull/1879
- * This component will be removed in version 4.0.0.
- * @component
- * @param {Object} props Component props
- * @param {Object} props.currentFrameRef Reference to the current frame
- * @param {Object} props.currentDocument Current document object
- * @param {string} props.currentHoveredRef Current content path
- * @param {string[]} props.selection Array of selected paths
- */
 const BoxesContextMenu = ({currentFrameRef, currentDocument, selection, nodes}) => {
     const contextualMenu = useRef();
     const {hoveredPath: currentPath} = useHoverContext();

--- a/tests/cypress/e2e/contentEditor/shard2/boundComponent.cy.ts
+++ b/tests/cypress/e2e/contentEditor/shard2/boundComponent.cy.ts
@@ -1,9 +1,8 @@
-import {JContent} from '../../../page-object/jcontent';
-import {enableModule} from '@jahia/cypress';
+import {JContent, JContentPageBuilder} from '../../../page-object';
+import { addNode, deleteSite, enableModule, setNodeProperty } from '@jahia/cypress'
 
 describe('Bound component tests', () => {
     const siteKey = 'boundComponentSite';
-    let jcontent: JContent;
 
     before(() => {
         cy.executeGroovy('contentEditor/createSite.groovy', {SITEKEY: siteKey});
@@ -11,19 +10,19 @@ describe('Bound component tests', () => {
     });
 
     after(() => {
-        cy.executeGroovy('contentEditor/deleteSite.groovy', {SITEKEY: siteKey});
+        deleteSite(siteKey);
     });
 
     beforeEach(() => {
         cy.loginAndStoreSession();
-        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
     });
 
-    afterEach(() => {
+    after(() => {
         cy.logout();
     });
 
     it('Bound component can be added via content editor', () => {
+        const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents')
         jcontent.switchToListMode();
         const contentEditor = jcontent.createContent('cent:boundComponent');
         const picker = contentEditor.getPickerField('jmix:bindedComponent_j:bindedComponent').open();
@@ -32,10 +31,56 @@ describe('Bound component tests', () => {
         picker.select();
         contentEditor.create();
 
-        const boundComponent = jcontent.getTable().getRowByLabel('boundcomponent');
+        const boundComponent = jcontent.getTable().getRowByName('boundcomponent');
         boundComponent.contextMenu().select('edit');
 
         const pickerField = contentEditor.getPickerField('jmix:bindedComponent_j:bindedComponent');
         pickerField.assertValue('Search Results');
+    });
+
+    it('Shows empty content overlay in page builder when bound rich text is empty, then displays content after editing', () => {
+        const homePath = `/sites/${siteKey}/home`;
+        const contentsPath = `/sites/${siteKey}/contents`;
+        const richTextName = 'bound-rich-text';
+        const boundComponentName = 'bound-component-test';
+        const boundComponentPath = `${homePath}/area-main/${boundComponentName}`;
+
+        // Create an empty rich text in site contents, then create the bound component referencing it
+        addNode({
+            parentPathOrId: contentsPath,
+            name: richTextName,
+            primaryNodeType: 'jnt:bigText'
+        }).then(result => {
+            const richTextUuid = result?.data?.jcr?.addNode?.uuid;
+            addNode({
+                parentPathOrId: homePath,
+                name: 'area-main',
+                primaryNodeType: 'jnt:contentList',
+                mixins: ['jmix:isAreaList'],
+                children: [{
+                    name: boundComponentName,
+                    primaryNodeType: 'cent:boundComponent',
+                    properties: [{
+                        name: 'j:bindedComponent',
+                        type: 'WEAKREFERENCE',
+                        value: richTextUuid,
+                        language: 'en'
+                    }]
+                }]
+            });
+        });
+
+        // Open page builder — the empty bound component should show the "Nothing to display" overlay
+        cy.log('Empty bound component should have "Nothing to display" overlay');
+        let pageBuilder: JContentPageBuilder = JContent
+            .visit(siteKey, 'en', 'pages/home')
+            .switchToPageBuilder();
+
+        pageBuilder.getModule(boundComponentPath).getBox().assertHasEmptyOverlay();
+
+        cy.log('Add text to binded component - bound component should now display rich text content');
+        setNodeProperty(`${contentsPath}/${richTextName}`, 'text', '<p>Hello bound world</p>', 'en');
+        pageBuilder = JContent.visit(siteKey, 'en', 'pages/home').switchToPageBuilder();
+        pageBuilder.getModule(boundComponentPath).get().should('contain', 'Hello bound world');
     });
 });

--- a/tests/cypress/e2e/contentEditor/shard2/boundComponent.cy.ts
+++ b/tests/cypress/e2e/contentEditor/shard2/boundComponent.cy.ts
@@ -1,5 +1,5 @@
 import {JContent, JContentPageBuilder} from '../../../page-object';
-import { addNode, deleteSite, enableModule, setNodeProperty } from '@jahia/cypress'
+import {addNode, deleteSite, enableModule, setNodeProperty} from '@jahia/cypress';
 
 describe('Bound component tests', () => {
     const siteKey = 'boundComponentSite';
@@ -22,7 +22,7 @@ describe('Bound component tests', () => {
     });
 
     it('Bound component can be added via content editor', () => {
-        const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents')
+        const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
         jcontent.switchToListMode();
         const contentEditor = jcontent.createContent('cent:boundComponent');
         const picker = contentEditor.getPickerField('jmix:bindedComponent_j:bindedComponent').open();

--- a/tests/cypress/e2e/jcontent/shard2/links.cy.ts
+++ b/tests/cypress/e2e/jcontent/shard2/links.cy.ts
@@ -145,8 +145,8 @@ describe('Links in jcontent', () => {
             ]
         });
         jcontent.switchToStructuredView();
-        jcontent.getTable().getRowByLabel('external2-link-nav').element.contains('External link');
-        jcontent.getTable().getRowByLabel('About').element.contains('Internal Link');
+        jcontent.getTable().getRowByName('external2-link-nav').element.contains('External link');
+        jcontent.getTable().getRowByName('my-internal-link').element.contains('Internal Link');
         jcontent.getTable().element.contains('Menu Entry').should('not.exist');
     });
 });

--- a/tests/cypress/page-object/jcontent.ts
+++ b/tests/cypress/page-object/jcontent.ts
@@ -212,6 +212,7 @@ export class JContent extends BasePage {
 
     switchToStructuredView(): JContent {
         this.switchToMode('Structured');
+        cy.get('.moonstone-loader', {timeout: 5000}).should('not.exist');
         return this;
     }
 

--- a/tests/cypress/page-object/pageBuilder/pageBuilderModuleBox.ts
+++ b/tests/cypress/page-object/pageBuilder/pageBuilderModuleBox.ts
@@ -33,4 +33,9 @@ export class PageBuilderModuleBox extends BaseComponent {
     assertIsClicked(): Cypress.Chainable<JQuery> {
         return this.get().should('have.attr', 'data-box-clicked', 'true');
     }
+
+    assertHasEmptyOverlay(): Cypress.Chainable<JQuery> {
+        this.get().scrollIntoView();
+        return this.get().should('contain', 'Nothing to display');
+    }
 }

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/cent_boundComponent/html/boundComponent.jsp
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/cent_boundComponent/html/boundComponent.jsp
@@ -1,0 +1,26 @@
+<%@ page language="java" contentType="text/html;charset=UTF-8" %>
+<%@ taglib prefix="template" uri="http://www.jahia.org/tags/templateLib" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="jcr" uri="http://www.jahia.org/tags/jcr" %>
+<%@ taglib prefix="ui" uri="http://www.jahia.org/tags/uiComponentsLib" %>
+<%--<%@ taglib prefix="functions" uri="http://www.jahia.org/tags/functions" %>--%>
+<%--<%@ taglib prefix="query" uri="http://www.jahia.org/tags/queryLib" %>--%>
+<%--<%@ taglib prefix="utility" uri="http://www.jahia.org/tags/utilityLib" %>--%>
+<%--<%@ taglib prefix="s" uri="http://www.jahia.org/tags/search" %>--%>
+<%--@elvariable id="currentNode" type="org.jahia.services.content.JCRNodeWrapper"--%>
+<%--@elvariable id="out" type="java.io.PrintWriter"--%>
+<%--@elvariable id="script" type="org.jahia.services.render.scripting.Script"--%>
+<%--@elvariable id="scriptInfo" type="java.lang.String"--%>
+<%--@elvariable id="workspace" type="java.lang.String"--%>
+<%--@elvariable id="renderContext" type="org.jahia.services.render.RenderContext"--%>
+<%--@elvariable id="currentResource" type="org.jahia.services.render.Resource"--%>
+<%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
+
+<c:set var="boundComponent"
+       value="${ui:getBoundComponent(currentNode, renderContext, 'j:bindedComponent')}"/>
+<c:if test="${not empty boundComponent}">
+    <template:addCacheDependency node="${boundComponent}"/>
+    <template:module node="${boundComponent}" />
+</c:if>


### PR DESCRIPTION
### Description

Add empty content overlay for bounded component when there is nothing to display. Reverted initial attempt to make it selectable ([link](https://github.com/Jahia/jcontent/pull/2330)) and moved into `Box` component to be able to add overlay

We use the same empty content display for when there is no translation and has empty content.

#### Misc 

- Remove deprecated BoxesContextMenu comment (this has been [reverted](https://github.com/Jahia/jcontent/issues/1878) and no longer accurate)
- Fixes for a failing links test

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
