### PR TITLE
fix: Do not display current domain if localhost is in list

### DIFF
--- a/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/useOpenInLiveData.js
+++ b/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/useOpenInLiveData.js
@@ -60,7 +60,7 @@ export const useOpenInLiveData = path => {
 
     const currentHostname = globalThis.location.hostname;
     const isHostnameInList = [serverName, ...serverNameAliases].includes(currentHostname) ||
-        serverNameAliases.includes('localhost');
+        [serverName, ...serverNameAliases].includes('localhost');
     return {
         selectedServerName,
         selectServerName,

--- a/tests/cypress/e2e/menuActions/openInLive.cy.ts
+++ b/tests/cypress/e2e/menuActions/openInLive.cy.ts
@@ -106,6 +106,13 @@ describe('Open in Live tests', () => {
                 .should('have.class', 'moonstone-selected');
         });
 
+        it('does not show current domain section when localhost is in the server names list', () => {
+            visitWithStub();
+            getComponentByRole(Button, 'openInLiveChevron').click();
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').should('be.visible');
+            cy.contains('Current domain').should('not.exist');
+        });
+
         it('selecting an alias opens URL with that alias', () => {
             visitWithStub();
             getComponentByRole(Button, 'openInLiveChevron').click();


### PR DESCRIPTION
### Description

Remove current domain group if localhost is already in the servername list

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
