### PR TITLE
fix: restored technical details in the sidebar

### DIFF
--- a/.chachalog/yuRLczGc.md
+++ b/.chachalog/yuRLczGc.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": patch
+---
+
+Restored technical details in the sidebar (#2519)

--- a/src/javascript/ContentEditor/ContentEditor/useEditFormDefinition.js
+++ b/src/javascript/ContentEditor/ContentEditor/useEditFormDefinition.js
@@ -128,11 +128,7 @@ const getTechnicalInfo = (nodeData, t) => {
     return [
         {
             label: t('jcontent:label.contentEditor.edit.advancedOption.technicalInformation.contentType'),
-            value: nodeData.primaryNodeType.displayName
-        },
-        {
-            label: t('jcontent:label.contentEditor.edit.advancedOption.technicalInformation.nodeTypeName'),
-            value: nodeData.primaryNodeType.name
+            value: `${nodeData.primaryNodeType.displayName} (${nodeData.primaryNodeType.name})`
         },
         {
             label: t('jcontent:label.contentEditor.edit.advancedOption.technicalInformation.inheritedMixins'),

--- a/src/javascript/ContentEditor/ContentEditor/useEditFormDefinition.spec.js
+++ b/src/javascript/ContentEditor/ContentEditor/useEditFormDefinition.spec.js
@@ -209,11 +209,7 @@ describe('adaptEditFormData', () => {
         expect(adaptEditFormData(graphqlResponse, 'fr', t).technicalInfo).toEqual([
             {
                 label: 'jcontent:label.contentEditor.edit.advancedOption.technicalInformation.contentType',
-                value: 'ContentType'
-            },
-            {
-                label: 'jcontent:label.contentEditor.edit.advancedOption.technicalInformation.nodeTypeName',
-                value: 'jcr:contentType'
+                value: 'ContentType (jcr:contentType)'
             },
             {
                 label: 'jcontent:label.contentEditor.edit.advancedOption.technicalInformation.inheritedMixins',

--- a/src/javascript/JContent/SidePanel/ContentDetails/ContentDetails.jsx
+++ b/src/javascript/JContent/SidePanel/ContentDetails/ContentDetails.jsx
@@ -235,7 +235,6 @@ const ContentLinks = () => {
 export const ContentDetails = () => {
     const {t} = useTranslation('jcontent');
     const {nodeData, technicalInfo, details} = useSidePanelContext();
-    const isDevMode = window.contextJsParameters?.config?.operatingMode === 'development';
 
     if (!nodeData) {
         return (
@@ -270,7 +269,7 @@ export const ContentDetails = () => {
 
             <ContentLinks/>
 
-            {isDevMode && technicalInfo && technicalInfo.length > 0 && (
+            {technicalInfo && technicalInfo.length > 0 && (
                 <div className={styles.section} data-sel-role="details-section" data-sel-content="technical">
                     <Typography variant="subheading" className={styles.sectionTitle}>
                         {t('jcontent:label.contentEditor.sidePanel.technical')}

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -704,10 +704,9 @@
         },
         "advancedOption": {
           "technicalInformation": {
-            "contentType": "Haupt Content Typ",
+            "contentType": "Content-Typ",
             "details": "Details",
             "label": "Technische Informationen",
-            "nodeTypeName": "Content-Typ",
             "inheritedMixins": "Geerbte Mixins",
             "appliedMixins": "Angewandte Mixins",
             "path": "Pfad",

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -710,10 +710,9 @@
         },
         "advancedOption": {
           "technicalInformation": {
-            "contentType": "Main content type",
+            "contentType": "Content type",
             "details": "Details",
             "label": "Technical information",
-            "nodeTypeName": "Content type",
             "inheritedMixins": "Inherited mixins",
             "appliedMixins": "Applied mixins",
             "path": "Path",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -705,10 +705,9 @@
         },
         "advancedOption": {
           "technicalInformation": {
-            "contentType": "Type de contenu principal",
+            "contentType": "Type de contenu",
             "details": "Détails",
             "label": "Informations techniques",
-            "nodeTypeName": "Type de contenu",
             "inheritedMixins": "Mixins hérités",
             "appliedMixins": "Mixins appliqués",
             "path": "Chemin",

--- a/tests/cypress/e2e/contentEditor/shard2/contentEditorForm.cy.ts
+++ b/tests/cypress/e2e/contentEditor/shard2/contentEditorForm.cy.ts
@@ -259,8 +259,9 @@ describe('Content editor form', () => {
         // Publication date/publisher rows only appear after the content has been published
 
         sidePanel.getDetailsSection('technical').scrollIntoView();
-        sidePanel.getDetailRow('Main content type').should('contain', 'Simple text');
-        sidePanel.getDetailRow('Content type').should('contain', 'jnt:text');
+        sidePanel.getDetailRow('Content type').should('contain', 'Simple text (jnt:text)');
+        sidePanel.getDetailRow('Inherited mixins').should('be.visible');
+        sidePanel.getDetailRow('Applied mixins').should('be.visible');
         sidePanel.getDetailRow('Path').should('contain', '/sites/contentEditorSite/contents/myText');
         sidePanel.getDetailRow('UUID').should('be.visible');
 


### PR DESCRIPTION
### Description
This PR restores the technical details in the sidebar, previously gated by the dev mode.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
