### PR TITLE
fix: Check for permissions in the dropdown tabs of the content editor

### DIFF
--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelFullscreen.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelFullscreen.jsx
@@ -64,6 +64,7 @@ export const EditPanelFullscreen = ({title}) => {
                     title={title}
                     isShowPublish={mode === Constants.routes.baseEditRoute}
                     activeTabState={[activeTab, setActiveTab]}
+                    displayableTabs={displayableTabs}
                 />
             )}
             content={(

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelFullscreen.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelFullscreen.jsx
@@ -9,6 +9,7 @@ import {Constants} from '~/ContentEditor/ContentEditor.constants';
 import {EditPanelHeader} from './EditPanelHeader/EditPanelHeader';
 import {useContentEditorConfigContext} from '~/shared';
 import {CeModalError} from '~/ContentEditor/ContentEditorApi/ContentEditorError';
+import {useEditHeaderTabs} from '~/ContentEditor/editorTabs/useEditHeaderTabs';
 
 export const EditPanelFullscreen = ({title}) => {
     const config = useContentEditorConfigContext();
@@ -26,6 +27,17 @@ export const EditPanelFullscreen = ({title}) => {
     if (!tab) {
         throw new CeModalError(`No tab found for the current active tab value (${activeTab}), check the registry for the "editHeaderTabsActions" target (valid values are: ${tabs.map(t => t.value).join(', ')})`);
     }
+
+    // Guard against the active tab being one the user isn't permitted to see (e.g. reached via
+    // advancedOpenTab without the tab's required permission): fall back to the always-available
+    // edit tab once permission checks resolve. The header dropdown never offers forbidden tabs.
+    const {tabs: displayableTabs, loading: tabsLoading} = useEditHeaderTabs();
+    const isActiveTabAllowed = displayableTabs.some(t => t.value === activeTab);
+    useEffect(() => {
+        if (!tabsLoading && activeTab && displayableTabs.length > 0 && !isActiveTabAllowed) {
+            setActiveTab(Constants.editPanel.editTab);
+        }
+    }, [tabsLoading, displayableTabs, activeTab, isActiveTabAllowed, setActiveTab]);
 
     // Track which tabs have been visited so we mount them lazily but keep them
     // mounted afterwards (CSS show/hide), preserving scroll position and local state.

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/EditPanelHeader.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/EditPanelHeader.jsx
@@ -17,7 +17,6 @@ import {useNodeChecks} from '@jahia/data-helper';
 import {Constants} from '~/ContentEditor/ContentEditor.constants';
 import {useEngineTabAvailability} from '~/ContentEditor/editorTabs/engineTabs/useEngineTabAvailability';
 import {useOpenEngineTabsWithConfirmation} from '~/ContentEditor/editorTabs/engineTabs/useOpenEngineTabsWithConfirmation';
-import {useEditHeaderTabs} from '~/ContentEditor/editorTabs/useEditHeaderTabs';
 
 const ButtonRenderer = getButtonRenderer({
     defaultButtonProps: {size: 'big', color: 'accent'}
@@ -33,6 +32,7 @@ export const EditPanelHeader = ({
     isShowPublish,
     hideLanguageSwitcher,
     activeTabState,
+    displayableTabs = [],
     targetActionKey = 'content-editor/header/3dots'
 }) => {
     const ctx = useContentEditorContext();
@@ -42,9 +42,6 @@ export const EditPanelHeader = ({
     // Some tabs may have `requiresAdvancedPermission: true`, we do a single perm check here
     const res = useNodeChecks({path: ctx.path}, {requiredSitePermission: [Constants.permissions.canSeeAdvancedOptionsTab]});
 
-    // Registry tabs the user may see (isDisplayable + each tab's own requiredPermission/requiredSitePermission),
-    // then the existing canSeeAdvancedOptionsTab gate for tabs flagged requiresAdvancedPermission.
-    const {tabs: displayableTabs} = useEditHeaderTabs();
     const tabs = displayableTabs.filter(tab => !tab.requiresAdvancedPermission || res.checksResult);
 
     const engineTabIds = ['workflow', 'liveroles', 'editroles'];
@@ -171,5 +168,6 @@ EditPanelHeader.propTypes = {
             1: PropTypes.func.isRequired
         })
     ),
+    displayableTabs: PropTypes.array,
     targetActionKey: PropTypes.string
 };

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/EditPanelHeader.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/EditPanelHeader.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {DisplayAction, DisplayActions, registry} from '@jahia/ui-extender';
+import {DisplayAction, DisplayActions} from '@jahia/ui-extender';
 import {ButtonRendererShortLabel, getButtonRenderer} from '~/ContentEditor/utils';
 import {truncate} from '~/utils';
 import {ButtonGroup, Dropdown, Header, Separator, Workflow, EditRole, LiveRole} from '@jahia/moonstone';
@@ -17,6 +17,7 @@ import {useNodeChecks} from '@jahia/data-helper';
 import {Constants} from '~/ContentEditor/ContentEditor.constants';
 import {useEngineTabAvailability} from '~/ContentEditor/editorTabs/engineTabs/useEngineTabAvailability';
 import {useOpenEngineTabsWithConfirmation} from '~/ContentEditor/editorTabs/engineTabs/useOpenEngineTabsWithConfirmation';
+import {useEditHeaderTabs} from '~/ContentEditor/editorTabs/useEditHeaderTabs';
 
 const ButtonRenderer = getButtonRenderer({
     defaultButtonProps: {size: 'big', color: 'accent'}
@@ -41,9 +42,10 @@ export const EditPanelHeader = ({
     // Some tabs may have `requiresAdvancedPermission: true`, we do a single perm check here
     const res = useNodeChecks({path: ctx.path}, {requiredSitePermission: [Constants.permissions.canSeeAdvancedOptionsTab]});
 
-    const tabs = registry
-        .find({target: 'editHeaderTabsActions'})
-        .filter(tab => tab.isDisplayable(ctx) && (!tab.requiresAdvancedPermission || res.checksResult));
+    // Registry tabs the user may see (isDisplayable + each tab's own requiredPermission/requiredSitePermission),
+    // then the existing canSeeAdvancedOptionsTab gate for tabs flagged requiresAdvancedPermission.
+    const {tabs: displayableTabs} = useEditHeaderTabs();
+    const tabs = displayableTabs.filter(tab => !tab.requiresAdvancedPermission || res.checksResult);
 
     const engineTabIds = ['workflow', 'liveroles', 'editroles'];
     const engineTabIcons = {

--- a/src/javascript/ContentEditor/editorTabs/registerDropdownOptions.js
+++ b/src/javascript/ContentEditor/editorTabs/registerDropdownOptions.js
@@ -51,6 +51,7 @@ export const registerDropdownOptions = actionsRegistry => {
             />
         ),
         editPanelHeaderProps: {hideLanguageSwitcher: true},
+        requiredSitePermission: ['translateAction'],
         isDisplayable: ({siteInfo}) => siteInfo?.languages?.length > 1
     });
 };

--- a/src/javascript/ContentEditor/editorTabs/useEditHeaderTabs.js
+++ b/src/javascript/ContentEditor/editorTabs/useEditHeaderTabs.js
@@ -1,0 +1,60 @@
+import {registry} from '@jahia/ui-extender';
+import {useNodeChecks} from '@jahia/data-helper';
+import {useContentEditorContext} from '~/ContentEditor/contexts/ContentEditor';
+
+const collect = (tabs, key) => [...new Set(tabs.flatMap(tab => tab[key] || []))];
+
+const hasDeclaredPermission = tab => Boolean(tab.requiredPermission || tab.requiredSitePermission);
+
+/**
+ * Resolves the Content Editor header tabs (target `editHeaderTabsActions`) the current user
+ * is allowed to see. Each tab may declare `requiredPermission` (node permissions) and/or
+ * `requiredSitePermission` (site permissions) alongside its synchronous `isDisplayable(ctx)`
+ * predicate, mirroring the convention used by the shared SidePanel tabs and other actions.
+ *
+ * Permission checks are async (GraphQL), so rather than one hook per tab (which the dynamic,
+ * registry-driven tab set forbids) we run a single `useNodeChecks` over the union of every
+ * declared permission and read each result back off the returned node
+ * (`node[perm]` / `node.site[perm]`). Within a single tab, a permission array is satisfied when
+ * the user holds ANY of the listed permissions, matching `useNodeChecks` semantics.
+ *
+ * @returns {{tabs: object[], allTabs: object[], loading: boolean}} the displayable+permitted
+ * tabs, the full registered set, and whether the permission check is still resolving.
+ */
+export const useEditHeaderTabs = () => {
+    const ctx = useContentEditorContext();
+    const allTabs = registry.find({target: 'editHeaderTabsActions'});
+
+    const requiredPermission = collect(allTabs, 'requiredPermission');
+    const requiredSitePermission = collect(allTabs, 'requiredSitePermission');
+    const needsCheck = requiredPermission.length > 0 || requiredSitePermission.length > 0;
+
+    const {node, loading} = useNodeChecks(
+        {path: ctx.path},
+        {
+            requiredPermission: requiredPermission.length > 0 ? requiredPermission : undefined,
+            requiredSitePermission: requiredSitePermission.length > 0 ? requiredSitePermission : undefined,
+            skip: !needsCheck || !ctx.path
+        }
+    );
+
+    // Until the check resolves (still loading, or node unreadable) we can't know which gated tabs
+    // are allowed. Decide that once here rather than per tab: surface only permission-free tabs.
+    if (needsCheck && (loading || !node)) {
+        return {
+            tabs: allTabs.filter(tab => tab.isDisplayable(ctx) && !hasDeclaredPermission(tab)),
+            allTabs,
+            loading
+        };
+    }
+
+    const isAllowed = tab => {
+        const nodeOk = !tab.requiredPermission || tab.requiredPermission.some(permission => node[permission]);
+        const siteOk = !tab.requiredSitePermission || tab.requiredSitePermission.some(permission => node.site?.[permission]);
+        return nodeOk && siteOk;
+    };
+
+    const tabs = allTabs.filter(tab => tab.isDisplayable(ctx) && isAllowed(tab));
+
+    return {tabs, allTabs, loading: false};
+};


### PR DESCRIPTION
### Description
Check for permissions in the dropdown tab of the content editor.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
