### PR TITLE
fix: Replace message rendering in Delete dialog

### DIFF
--- a/.chachalog/pHL6W7pL.md
+++ b/.chachalog/pHL6W7pL.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Fixed an issue where special characters in display name were not displayed correctly in the Mark for Deletion dialog. (#2531)

--- a/src/javascript/JContent/actions/deleteActions/Delete/Delete.jsx
+++ b/src/javascript/JContent/actions/deleteActions/Delete/Delete.jsx
@@ -53,7 +53,7 @@ const DeleteContent = ({data, onClose, isLoading, isMutationLoading, dialogType,
             {isMutationLoading ?
                 <Loader size="big" style={{width: '100%'}}/> :
                 <DialogContent>
-                    <DialogContentText className={styles.content}>{label}</DialogContentText>
+                    <DialogContentText className={styles.content} data-sel-role="delete-message">{label}</DialogContentText>
                     {hasUsages && count === 1 &&
                         <DialogContentText>{t('jcontent:label.contentManager.deleteAction.hasUsages.single')}</DialogContentText>}
                     {hasUsages && count !== 1 &&

--- a/src/javascript/JContent/actions/deleteActions/Delete/Delete.jsx
+++ b/src/javascript/JContent/actions/deleteActions/Delete/Delete.jsx
@@ -16,40 +16,10 @@ import {
 import InfoTable from './InfoTable';
 import SvgInformation from '@jahia/moonstone/dist/icons/components/Information';
 import {Info} from '~/JContent/actions/deleteActions/Delete/Info';
-import {getName} from '~/JContent';
 import {isPathChildOfAnotherPath, JahiaRenderedModulesUtil} from '../../../JContent.utils';
+import {renderLabel} from './renderLabel';
 import {useNotifications} from '@jahia/react-material';
 import {cmRemoveSelection} from '~/JContent/redux/selection.redux';
-
-const getLabel = ({dialogType, locked, count, data, firstNode, pages, folders, t}) => {
-    if (locked) {
-        return t(`jcontent:label.contentManager.deleteAction.locked.${dialogType}.content`, {
-            count: count,
-            name: data.jcr.nodesByPath.map(n => getName(n)).join(', '),
-            parentName: firstNode && getName(firstNode?.rootDeletionInfo[0])
-        });
-    }
-
-    if (!count) {
-        return t('jcontent:label.contentManager.deleteAction.loading');
-    }
-
-    if (count === 1) {
-        return t(`jcontent:label.contentManager.deleteAction.${dialogType}.item`, {
-            name: firstNode && getName(firstNode)
-        });
-    }
-
-    if (pages === 0 && folders === 0) {
-        return t(`jcontent:label.contentManager.deleteAction.${dialogType}.itemsOnly`, {count});
-    }
-
-    if (pages === 0) {
-        return t(`jcontent:label.contentManager.deleteAction.${dialogType}.filesAndFolders`, {count, folders});
-    }
-
-    return t(`jcontent:label.contentManager.deleteAction.${dialogType}.items`, {count, pages});
-};
 
 const DeleteContent = ({data, onClose, isLoading, isMutationLoading, dialogType, onAction, paths, setInfoOpen}) => {
     const {t} = useTranslation('jcontent');
@@ -66,7 +36,7 @@ const DeleteContent = ({data, onClose, isLoading, isMutationLoading, dialogType,
                 _hasUsages || [node, ...node.allDescendants.nodes].some(p => p?.usagesCount > 0), false
         );
     const usagesOverflow = dialogType !== 'undelete' && data?.jcr?.nodesByPath?.reduce((isOverflow, node) => isOverflow || node.allDescendants.nodes.length === 100, false);
-    const label = getLabel({dialogType, locked, count, data, firstNode, pages, folders, t});
+    const label = renderLabel({dialogType, locked, count, data, firstNode, pages, folders, t});
 
     return (
         <>
@@ -83,7 +53,7 @@ const DeleteContent = ({data, onClose, isLoading, isMutationLoading, dialogType,
             {isMutationLoading ?
                 <Loader size="big" style={{width: '100%'}}/> :
                 <DialogContent>
-                    <DialogContentText className={styles.content} dangerouslySetInnerHTML={{__html: label}}/>
+                    <DialogContentText className={styles.content}>{label}</DialogContentText>
                     {hasUsages && count === 1 &&
                         <DialogContentText>{t('jcontent:label.contentManager.deleteAction.hasUsages.single')}</DialogContentText>}
                     {hasUsages && count !== 1 &&

--- a/src/javascript/JContent/actions/deleteActions/Delete/renderLabel.jsx
+++ b/src/javascript/JContent/actions/deleteActions/Delete/renderLabel.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {Trans} from 'react-i18next';
+import {getName} from '~/JContent';
+
+export const renderLabel = ({dialogType, locked, count, data, firstNode, pages, folders, t}) => {
+    if (locked) {
+        return (
+            <Trans i18nKey={`jcontent:label.contentManager.deleteAction.locked.${dialogType}.content`}
+                   count={count}
+            >
+                <strong>{{name: data.jcr.nodesByPath.map(n => getName(n)).join(', ')}}</strong>
+                <strong>{{parentName: firstNode && getName(firstNode?.rootDeletionInfo[0])}}</strong>
+            </Trans>
+        );
+    }
+
+    if (!count) {
+        return t('jcontent:label.contentManager.deleteAction.loading');
+    }
+
+    if (count === 1) {
+        return (
+            <Trans i18nKey={`jcontent:label.contentManager.deleteAction.${dialogType}.item`}>
+                <span>{{name: firstNode && getName(firstNode)}}</span>
+                <strong/>
+            </Trans>
+        );
+    }
+
+    if (pages === 0 && folders === 0) {
+        return (
+            <Trans i18nKey={`jcontent:label.contentManager.deleteAction.${dialogType}.itemsOnly`}
+                   values={{count}}
+                   components={{span: <span/>}}/>
+        );
+    }
+
+    if (pages === 0) {
+        return (
+            <Trans i18nKey={`jcontent:label.contentManager.deleteAction.${dialogType}.filesAndFolders`}
+                   values={{count, folders}}
+                   components={{span: <span/>}}/>
+        );
+    }
+
+    return (
+        <Trans i18nKey={`jcontent:label.contentManager.deleteAction.${dialogType}.items`}
+               values={{count, pages}}
+               components={{span: <span/>}}/>
+    );
+};

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -477,7 +477,7 @@
         },
         "mark": {
           "title": "Zur Löschung markiert",
-          "item": "Sie sind dabei, <span>{{name}}</span> zu löschen.",
+          "item": "Sie sind dabei, <0>{{name}}</0> zu löschen.",
           "items": "Sie sind dabei, <span>{{count}} Element(e)</span> zu löschen, darunter <span>{{pages}} Seite(n)</span>.",
           "filesAndFolders": "Sie sind dabei, <span>{{count}} Element(e)</span> zu löschen, darunter <span>{{folders}} Ordner</span>.",
           "itemsOnly": "Sie sind dabei, <span>{{count}} Element(e)</span> zu löschen.",
@@ -485,7 +485,7 @@
         },
         "permanently": {
           "title": "Löschen",
-          "item": "Sie sind dabei, die Löschung von <span>{{name}}</span> zu veröffentlichen. <strong>Dies kann nicht rückgängig gemacht werden.</strong>",
+          "item": "Sie sind dabei, die Löschung von <0>{{name}}</0> zu veröffentlichen. <1>Dies kann nicht rückgängig gemacht werden.</1>",
           "items": "Sie sind dabei, die Löschung von <span>{{count}} Element(e)</span> zu veröffentlichen, darunter <span>{{pages}} Seite(n)</span>. <strong>Dies kann nicht rückgängig gemacht werden.</strong>",
           "filesAndFolders": "Sie sind dabei, die Löschung von <span>{{count}} Element(e)</span> zu veröffentlichen, darunter <span>{{folders}} Ordner</span>. <strong>Dies kann nicht rückgängig gemacht werden.</strong>",
           "itemsOnly": "Sie sind dabei, die Löschung von <span>{{count}} Element(e)</span> zu veröffentlichen. <strong>Dies kann nicht rückgängig gemacht werden.</strong>",
@@ -493,7 +493,7 @@
         },
         "undelete": {
           "title": "Wiederherstellen",
-          "item": "Möchten Sie wirklich <span>{{name}}</span> wiederherstellen?",
+          "item": "Möchten Sie wirklich <0>{{name}}</0> wiederherstellen?",
           "items": "Möchten Sie wirklich <span>{{count}} Element(e)</span> wiederherstellen, darunter <span>{{pages}} Seite(n)</span> ?",
           "filesAndFolders": "Möchten Sie wirklich <span>{{count}} Element(e)</span> wiederherstellen, darunter <span>{{folders}} Ordner</span> ?",
           "itemsOnly": "Möchten Sie wirklich <span>{{count}} Element(e)</span> wiederherstellen?",
@@ -507,13 +507,13 @@
         "locked": {
           "permanently": {
             "title": "Löschung nicht möglich",
-            "content": "Das Element <strong>{{name}}</strong> kann aktuell nicht allein gelöscht werden. Bitte stellen Sie es wieder her, oder löschen Sie das übergeordnete Element <strong>{{parentName}}</strong>, welches zuerst zur Löschung markiert wurde.",
-            "content_plural": "Die {{count}} Elemente <strong>{{name}}</strong> können aktuell nicht allein gelöscht werden. Bitte stellen Sie diese wieder her, oder löschen Sie das übergeordnete Element <strong>{{parentName}}</strong>, welches zuerst zur Löschung markiert wurde."
+            "content": "Das Element <0>{{name}}</0> kann aktuell nicht allein gelöscht werden. Bitte stellen Sie es wieder her, oder löschen Sie das übergeordnete Element <1>{{parentName}}</1>, welches zuerst zur Löschung markiert wurde.",
+            "content_plural": "Die {{count}} Elemente <0>{{name}}</0> können aktuell nicht allein gelöscht werden. Bitte stellen Sie diese wieder her, oder löschen Sie das übergeordnete Element <1>{{parentName}}</1>, welches zuerst zur Löschung markiert wurde."
           },
           "undelete": {
             "title": "Wiederherstellung nicht möglich",
-            "content": "Das Element <strong>{{name}}</strong> kann aktuell nicht allein wiederhergestellt werden. Bitte stellen Sie das übergeordnete Element <strong>{{parentName}}</strong> wieder her, welches zuerst zur Löschung markiert wurde.",
-            "content_plural": "Die {{count}} Elemente <strong>{{name}}</strong> können aktuell nicht allein wiederhergestellt werden. Bitte stellen Sie das übergeordnete Element <strong>{{parentName}}</strong> wieder her, welches zuerst zur Löschung markiert wurde."
+            "content": "Das Element <0>{{name}}</0> kann aktuell nicht allein wiederhergestellt werden. Bitte stellen Sie das übergeordnete Element <1>{{parentName}}</1> wieder her, welches zuerst zur Löschung markiert wurde.",
+            "content_plural": "Die {{count}} Elemente <0>{{name}}</0> können aktuell nicht allein wiederhergestellt werden. Bitte stellen Sie das übergeordnete Element <1>{{parentName}}</1> wieder her, welches zuerst zur Löschung markiert wurde."
           }
         },
         "error": "Die angeforderte Operation konnte am ausgewählten Content nicht durchgeführt werden. Dialog wird geschlossen und Daten werden neu geladen."

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -483,7 +483,7 @@
         },
         "mark": {
           "title": "Mark for deletion",
-          "item": "You are about to delete <span>{{name}}</span>",
+          "item": "You are about to delete <0>{{name}}</0>",
           "items": "You are about to delete <span>{{count}} items</span>, including <span>{{pages}} page(s)</span>",
           "filesAndFolders": "You are about to delete <span>{{count}} items</span>, including <span>{{folders}} folder(s)</span>",
           "itemsOnly": "You are about to delete <span>{{count}} items</span>",
@@ -491,7 +491,7 @@
         },
         "permanently": {
           "title": "Delete permanently",
-          "item": "You are about to permanently delete <span>{{name}}</span>. <strong>This operation cannot be undone.</strong>",
+          "item": "You are about to permanently delete <0>{{name}}</0>. <1>This operation cannot be undone.</1>",
           "items": "You are about to permanently delete <span>{{count}} items</span>, including <span>{{pages}} page(s)</span>. <strong>This operation cannot be undone.</strong>",
           "filesAndFolders": "You are about to permanently delete <span>{{count}} items</span>, including <span>{{folders}} folder(s)</span>. <strong>This operation cannot be undone.</strong>",
           "itemsOnly": "You are about to permanently delete <span>{{count}} items</span>. <strong>This operation cannot be undone.</strong>",
@@ -499,7 +499,7 @@
         },
         "undelete": {
           "title": "Undelete",
-          "item": "Do you really want to undelete <span>{{name}}</span> ?",
+          "item": "Do you really want to undelete <0>{{name}}</0> ?",
           "items": "Do you really want to undelete <span>{{count}} items</span>, including <span>{{pages}} page(s)</span> ?",
           "filesAndFolders": "Do you really want to undelete <span>{{count}} items</span>, including <span>{{folders}} folder(s)</span> ?",
           "itemsOnly": "Do you really want to undelete <span>{{count}} items</span> ?",
@@ -513,13 +513,13 @@
         "locked": {
           "permanently": {
             "title": "Cannot be deleted",
-            "content": "The content item <strong>{{name}}</strong> cannot currently be deleted on its own. Please undelete, or permanently delete, its parent content <strong>{{parentName}}</strong> which was the one initially marked for deletion.",
-            "content_plural": "{{count}} items <strong>{{name}}</strong> cannot currently be deleted on their own. Please undelete, or permanently delete, their parent content <strong>{{parentName}}</strong> which was the one initially marked for deletion."
+            "content": "The content item <0>{{name}}</0> cannot currently be deleted on its own. Please undelete, or permanently delete, its parent content <1>{{parentName}}</1> which was the one initially marked for deletion.",
+            "content_plural": "{{count}} items <0>{{name}}</0> cannot currently be deleted on their own. Please undelete, or permanently delete, their parent content <1>{{parentName}}</1> which was the one initially marked for deletion."
           },
           "undelete": {
             "title": "Cannot be undeleted",
-            "content": "The content item <strong>{{name}}</strong> cannot currently be undeleted on its own. Please undelete its parent content <strong>{{parentName}}</strong> which was the one initially marked for deletion.",
-            "content_plural": "{{count}} items <strong>{{name}}</strong> cannot currently be undeleted on their own. Please undelete their parent content <strong>{{parentName}}</strong> which was the one initially marked for deletion."
+            "content": "The content item <0>{{name}}</0> cannot currently be undeleted on its own. Please undelete its parent content <1>{{parentName}}</1> which was the one initially marked for deletion.",
+            "content_plural": "{{count}} items <0>{{name}}</0> cannot currently be undeleted on their own. Please undelete their parent content <1>{{parentName}}</1> which was the one initially marked for deletion."
           }
         },
         "details": "DETAILS",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -478,7 +478,7 @@
         },
         "mark": {
           "title": "Marquer pour suppression",
-          "item": "Vous allez supprimer <span>{{name}}</span>",
+          "item": "Vous allez supprimer <0>{{name}}</0>",
           "items": "Vous allez supprimer <span>{{count}} éléments</span>, dont <span>{{pages}} page(s)</span>",
           "filesAndFolders": "Vous allez supprimer <span>{{count}} éléments</span>, dont <span>{{folders}} dossier(s)</span>",
           "itemsOnly": "Vous allez supprimer <span>{{count}} éléments</span>",
@@ -486,7 +486,7 @@
         },
         "permanently": {
           "title": "Supprimer définitivement",
-          "item": "Vous allez supprimer définitivement <span>{{name}}</span>. <strong>Cette opération ne peut pas être annulée.</strong>",
+          "item": "Vous allez supprimer définitivement <0>{{name}}</0>. <1>Cette opération ne peut pas être annulée.</1>",
           "items": "Vous allez supprimer définitivement <span>{{count}} éléments</span>, dont <span>{{pages}} page(s)</span>. <strong>Cette opération ne peut pas être annulée.</strong>",
           "filesAndFolders": "Vous allez supprimer définitivement <span>{{count}} éléments</span>, dont <span>{{folders}} dossier(s)</span>. <strong>Cette opération ne peut pas être annulée.</strong>",
           "itemsOnly": "Vous allez supprimer définitivement <span>{{count}} éléments</span>. <strong>Cette opération ne peut pas être annulée.</strong>",
@@ -494,7 +494,7 @@
         },
         "undelete": {
           "title": "Annuler la suppression",
-          "item": "Souhaitez-vous annuler la suppression de <span>{{name}}</span> ?",
+          "item": "Souhaitez-vous annuler la suppression de <0>{{name}}</0> ?",
           "items": "Souhaitez-vous annuler la suppression de <span>{{count}} éléments</span>, dont <span>{{pages}} page(s)</span> ?",
           "filesAndFolders": "Souhaitez-vous annuler la suppression de <span>{{count}} éléments</span>, dont <span>{{folders}} dossier(s)</span> ?",
           "itemsOnly": "Souhaitez-vous annuler la suppression de <span>{{count}} éléments</span> ?",
@@ -508,13 +508,13 @@
         "locked": {
           "permanently": {
             "title": "Impossible de supprimer",
-            "content": "L’élément <strong>{{name}}</strong> ne peut actuellement pas être supprimé seul. Merci d’annuler la suppression, ou de supprimer définitivement, son contenu parent <strong>{{parentName}}</strong>, qui est le contenu initialement marqué pour suppression. ",
-            "content_plural": "Il y a ${count} éléments <strong>{{name}}</strong> qui ne peuvent pas être supprimés. Veuillez restaurer, ou supprimer définitivement le contenu parent <strong>{{parentName}}</strong> qui est le contenu initialement marqué pour suppression."
+            "content": "L’élément <0>{{name}}</0> ne peut actuellement pas être supprimé seul. Merci d’annuler la suppression, ou de supprimer définitivement, son contenu parent <1>{{parentName}}</1>, qui est le contenu initialement marqué pour suppression. ",
+            "content_plural": "Il y a ${count} éléments <0>{{name}}</0> qui ne peuvent pas être supprimés. Veuillez restaurer, ou supprimer définitivement le contenu parent <1>{{parentName}}</1> qui est le contenu initialement marqué pour suppression."
           },
           "undelete": {
             "title": "Impossible d'annuler la suppression",
-            "content": "Il n’est actuellement pas possible d’annuler directement la suppression de l’élément <strong>{{name}}</strong>. Veuillez annuler la suppression de son contenu parent <strong>{{parentName}}</strong>, qui est le contenu initialement marqué pour suppression. ",
-            "content_plural": "Il y a ${count} éléments <strong>{{name}}</strong> qui ne peuvent pas être restaurés. Veuillez restaurer, ou supprimer définitivement le contenu parent <strong>{{parentName}}</strong> qui est le contenu initialement marqué pour suppression."
+            "content": "Il n’est actuellement pas possible d’annuler directement la suppression de l’élément <0>{{name}}</0>. Veuillez annuler la suppression de son contenu parent <1>{{parentName}}</1>, qui est le contenu initialement marqué pour suppression. ",
+            "content_plural": "Il y a ${count} éléments <0>{{name}}</0> qui ne peuvent pas être restaurés. Veuillez restaurer, ou supprimer définitivement le contenu parent <1>{{parentName}}</1> qui est le contenu initialement marqué pour suppression."
           }
         },
         "error": "Impossible d'exécuter l'opération demandée. Fermeture de la fenêtre et rafraîchissement des données."

--- a/tests/cypress/e2e/menuActions/deleteSpecialChars.cy.ts
+++ b/tests/cypress/e2e/menuActions/deleteSpecialChars.cy.ts
@@ -1,0 +1,53 @@
+import {JContent} from '../../page-object';
+import {createSite, deleteSite, getComponent, uploadFile} from '@jahia/cypress';
+import {DeleteDialog} from '../../page-object/deleteDialog';
+
+const siteKey = 'jContentSite-deleteSpecialChars';
+const nodeName = 'test.png';
+const nodePath = `/sites/${siteKey}/files/${nodeName}`;
+const SPECIAL_CHARS_PAYLOAD = '<img src=x onerror=alert(1)>';
+
+describe('Delete dialog special characters rendering', () => {
+    before(() => {
+        createSite(siteKey);
+        uploadFile('/assets/uploadMedia/myfile.png', `/sites/${siteKey}/files`, nodeName, 'image/png');
+        cy.apollo({
+            mutationFile: 'jcontent/jcrSetProperty.graphql',
+            variables: {
+                pathOrId: nodePath,
+                property: 'jcr:title',
+                value: SPECIAL_CHARS_PAYLOAD,
+                language: 'en'
+            }
+        });
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession();
+    });
+
+    after(() => {
+        deleteSite(siteKey);
+        cy.logout();
+    });
+
+    it('displays special characters in item names as text in the Mark for Deletion dialog', () => {
+        cy.on('window:alert', cy.stub().as('alertStub'));
+
+        const jcontent = JContent.visit(siteKey, 'en', 'media/files');
+        jcontent.switchToListMode();
+        jcontent.getTable().getRowByName(nodeName).contextMenu().select('Delete');
+
+        // Wait for dialog data to finish loading (cancel-button only appears once query returns)
+        cy.get('[data-sel-role="cancel-button"]').should('be.visible');
+
+        cy.get('[data-sel-role="delete-message"]').within(() => {
+            cy.get('img').should('not.exist');
+            cy.contains(SPECIAL_CHARS_PAYLOAD).should('exist');
+        });
+
+        cy.get('@alertStub').should('not.have.been.called');
+
+        getComponent(DeleteDialog).close();
+    });
+});

--- a/tests/cypress/page-object/jcontent.ts
+++ b/tests/cypress/page-object/jcontent.ts
@@ -205,12 +205,14 @@ export class JContent extends BasePage {
     }
 
     switchToListMode(): JContent {
+        cy.get('.moonstone-loader', {timeout: 5000}).should('not.exist');
         this.switchToMode('List');
         cy.get('.moonstone-loader', {timeout: 5000}).should('not.exist');
         return this;
     }
 
     switchToStructuredView(): JContent {
+        cy.get('.moonstone-loader', {timeout: 5000}).should('not.exist');
         this.switchToMode('Structured');
         cy.get('.moonstone-loader', {timeout: 5000}).should('not.exist');
         return this;


### PR DESCRIPTION
### Description

Remove `innerhtml` raw rendering when displaying delete message. 

Replace with use of `<Trans>` component from i18n package. Refactored `renderLabel` as a separate file.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
