### PR TITLE
feat: Add dompurify profile to docx viewer

### DIFF
--- a/src/javascript/JContent/preview/viewers/DocumentViewer/DocxViewer.jsx
+++ b/src/javascript/JContent/preview/viewers/DocumentViewer/DocxViewer.jsx
@@ -22,7 +22,7 @@ export const DocxViewer = ({file}) => {
             .then(buf => mammoth.convertToHtml({arrayBuffer: buf}, {includeDefaultStyleMap: true}))
             .then(result => {
                 if (mountedRef.current) {
-                    setHtml(DOMPurify.sanitize(result.value));
+                    setHtml(DOMPurify.sanitize(result.value, {USE_PROFILES: {html: true}}));
                 }
             })
             .catch(err => {


### PR DESCRIPTION
### Description
Follow-up to Benjamin comment in docx viewer PR: https://github.com/Jahia/jcontent/pull/2493/changes#r3523705644

Restrict dompurify profile explicit to html only

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
