### PR TITLE
fix: Exclude ";" from system name

### DIFF
--- a/.chachalog/7WzBDOgM.md
+++ b/.chachalog/7WzBDOgM.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Exclude ";" from system name (#2552)

--- a/src/javascript/ContentEditor/validation/validate.js
+++ b/src/javascript/ContentEditor/validation/validate.js
@@ -210,7 +210,7 @@ const requiredFieldValidation = (values, field) => {
 };
 
 const systemNameValidation = (values, field) => {
-    const regex = /[\\/:*?"<>|%]/;
+    const regex = /[\\/:*?"<>|%;]/;
     if (field.name === 'nt:base_ce:systemName' && regex.test(values[field.name])) {
         return 'invalidSystemName';
     }

--- a/src/javascript/ContentEditor/validation/validate.spec.js
+++ b/src/javascript/ContentEditor/validation/validate.spec.js
@@ -772,4 +772,36 @@ describe('validate', () => {
             });
         });
     });
+
+    describe('systemName', () => {
+        const systemNameFieldName = 'nt:base_ce:systemName';
+        const buildSystemNameSections = value => ({
+            sections: [{
+                fieldSets: [{
+                    name: 'fieldSet1',
+                    dynamic: false,
+                    fields: [{name: systemNameFieldName, requiredType: 'STRING'}]
+                }]
+            }],
+            values: {[systemNameFieldName]: value}
+        });
+
+        it('should not return an error for a valid system name', () => {
+            const {sections, values} = buildSystemNameSections('financeops2026.jpg');
+            expect(validate(sections)(values)).toEqual({[systemNameFieldName]: undefined});
+        });
+
+        it('should return invalidSystemName when the name contains a semicolon', () => {
+            const {sections, values} = buildSystemNameSections('financeops202;6.jpg');
+            expect(validate(sections)(values)).toEqual({[systemNameFieldName]: 'invalidSystemName'});
+        });
+
+        it.each(['a/b', 'a:b', 'a*b', 'a?b', 'a"b', 'a<b', 'a>b', 'a|b', 'a%b', 'a\\b'])(
+            'should return invalidSystemName for the forbidden character in "%s"',
+            value => {
+                const {sections, values} = buildSystemNameSections(value);
+                expect(validate(sections)(values)).toEqual({[systemNameFieldName]: 'invalidSystemName'});
+            }
+        );
+    });
 });

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -761,7 +761,7 @@
           "invalidPattern": "Die Eingabe entspricht nicht den Vorgaben der Content-Typ-Definition",
           "invalidNumber": "Bitte geben Sie eine gültige Nummer ein",
           "invalidRange": "Die Eingabe entspricht nicht den Vorgaben der Content-Typ-Definition",
-          "invalidSystemName": "Systemname darf nicht die folgenden Sonderzeichen enthalten: '/:*?\"<>|%'",
+          "invalidSystemName": "Systemname darf nicht die folgenden Sonderzeichen enthalten: '/:*?\"<>|%;'",
           "required": "",
           "alreadyExist": "Ein Element mit demselben Systemnamen ist bereits vorhanden. Bitte wählen Sie ein anderes aus",
           "maxLength": "Maximal {{selectorOptions.maxLength}} Zeichen.",

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -771,7 +771,7 @@
           "invalidPattern": "The value does not match the constraints defined in the content type definitions file",
           "invalidNumber": "Please provide a valid number",
           "invalidRange": "The value does not match the constraints defined in the content type definitions file",
-          "invalidSystemName": "System name cannot consist of special characters such as '/:*?\"<>|%'",
+          "invalidSystemName": "System name cannot consist of special characters such as '/:*?\"<>|%;'",
           "required": "",
           "alreadyExist": "An item with the same system name already exists, please choose another one",
           "maxLength": "{{selectorOptions.maxLength}} characters maximum",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -762,7 +762,7 @@
           "invalidPattern": "La valeur ne correspond pas aux contraintes définies dans le fichier de définition des types de contenu",
           "invalidNumber": "Veuillez fournir un numéro valide",
           "invalidRange": "La valeur ne correspond pas aux contraintes définies dans le fichier de définition des types de contenu",
-          "invalidSystemName": "Le nom système ne peut contenir les caractères suivants ‘/:*?\"<>|%’",
+          "invalidSystemName": "Le nom système ne peut contenir les caractères suivants ‘/:*?\"<>|%;’",
           "required": "",
           "alreadyExist": "Il y a déjà un objet avec ce nom système, veuillez en choisir un autre",
           "maxLength": "{{selectorOptions.maxLength}} caractères maximum",


### PR DESCRIPTION
### Description
Exclude ";" from system name.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
