### PR TITLE
feat: Add Live dropdown button

### DIFF
--- a/.chachalog/3o_OsgL4.md
+++ b/.chachalog/3o_OsgL4.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Add a button group dropdown for the _Live_ button that lets users select which domain to open the live URL in, based on the domains configured on the site (j:serverName and j:serverNameAliases). The selected domain is saved in localStorage and used by default when clicking the _Live_ button. (#2522)

--- a/src/javascript/JContent/ContentRoute/MainActionBar/MainActionBar.jsx
+++ b/src/javascript/JContent/ContentRoute/MainActionBar/MainActionBar.jsx
@@ -5,48 +5,42 @@ import {DisplayAction} from '@jahia/ui-extender';
 import {useNodeInfo} from '@jahia/data-helper';
 import {shallowEqual, useSelector} from 'react-redux';
 import styles from './MainActionBar.scss';
-import {booleanValue} from '~/JContent/JContent.utils';
 
 const ButtonRenderer = getButtonRenderer({defaultButtonProps: {size: 'big'}});
 const ButtonRendererNoLabel = getButtonRenderer({labelStyle: 'none', defaultButtonProps: {size: 'big'}});
 const ButtonRendererShortLabel = getButtonRenderer({labelStyle: 'short', defaultButtonProps: {size: 'big'}});
 
 export const MainActionBar = () => {
-    const showPageBuilder = booleanValue(contextJsParameters.config.jcontent?.showPageBuilder);
-
-    const {path, language, selection} = useSelector(state => ({path: state.jcontent.path, language: state.language, selection: state.jcontent.selection}), shallowEqual);
-
-    const {node, loading} = useNodeInfo({path, language}, {getIsNodeTypes: ['jnt:page', 'jnt:contentFolder', 'jnt:folder']});
+    const {path, language, selection} = useSelector(state => ({
+        path: state.jcontent.path,
+        language: state.language,
+        selection: state.jcontent.selection
+    }), shallowEqual);
+    const {node, loading} = useNodeInfo(
+        {path, language},
+        {getIsNodeTypes: ['jnt:page', 'jnt:contentFolder', 'jnt:folder']}
+    );
 
     if (loading || !node) {
-        return false;
+        return null;
     }
 
     const isFolder = node['jnt:folder'] || node['jnt:contentFolder'];
     const publishAction = isFolder ? 'publishAll' : 'publish';
-    const isDisabled = selection && selection.length > 0;
+    const isDisabled = selection?.length > 0;
 
     return (
         <div className={styles.root}>
             <DisplayAction actionKey="search" path={path} isDisabled={isDisabled} render={ButtonRenderer} buttonProps={{variant: 'ghost', size: 'big', 'data-sel-role': 'open-search-dialog'}}/>
-            <Separator variant="vertical" invisible="firstOrLastChild" className={styles.showSeparator}/>
+            <Separator variant="vertical" invisible="firstOrLastChild"/>
 
-            {showPageBuilder ? (
-                <>
-                    { !isFolder && (
-                        <ButtonGroup size="big" variant="outlined" color="default" className={styles.item}>
-                            <DisplayAction isMediumLabel actionKey="openInPreview" path={path} isDisabled={isDisabled} render={ButtonRendererShortLabel} buttonProps={{className: styles.item}}/>
-                            <DisplayAction menuUseElementAnchor actionKey="openInPreviewMenu" path={path} isDisabled={isDisabled} render={ButtonRendererNoLabel} buttonProps={{icon: <ChevronDown/>}}/>
-                        </ButtonGroup>)}
-                    <DisplayAction actionKey="openInLive" path={path} isDisabled={isDisabled} render={ButtonRenderer} buttonProps={{variant: 'outlined', size: 'big', color: 'accent', className: styles.item}}/>
-                </>
-            ) : (
-                <>
-                    <DisplayAction actionKey="pageComposer" path={path} isDisabled={isDisabled} render={ButtonRenderer} buttonProps={{variant: 'ghost', size: 'big', color: 'accent', className: styles.item}}/>
-                    <DisplayAction actionKey={node['jnt:page'] ? 'editPage' : 'edit'} path={path} isDisabled={isDisabled} render={ButtonRenderer} buttonProps={{variant: 'outlined', size: 'big', className: styles.item}}/>
-                </>
-            )}
+            { !isFolder && (
+                <ButtonGroup size="big" variant="outlined" color="default" className={styles.item}>
+                    <DisplayAction isMediumLabel actionKey="openInPreview" path={path} isDisabled={isDisabled} render={ButtonRendererShortLabel} buttonProps={{className: styles.item}}/>
+                    <DisplayAction menuUseElementAnchor actionKey="openInPreviewMenu" path={path} isDisabled={isDisabled} render={ButtonRendererNoLabel} buttonProps={{icon: <ChevronDown/>}}/>
+                </ButtonGroup>)}
 
+            <DisplayAction actionKey="openInLive" path={path} isDisabled={isDisabled} render={ButtonRenderer} buttonProps={{variant: 'outlined', size: 'big', color: 'accent', className: styles.item}}/>
             <ButtonGroup size="big" variant="default" color="accent" className={styles.item}>
                 <DisplayAction isMediumLabel actionKey={publishAction} path={path} isDisabled={isDisabled} render={ButtonRendererShortLabel} buttonProps={{variant: 'default', size: 'big', color: 'accent'}}/>
                 <DisplayAction menuUseElementAnchor actionKey="publishMenu" path={path} isDisabled={isDisabled} render={ButtonRendererNoLabel} buttonProps={{variant: 'default', size: 'big', color: 'accent', icon: <ChevronDown/>}}/>

--- a/src/javascript/JContent/ContentRoute/MainActionBar/MainActionBar.jsx
+++ b/src/javascript/JContent/ContentRoute/MainActionBar/MainActionBar.jsx
@@ -4,6 +4,7 @@ import {getButtonRenderer} from '~/utils/getButtonRenderer';
 import {DisplayAction} from '@jahia/ui-extender';
 import {useNodeInfo} from '@jahia/data-helper';
 import {shallowEqual, useSelector} from 'react-redux';
+import {OpenInLiveButtonGroup} from './OpenInLiveButtonGroup';
 import styles from './MainActionBar.scss';
 
 const ButtonRenderer = getButtonRenderer({defaultButtonProps: {size: 'big'}});
@@ -40,7 +41,7 @@ export const MainActionBar = () => {
                     <DisplayAction menuUseElementAnchor actionKey="openInPreviewMenu" path={path} isDisabled={isDisabled} render={ButtonRendererNoLabel} buttonProps={{icon: <ChevronDown/>}}/>
                 </ButtonGroup>)}
 
-            <DisplayAction actionKey="openInLive" path={path} isDisabled={isDisabled} render={ButtonRenderer} buttonProps={{variant: 'outlined', size: 'big', color: 'accent', className: styles.item}}/>
+            <OpenInLiveButtonGroup path={path} isDisabled={isDisabled}/>
             <ButtonGroup size="big" variant="default" color="accent" className={styles.item}>
                 <DisplayAction isMediumLabel actionKey={publishAction} path={path} isDisabled={isDisabled} render={ButtonRendererShortLabel} buttonProps={{variant: 'default', size: 'big', color: 'accent'}}/>
                 <DisplayAction menuUseElementAnchor actionKey="publishMenu" path={path} isDisabled={isDisabled} render={ButtonRendererNoLabel} buttonProps={{variant: 'default', size: 'big', color: 'accent', icon: <ChevronDown/>}}/>

--- a/src/javascript/JContent/ContentRoute/MainActionBar/MainActionBar.scss
+++ b/src/javascript/JContent/ContentRoute/MainActionBar/MainActionBar.scss
@@ -3,7 +3,7 @@
 }
 
 .item {
-    & + & {
+    & ~ & {
         margin-left: var(--spacing-small);
     }
 }

--- a/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/OpenInLiveButtonGroup.jsx
+++ b/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/OpenInLiveButtonGroup.jsx
@@ -1,0 +1,71 @@
+import React, {useState} from 'react';
+import PropTypes from 'prop-types';
+import {useTranslation} from 'react-i18next';
+import {Button, ButtonGroup, ChevronDown, OpenInNew} from '@jahia/moonstone';
+import {useOpenInLiveData} from './useOpenInLiveData';
+import {ServerNameMenu} from './ServerNameMenu';
+import {resolveUrlForLiveOrPreview} from '~/JContent/JContent.utils';
+import styles from '../MainActionBar.scss';
+
+export const OpenInLiveButtonGroup = ({path, isDisabled}) => {
+    const {t} = useTranslation();
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const [anchorEl, setAnchorEl] = useState(null);
+
+    const {liveData, selectedServerName, selectServerName} = useOpenInLiveData(path);
+
+    if (!liveData) {
+        return null;
+    }
+
+    const {urlPath, serverName, serverNameAliases, currentHostname} = liveData;
+
+    const handleOpen = () => {
+        const url = resolveUrlForLiveOrPreview(urlPath, true, selectedServerName || serverName);
+        window.open(url, '_blank');
+    };
+
+    const handleChevronClick = e => {
+        setAnchorEl(e.currentTarget);
+        setIsMenuOpen(open => !open);
+    };
+
+    const handleSelectServerName = name => {
+        selectServerName(name);
+        const url = resolveUrlForLiveOrPreview(urlPath, true, name);
+        window.open(url, '_blank');
+        setIsMenuOpen(false);
+    };
+
+    return (
+        <>
+            <ButtonGroup size="big" variant="outlined" color="accent" className={styles.item}>
+                <Button
+                    label={t('jcontent:label.contentManager.actions.openInLive')}
+                    icon={<OpenInNew/>}
+                    isDisabled={isDisabled}
+                    onClick={handleOpen}
+                />
+                <Button
+                    icon={<ChevronDown/>}
+                    isDisabled={isDisabled}
+                    aria-label={t('jcontent:label.contentManager.actions.openInLive')}
+                    onClick={handleChevronClick}
+                />
+            </ButtonGroup>
+            {isMenuOpen && (
+                <ServerNameMenu
+                    anchorEl={anchorEl}
+                    serverNames={{serverName, serverNameAliases, selectedServerName, currentHostname}}
+                    onSelect={handleSelectServerName}
+                    onClose={() => setIsMenuOpen(false)}
+                />
+            )}
+        </>
+    );
+};
+
+OpenInLiveButtonGroup.propTypes = {
+    path: PropTypes.string,
+    isDisabled: PropTypes.bool
+};

--- a/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/OpenInLiveButtonGroup.jsx
+++ b/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/OpenInLiveButtonGroup.jsx
@@ -41,12 +41,14 @@ export const OpenInLiveButtonGroup = ({path, isDisabled}) => {
         <>
             <ButtonGroup size="big" variant="outlined" color="accent" className={styles.item}>
                 <Button
+                    data-sel-role="openInLive"
                     label={t('jcontent:label.contentManager.actions.openInLive')}
                     icon={<OpenInNew/>}
                     isDisabled={isDisabled}
                     onClick={handleOpen}
                 />
                 <Button
+                    data-sel-role="openInLiveChevron"
                     icon={<ChevronDown/>}
                     isDisabled={isDisabled}
                     aria-label={t('jcontent:label.contentManager.actions.openInLive')}

--- a/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/ServerNameMenu.jsx
+++ b/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/ServerNameMenu.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {useTranslation} from 'react-i18next';
+import {Menu, MenuItem, Separator} from '@jahia/moonstone';
+
+export const ServerNameMenu = ({anchorEl, serverNames, onSelect, onClose}) => {
+    const {t} = useTranslation();
+    const {serverName, serverNameAliases, selectedServerName, currentHostname} = serverNames;
+
+    return (
+        <Menu
+            isDisplayed
+            anchorEl={anchorEl}
+            anchorElOrigin={{vertical: 'bottom', horizontal: 'left'}}
+            transformElOrigin={{vertical: 'top', horizontal: 'left'}}
+            onClose={onClose}
+        >
+            <MenuItem
+                variant="title"
+                label={t('jcontent:label.contentManager.actions.openInLiveDefaultDomain')}
+            />
+            <MenuItem
+                label={serverName}
+                isSelected={selectedServerName === serverName}
+                onClick={() => onSelect(serverName)}
+            />
+            {serverNameAliases.length > 0 && (
+                <>
+                    <Separator/>
+                    <MenuItem
+                        variant="title"
+                        label={t('jcontent:label.contentManager.actions.openInLiveAdditionalDomains')}
+                    />
+                    {serverNameAliases.map(alias => (
+                        <MenuItem
+                            key={alias}
+                            label={alias}
+                            isSelected={selectedServerName === alias}
+                            onClick={() => onSelect(alias)}
+                        />
+                    ))}
+                </>
+            )}
+            {currentHostname && (
+                <>
+                    <Separator/>
+                    <MenuItem
+                        variant="title"
+                        label={t('jcontent:label.contentManager.actions.openInLiveCurrentDomain')}
+                    />
+                    <MenuItem
+                        label={currentHostname}
+                        onClick={() => onSelect(currentHostname)}
+                    />
+                </>
+            )}
+        </Menu>
+    );
+};
+
+ServerNameMenu.propTypes = {
+    anchorEl: PropTypes.object,
+    serverNames: PropTypes.shape({
+        serverName: PropTypes.string,
+        serverNameAliases: PropTypes.arrayOf(PropTypes.string),
+        selectedServerName: PropTypes.string,
+        currentHostname: PropTypes.string
+    }).isRequired,
+    onSelect: PropTypes.func.isRequired,
+    onClose: PropTypes.func.isRequired
+};

--- a/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/index.js
+++ b/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/index.js
@@ -1,0 +1,1 @@
+export {OpenInLiveButtonGroup} from './OpenInLiveButtonGroup';

--- a/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/useOpenInLiveData.js
+++ b/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/useOpenInLiveData.js
@@ -1,0 +1,73 @@
+import {useEffect, useState} from 'react';
+import {useQuery} from '@apollo/client';
+import {useSelector} from 'react-redux';
+import {OpenInActionQuery} from '~/JContent/actions/openInAction/openInAction.gql-queries';
+import {setRefetcher, unsetRefetcher} from '~/JContent/JContent.refetches';
+import JContentConstants from '~/JContent/JContent.constants';
+
+const STORAGE_KEY = JContentConstants.localStorageKeys.liveServerName;
+
+export const useOpenInLiveData = path => {
+    const language = useSelector(state => state.language);
+    const {data, loading, error, refetch} = useQuery(OpenInActionQuery, {
+        variables: {path, language, workspace: 'LIVE'},
+        fetchPolicy: 'cache-and-network',
+        skip: !path
+    });
+
+    useEffect(() => {
+        setRefetcher('openInLive', {refetch});
+        return () => unsetRefetcher('openInLive');
+    }, [refetch]);
+
+    const node = data?.jcr?.result;
+    const serverName = node?.site?.serverName;
+    const serverNameAliases = node?.site?.additionalServerNames?.values ?? [];
+
+    const [selectedServerName, setSelectedServerName] = useState(
+        () => localStorage.getItem(STORAGE_KEY) || null
+    );
+
+    useEffect(() => {
+        if (!serverName) {
+            return;
+        }
+
+        const allNames = [serverName, ...serverNameAliases];
+        const stored = localStorage.getItem(STORAGE_KEY);
+        const effective = stored && allNames.includes(stored) ? stored : serverName;
+
+        if (effective !== selectedServerName) {
+            setSelectedServerName(effective);
+        }
+
+        if (effective !== stored) {
+            localStorage.setItem(STORAGE_KEY, effective);
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [serverName, serverNameAliases.join(',')]);
+
+    const selectServerName = name => {
+        localStorage.setItem(STORAGE_KEY, name);
+        setSelectedServerName(name);
+    };
+
+    const isVisible = !loading && !error && Boolean(node) &&
+        (node.previewAvailable || node.displayableNode !== null) &&
+        node.publicationInfo.existsInLive &&
+        node.publicationInfo.status !== 'NOT_PUBLISHED' &&
+        node.publicationInfo.status !== 'UNPUBLISHED';
+
+    const currentHostname = globalThis.location.hostname;
+    const isHostnameInList = [serverName, ...serverNameAliases].includes(currentHostname);
+    return {
+        selectedServerName,
+        selectServerName,
+        liveData: isVisible ? {
+            urlPath: node.renderUrl,
+            serverName,
+            serverNameAliases,
+            currentHostname: isHostnameInList ? null : currentHostname
+        } : null
+    };
+};

--- a/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/useOpenInLiveData.js
+++ b/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/useOpenInLiveData.js
@@ -59,7 +59,8 @@ export const useOpenInLiveData = path => {
         node.publicationInfo.status !== 'UNPUBLISHED';
 
     const currentHostname = globalThis.location.hostname;
-    const isHostnameInList = [serverName, ...serverNameAliases].includes(currentHostname);
+    const isHostnameInList = [serverName, ...serverNameAliases].includes(currentHostname) ||
+        serverNameAliases.includes('localhost');
     return {
         selectedServerName,
         selectServerName,

--- a/src/javascript/JContent/JContent.actions.jsx
+++ b/src/javascript/JContent/JContent.actions.jsx
@@ -19,7 +19,6 @@ import {
     MoreVert,
     NoCloud,
     OpenInBrowser,
-    OpenInNew,
     Paste,
     PasteAsReference,
     Publish,
@@ -50,7 +49,6 @@ import {
     LocateActionComponent,
     LockActionComponent,
     OpenInJContentActionComponent,
-    OpenInLiveActionComponent,
     OpenInPreviewActionComponent,
     PasteActionComponent,
     PreviewActionComponent,
@@ -414,12 +412,6 @@ export const jContentActions = registry => {
         buttonIcon: <OpenInBrowser/>,
         buttonLabel: 'jcontent:label.contentManager.actions.openInPageBuilder',
         component: OpenInPageBuilderActionComponent
-    });
-
-    registry.add('action', 'openInLive', {
-        buttonIcon: <OpenInNew/>,
-        buttonLabel: 'jcontent:label.contentManager.actions.openInLive',
-        component: OpenInLiveActionComponent
     });
 
     registry.add('action', 'openInPreviewMenu', menuActionWithRenderer, {

--- a/src/javascript/JContent/JContent.constants.js
+++ b/src/javascript/JContent/JContent.constants.js
@@ -36,7 +36,8 @@ const JContentConstants = /** @type {const} */ ({
     localStorageKeys: {
         viewType: 'jcontent_view_type',
         viewMode: 'jcontent_view_mode',
-        filesSelectorMode: 'jcontent_files_selector_mode'
+        filesSelectorMode: 'jcontent_files_selector_mode',
+        liveServerName: 'jcontent-live-servername'
     },
     accordionPermissions: {
         pagesAccordionAccess: 'pagesAccordionAccess',

--- a/src/javascript/JContent/JContent.utils.js
+++ b/src/javascript/JContent/JContent.utils.js
@@ -471,14 +471,16 @@ export const resolveUrlForLiveOrPreview = (url, isLive, serverName) => {
         return url;
     }
 
-    let host = location.hostname;
-
     // Use current host for preview urls
-    if (isLive && serverName !== 'localhost') {
+    let host = location.hostname;
+    let port = location.port ? `:${location.port}` : '';
+
+    if (isLive && serverName && serverName !== 'localhost' && serverName !== location.hostname) {
         host = serverName;
+        port = '';
     }
 
-    return `${location.protocol}//${host}:${location.port}${url}`;
+    return `${location.protocol}//${host}${port}${url}`;
 };
 
 /**

--- a/src/javascript/JContent/actions/openInAction/openInAction.gql-queries.js
+++ b/src/javascript/JContent/actions/openInAction/openInAction.gql-queries.js
@@ -19,6 +19,9 @@ const OpenInActionQuery = gql`
                 site {
                     ...NodeCacheRequiredFields
                     serverName
+                    additionalServerNames: property(name: "j:serverNameAliases") {
+                        values
+                    }
                 }
             }
         }

--- a/src/javascript/JContent/actions/openInAction/openInAction.jsx
+++ b/src/javascript/JContent/actions/openInAction/openInAction.jsx
@@ -1,37 +1,16 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {useQuery} from '@apollo/client';
 import {OpenInActionQuery} from '~/JContent/actions/openInAction/openInAction.gql-queries';
 import {useSelector} from 'react-redux';
-import {setRefetcher, unsetRefetcher} from '~/JContent/JContent.refetches';
 import {resolveUrlForLiveOrPreview} from '../../JContent.utils';
 
-export const OpenInLiveActionComponent = props => <OpenInActionComponent isLive {...props}/>;
-export const OpenInPreviewActionComponent = props => <OpenInActionComponent {...props}/>;
-
-const OpenInActionComponent = ({
-    isLive = false,
-    render: Render,
-    path,
-    ...others
-}) => {
+export const OpenInPreviewActionComponent = ({render: Render, path, ...others}) => {
     const language = useSelector(state => state.language);
     const res = useQuery(OpenInActionQuery, {
-        variables: {
-            path: path,
-            language: language,
-            workspace: isLive ? 'LIVE' : 'EDIT'
-        },
+        variables: {path, language, workspace: 'EDIT'},
         skip: !path
     });
-
-    useEffect(() => {
-        setRefetcher('openInLive', {
-            refetch: res.refetch
-        });
-
-        return () => unsetRefetcher('openInLive');
-    }, [res.refetch]);
 
     const node = res?.data?.jcr.result;
     if (res.loading || res.error || !res.data ||
@@ -39,31 +18,18 @@ const OpenInActionComponent = ({
         return false;
     }
 
-    if (isLive && (!node.publicationInfo.existsInLive ||
-        node.publicationInfo.status === 'NOT_PUBLISHED' ||
-        node.publicationInfo.status === 'UNPUBLISHED')) {
-        return false;
-    }
-
-    const urlPath = node.renderUrl;
-
     return (
         <Render
             {...others}
             onClick={() => {
-                const url = resolveUrlForLiveOrPreview(urlPath, isLive, node.site.serverName);
+                const url = resolveUrlForLiveOrPreview(node.renderUrl, false, node.site.serverName);
                 window.open(url, '_blank');
             }}
         />
     );
 };
 
-OpenInActionComponent.propTypes = {
-    isLive: PropTypes.bool,
+OpenInPreviewActionComponent.propTypes = {
     path: PropTypes.string,
     render: PropTypes.func.isRequired
-};
-
-export const openInAction = {
-    component: OpenInLiveActionComponent
 };

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -320,6 +320,9 @@
         },
         "locate": "Finden",
         "openInLive": "Live",
+        "openInLiveDefaultDomain": "Standard-Domain",
+        "openInLiveAdditionalDomains": "Weitere Domain(s)",
+        "openInLiveCurrentDomain": "Aktuelle Domain",
         "openInPreview": "Vorschau",
         "compareStagingToLive": "Vergleich Staging vs Live Version",
         "customizedPreview": {

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -324,6 +324,9 @@
         },
         "locate": "Locate",
         "openInLive": "Live",
+        "openInLiveDefaultDomain": "Default domain",
+        "openInLiveAdditionalDomains": "Additional domain(s)",
+        "openInLiveCurrentDomain": "Current domain",
         "openInPreview": "Preview",
         "compareStagingToLive": "Compare staging vs live version",
         "customizedPreview": {

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -320,6 +320,9 @@
         },
         "locate": "Localiser",
         "openInLive": "Live",
+        "openInLiveDefaultDomain": "Domaine par défaut",
+        "openInLiveAdditionalDomains": "Domaine(s) supplémentaire(s)",
+        "openInLiveCurrentDomain": "Domaine actuel",
         "openInPreview": "Aperçu",
         "compareStagingToLive": "Comparer la version de travail et la version publiée",
         "customizedPreview": {

--- a/tests/cypress/e2e/menuActions/openInLive.cy.ts
+++ b/tests/cypress/e2e/menuActions/openInLive.cy.ts
@@ -1,0 +1,154 @@
+import {Button, createSite, deleteSite, getComponentByRole, publishAndWaitJobEnding} from '@jahia/cypress';
+import {JContent} from '../../page-object';
+import gql from 'graphql-tag';
+
+describe('Open in Live tests', () => {
+    const siteKey = 'openInLiveSite';
+    const storageKey = 'jcontent-live-servername';
+    const serverName = 'localhost';
+    const alias1 = 'alias1.example.com';
+    const alias2 = 'alias2.example.com';
+
+    const visitWithStub = (preloadStorage?: Record<string, string>) =>
+        JContent.visit(siteKey, 'en', 'pages/home', {
+            onBeforeLoad(win: Window) {
+                if (preloadStorage) {
+                    Object.entries(preloadStorage).forEach(([k, v]) => win.localStorage.setItem(k, v));
+                }
+
+                // @ts-expect-error window definition does not have "open" for some reason
+                cy.stub(win, 'open').as('winOpen');
+            }
+        });
+
+    before(() => {
+        createSite(siteKey, {templateSet: 'dx-base-demo-templates', serverName, locale: 'en'});
+        cy.apollo({
+            mutation: gql`
+                mutation SetServerNameAliases($pathOrId: String!, $values: [String]!) {
+                    jcr {
+                        mutateNode(pathOrId: $pathOrId) {
+                            mutateProperty(name: "j:serverNameAliases") {
+                                setValues(values: $values)
+                            }
+                        }
+                    }
+                }
+            `,
+            variables: {
+                pathOrId: `/sites/${siteKey}`,
+                values: [alias1, alias2]
+            }
+        });
+        publishAndWaitJobEnding(`/sites/${siteKey}/home`, ['en']);
+        cy.loginAndStoreSession();
+    });
+
+    after(() => {
+        cy.logout();
+        deleteSite(siteKey);
+    });
+
+    beforeEach(() => {
+        cy.clearLocalStorage();
+        cy.loginAndStoreSession();
+    });
+
+    describe('primary Live button', () => {
+        it('opens with default server name when localStorage is empty', () => {
+            visitWithStub();
+            getComponentByRole(Button, 'openInLive').click();
+            const localHostname = new URL(Cypress.config('baseUrl')).hostname;
+            cy.get('@winOpen').should(
+                'be.calledWith',
+                Cypress.sinon.match(f => f.includes(localHostname) && !f.includes(alias1))
+            );
+        });
+
+        it('opens with server name stored in localStorage', () => {
+            visitWithStub({[storageKey]: alias1});
+            getComponentByRole(Button, 'openInLive').click();
+            cy.get('@winOpen').should('be.calledWith', Cypress.sinon.match(f => f.includes(alias1)));
+        });
+    });
+
+    describe('dropdown menu', () => {
+        it('shows default domain group with server name', () => {
+            visitWithStub();
+            getComponentByRole(Button, 'openInLiveChevron').click();
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').should('be.visible');
+            cy.contains('Default domain').should('be.visible');
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').contains('.moonstone-menuItem', serverName).should('be.visible');
+        });
+
+        it('shows additional domains group with both aliases', () => {
+            visitWithStub();
+            getComponentByRole(Button, 'openInLiveChevron').click();
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').should('be.visible');
+            cy.contains('Additional domain(s)').should('be.visible');
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').contains('.moonstone-menuItem', alias1).should('be.visible');
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').contains('.moonstone-menuItem', alias2).should('be.visible');
+        });
+
+        it('default server name is selected when localStorage is empty', () => {
+            visitWithStub();
+            getComponentByRole(Button, 'openInLiveChevron').click();
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').should('be.visible');
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').contains('.moonstone-menuItem', serverName)
+                .should('have.class', 'moonstone-selected');
+        });
+
+        it('alias is pre-selected when stored in localStorage', () => {
+            visitWithStub({[storageKey]: alias1});
+            getComponentByRole(Button, 'openInLiveChevron').click();
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').should('be.visible');
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').contains('.moonstone-menuItem', alias1)
+                .should('have.class', 'moonstone-selected');
+        });
+
+        it('selecting an alias opens URL with that alias', () => {
+            visitWithStub();
+            getComponentByRole(Button, 'openInLiveChevron').click();
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').should('be.visible');
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').contains('.moonstone-menuItem', alias1).click();
+            cy.get('@winOpen').should('be.calledWith', Cypress.sinon.match(f => f.includes(alias1)));
+        });
+
+        it('selecting an alias stores it in localStorage', () => {
+            visitWithStub();
+            getComponentByRole(Button, 'openInLiveChevron').click();
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').should('be.visible');
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').contains('.moonstone-menuItem', alias1).click();
+            cy.window().then(win => {
+                expect(win.localStorage.getItem(storageKey)).to.equal(alias1);
+            });
+        });
+
+        it('primary button uses alias selected from dropdown on next click', () => {
+            visitWithStub();
+            getComponentByRole(Button, 'openInLiveChevron').click();
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').should('be.visible');
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').contains('.moonstone-menuItem', alias1).click();
+            getComponentByRole(Button, 'openInLive').click();
+            cy.get('@winOpen').should('be.calledTwice');
+            cy.get('@winOpen').should('be.calledWith', Cypress.sinon.match(f => f.includes(alias1)));
+        });
+    });
+
+    describe('localStorage validation', () => {
+        it('resets to default server name when stored value is not in server names list', () => {
+            visitWithStub({[storageKey]: 'unknown.invalid.host'});
+            // Wait for Live button — component mounted and reset effect has run
+            getComponentByRole(Button, 'openInLive').should('be.visible');
+            cy.window().then(win => {
+                expect(win.localStorage.getItem(storageKey)).to.equal(serverName);
+            });
+            getComponentByRole(Button, 'openInLive').click();
+            const localHostname = new URL(Cypress.config('baseUrl')).hostname;
+            cy.get('@winOpen').should(
+                'be.calledWith',
+                Cypress.sinon.match(f => f.includes(localHostname) && !f.includes('unknown.invalid.host'))
+            );
+        });
+    });
+});


### PR DESCRIPTION
### Description

- Replace "Open in Live" single button with a ButtonGroup that lets users pick which server name (domain) to open the live URL in, and persisted to localStorage `jcontent-live-servername`.
- Support j:serverNameAliases (j:serverNameAliases JCR property) alongside the existing j:serverName, exposing all configured domains in a grouped dropdown menu (Default domain / Additional domain(s) / Current domain).
- Fix resolveUrlForLiveOrPreview so that when the selected server name matches the current hostname (e.g. localhost), the port is preserved, and that we also do not add when using servername.
- Cleanup: Removed OpenInLiveActionComponent from openInAction.jsx and its registry entry from JContent.actions.jsx — replaced entirely by the new ButtonGroup. Rename shared openInAction into preview specifically.


### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
