### PR TITLE
fix: validate node types used in the sub-contents count query

### DIFF
--- a/.chachalog/av.md
+++ b/.chachalog/av.md
@@ -1,0 +1,5 @@
+---
+jcontent: patch
+---
+
+Validate node types against the registry before using them in the sub-contents count query

--- a/src/main/java/org/jahia/modules/contenteditor/graphql/api/GqlEditorForms.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/api/GqlEditorForms.java
@@ -237,7 +237,11 @@ public class GqlEditorForms {
 
         QueryManager queryManager = session.getWorkspace().getQueryManager();
         for (String type : nodeTypes) {
-            count += queryManager.createQuery("SELECT count " + "AS [rep:count()] " + "FROM [" + type + "] " + "WHERE isdescendantnode(['" + JCRContentUtils.sqlEncode(node.getPath()) + "'])", Query.JCR_SQL2).execute().getRows().nextRow().getValue("count").getLong();
+            // Resolve the requested type against the node type registry and use its canonical name in
+            // the query. Only a real node type name (which cannot contain query syntax) can reach the
+            // FROM clause — a crafted value is rejected here instead of altering the query structure.
+            String typeName = NodeTypeRegistry.getInstance().getNodeType(type).getName();
+            count += queryManager.createQuery("SELECT count " + "AS [rep:count()] " + "FROM [" + typeName + "] " + "WHERE isdescendantnode(['" + JCRContentUtils.sqlEncode(node.getPath()) + "'])", Query.JCR_SQL2).execute().getRows().nextRow().getValue("count").getLong();
             if (limit != null && limit > 0 && count >= limit) {
                 return limit;
             }


### PR DESCRIPTION
### Summary
`subContentsCounts` builds a JCR-SQL2 query for each requested node type by concatenating the type name directly into the `FROM [<type>]` clause. The `includeTypes` values were not validated, so special characters in a type name could alter the query structure.

### Change
Resolve each requested type against the node type registry (`NodeTypeRegistry.getNodeType(...)`) and use its **canonical name** in the query. Only a real, registered node type name — which cannot contain query syntax — can reach the `FROM` clause; anything else is rejected up front.

### Verification
Static + module CI. The change is small and self-contained (`NodeTypeRegistry` is already imported) and is covered by the module's CI build and test suite. A valid type returns its count as before; a value that is not a registered node type no longer reaches the query.
