### PR TITLE
fix: Maintain button state as formik validation runs

### DIFF
--- a/src/javascript/ContentEditor/utils/getButtonRenderer.jsx
+++ b/src/javascript/ContentEditor/utils/getButtonRenderer.jsx
@@ -2,6 +2,7 @@ import {useTranslation} from 'react-i18next';
 import {Button, Report} from '@jahia/moonstone';
 import PropTypes from 'prop-types';
 import React from 'react';
+import clsx from 'clsx';
 import styles from './getButtonRenderer.scss';
 
 export const getButtonRenderer = ({labelStyle, defaultButtonProps, noIcon} = {}) => {
@@ -40,16 +41,18 @@ export const getButtonRenderer = ({labelStyle, defaultButtonProps, noIcon} = {})
             />
         );
 
-        if (!hasWarningBadge) {
-            return button;
-        }
-
-        // Wrap the button and badge in a positioned container so the absolutely
-        // positioned badge anchors to the button instead of the page.
+        // Always render the same wrapper element so the button keeps a stable identity across
+        // renders. Toggling the root element type (bare button vs wrapped) when hasWarningBadge
+        // changes makes React remount the button, which swallows an in-progress click (the badge
+        // clears mid-click, e.g. on save) and forces a second click. The wrapper is layout-neutral
+        // (display: contents) until the badge is shown, when it becomes the positioned anchor so
+        // the absolutely positioned badge attaches to the button instead of the page.
         return (
-            <div className={styles.pastilleWrapper}>
+            <div className={clsx(styles.pastilleWrapper, {[styles.hasBadge]: hasWarningBadge})}>
                 {button}
-                <Report size="big" data-sel-role={`${actionKey}_pastille`} className={styles.warningBadge}/>
+                {hasWarningBadge && (
+                    <Report size="big" data-sel-role={`${actionKey}_pastille`} className={styles.warningBadge}/>
+                )}
             </div>
         );
     };

--- a/src/javascript/ContentEditor/utils/getButtonRenderer.scss
+++ b/src/javascript/ContentEditor/utils/getButtonRenderer.scss
@@ -11,6 +11,11 @@
 }
 
 .pastilleWrapper {
+    // Layout-neutral by default so wrapping every button does not affect inline/ButtonGroup layouts.
+    display: contents;
+}
+
+.pastilleWrapper.hasBadge {
     position: relative;
 
     display: flex;

--- a/tests/cypress/e2e/contentEditor/shard2/saveButtonValidationBadge.cy.ts
+++ b/tests/cypress/e2e/contentEditor/shard2/saveButtonValidationBadge.cy.ts
@@ -1,0 +1,59 @@
+import {ContentEditor} from '../../../page-object';
+import {addNode, deleteSite, enableModule} from '@jahia/cypress';
+
+describe('Content Editor - Save button with a validation warning badge', () => {
+    const siteKey = 'saveButtonValidationBadge';
+    const contentName = 'mandatoryFieldContent';
+    const contentPath = `/sites/${siteKey}/contents/${contentName}`;
+    const savePastille = '[data-sel-role="submitSave_pastille"]';
+
+    before(() => {
+        cy.executeGroovy('contentEditor/createSiteI18N.groovy', {SITEKEY: siteKey});
+        enableModule('qa-module', siteKey);
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: contentName,
+            primaryNodeType: 'qant:constraints',
+            properties: [
+                {name: 'mandatorySharedSmallText', value: 'test'},
+                {name: 'mandatoryRegexSharedSmallText', value: 'test'},
+                {name: 'mandatorySmallText', value: 'test', language: 'en'},
+                {name: 'mandatoryRegexSmallText', value: 'test', language: 'en'}
+            ]
+        });
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession();
+    });
+
+    afterEach(() => {
+        cy.logout();
+    });
+
+    after(() => {
+        deleteSite(siteKey);
+    });
+
+    it('saves in a single click when the Save button shows a validation warning badge', () => {
+        // Open in French, where both i18n mandatory fields are empty → Save button shows the badge.
+        const contentEditor = ContentEditor.visit(contentPath, siteKey, 'fr', 'content-folders/contents');
+
+        // Precondition: the Save button warning badge is displayed.
+        cy.get(savePastille).should('be.visible');
+
+        // Fill every empty mandatory field. Validation runs on save (not on change), so the badge is
+        // still shown at click time — the exact state that used to remount the button and eat the
+        // first click.
+        contentEditor.getSmallTextField('qant:constraints_mandatorySmallText').addNewValue('test');
+        contentEditor.getSmallTextField('qant:constraints_mandatoryRegexSmallText').addNewValue('test');
+        cy.get(savePastille).should('be.visible');
+
+        // A SINGLE click must save. save() clicks submitSave once and asserts the success toast,
+        // so on the buggy (remounting) button this times out; with the fix it passes.
+        contentEditor.save();
+
+        // The badge is gone once the content has been saved.
+        cy.get(savePastille).should('not.exist');
+    });
+});


### PR DESCRIPTION
### Description
Maintain button state as formik validation runs. This fixes the issue when two clicks are required to save the form if it is opened with a validation error, which is then fixed and save button is clicked without blur listener getting called.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
