### PR TITLE
fix: Replace structuredClone for browser compatibility

### DIFF
--- a/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
+++ b/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.js
@@ -11,6 +11,7 @@ import {LoaderOverlay} from '~/ContentEditor/DesignSystem/LoaderOverlay';
 import {CeModalError} from '~/ContentEditor/ContentEditorApi/ContentEditorError';
 import {useOnBeforeContextHooks} from '~/ContentEditor/ContentEditor/useOnBeforeContextHooks';
 import {isEqual} from 'lodash';
+import {cloneDeep} from 'es-toolkit';
 
 export const ContentEditorContext = React.createContext({});
 
@@ -177,7 +178,7 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
         }
 
         sectionsSourceRef.current = sections;
-        sectionsCloneRef.current = structuredClone(sections);
+        sectionsCloneRef.current = cloneDeep(sections);
         return sectionsCloneRef.current;
     }, [sections]);
 


### PR DESCRIPTION
### Description

`structuredClone` method only supported on fairly recent versions https://caniuse.com/?search=structuredClone and causing issues on selenium tests due to browser compatibility.

Replace with an equivalent deepClone method that also does deep copy of the sections object.

Decided to fully replace and not just do a fallback so that we stay consistent during when in test and not in test.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
