### PR TITLE
feat: Add GWT versioning modal to CE modes dropdown

### DIFF
--- a/.chachalog/b66a36a9.md
+++ b/.chachalog/b66a36a9.md
@@ -5,4 +5,5 @@
 
 Remove the Advanced Options tab from the Content Editor
   - Technical information and usages are now available in the CE side panel
-  - Versioning, workflow and role engine tabs are now available from the modes dropdown
+  - GWT Workflow and role engine tabs are now available from the advanced section in Content Editor modes dropdown
+  - Legacy GWT versioning also available from the advanced section in Content Editor modes dropdown for Jahia versions < 8.2.4.0

--- a/.chachalog/b66a36a9.md
+++ b/.chachalog/b66a36a9.md
@@ -1,6 +1,8 @@
 ---
 # Allowed version bumps: patch, minor, major
-"@jahia/jcontent": patch
+"@jahia/jcontent": minor
 ---
 
-Remove the Advanced Options tab from the Content Editor. Technical information and usages are available in the CE side panel, and the workflow and role engine tabs are available from the modes dropdown.
+Remove the Advanced Options tab from the Content Editor
+  - Technical information and usages are now available in the CE side panel
+  - Versioning, workflow and role engine tabs are now available from the modes dropdown

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/EditPanelHeader.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/EditPanelHeader.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {DisplayAction, DisplayActions} from '@jahia/ui-extender';
 import {ButtonRendererShortLabel, getButtonRenderer} from '~/ContentEditor/utils';
 import {truncate} from '~/utils';
-import {ButtonGroup, Dropdown, Header, Separator, Workflow, EditRole, LiveRole} from '@jahia/moonstone';
+import {ButtonGroup, Dropdown, Header, Separator} from '@jahia/moonstone';
 import styles from './EditPanelHeader.scss';
 import {PublishMenu} from './PublishMenu';
 import {useTranslation} from 'react-i18next';
@@ -35,22 +35,18 @@ export const EditPanelHeader = ({
     displayableTabs = [],
     targetActionKey = 'content-editor/header/3dots'
 }) => {
-    const ctx = useContentEditorContext();
+    const {nodeData, site, mode} = useContentEditorContext();
     const {t} = useTranslation('jcontent');
     const [activeTab, setActiveTab] = activeTabState || [];
 
     // Some tabs may have `requiresAdvancedPermission: true`, we do a single perm check here
-    const res = useNodeChecks({path: ctx.path}, {requiredSitePermission: [Constants.permissions.canSeeAdvancedOptionsTab]});
-
+    const res = useNodeChecks(
+        {path: nodeData?.path},
+        {requiredSitePermission: [Constants.permissions.canSeeAdvancedOptionsTab]}
+    );
     const tabs = displayableTabs.filter(tab => !tab.requiresAdvancedPermission || res.checksResult);
 
-    const engineTabIds = ['workflow', 'liveroles', 'editroles'];
-    const engineTabIcons = {
-        workflow: <Workflow/>,
-        liveroles: <LiveRole/>,
-        editroles: <EditRole/>
-    };
-    const {availableTabs: engineTabs} = useEngineTabAvailability(engineTabIds);
+    const {engineTabs, engineTabIds} = useEngineTabAvailability({nodeData, site, mode});
     const {openTabs: openEngineTab, confirmationDialog: engineConfirmationDialog} = useOpenEngineTabsWithConfirmation(engineTabIds);
     const hasEngineEntries = res.checksResult && engineTabs.length > 0;
 
@@ -70,7 +66,7 @@ export const EditPanelHeader = ({
             options: engineTabs.map(tab => ({
                 value: tab.id,
                 label: tab.title,
-                iconStart: engineTabIcons[tab.id],
+                iconStart: tab.icon,
                 attributes: {'data-sel-role': `tab-${tab.id}`}
             }))
         }
@@ -80,8 +76,8 @@ export const EditPanelHeader = ({
         <Header
             title={truncate(title, 60)}
             breadcrumb={
-                ctx.nodeData?.path?.startsWith('/sites') && (
-                    <ContentPath path={ctx.nodeData.path}/>
+                nodeData?.path?.startsWith('/sites') && (
+                    <ContentPath path={nodeData.path}/>
                 )
             }
             contentType={<ContentTypeChip/>}

--- a/src/javascript/ContentEditor/SelectorTypes/registerSelectorTypesOnChange.js
+++ b/src/javascript/ContentEditor/SelectorTypes/registerSelectorTypesOnChange.js
@@ -38,7 +38,6 @@ export const registerSelectorTypesOnChange = registry => {
     registry.add('selectorType.onChange', 'dependentProperties', {
         targets: ['*'],
         onChange: (previousValue, currentValue, field, onChangeContext) => {
-            console.debug(`Processing field ${field.name}: currentValue: ${currentValue}, previousValue: ${previousValue}`);
             const sections = onChangeContext.sections;
             const fields = getFields(sections);
             const dependentPropertiesFields = fields

--- a/src/javascript/ContentEditor/editorTabs/engineTabs/useEngineTabAvailability.js
+++ b/src/javascript/ContentEditor/editorTabs/engineTabs/useEngineTabAvailability.js
@@ -1,8 +1,9 @@
+import React from 'react';
 import {useQuery} from '@apollo/client';
 import {engineTabsPermissionCheckQuery} from './engineTabs.permission.gql-query';
 import {getGwtEngineTabs} from './engineTabs.utils';
-import {useContentEditorContext} from '~/ContentEditor/contexts/ContentEditor';
 import {Constants} from '~/ContentEditor/ContentEditor.constants';
+import {EditRole, LiveRole, Version, Workflow} from '@jahia/moonstone';
 
 /**
  * Resolves which of the given GWT engine tabs are available for the current node,
@@ -10,20 +11,33 @@ import {Constants} from '~/ContentEditor/ContentEditor.constants';
  * returned by the GWT authoring API and its required permission (if any) must be granted.
  *
  * @param tabIds array of GWT engine tab ids to look for (e.g. ['workflow'])
- * @returns {{availableTabs: array, loading: boolean, error: object}}
+ * @returns {{engineTabIds: string[], engineTabs: array}}
  */
-export const useEngineTabAvailability = tabIds => {
-    const {nodeData, site, mode} = useContentEditorContext();
-
-    const gwtTabs = (mode === Constants.routes.baseEditRoute && nodeData) ?
-        getGwtEngineTabs(nodeData).filter(tab => tabIds.includes(tab.id)) :
-        [];
-
-    const {loading, error, data} = useQuery(engineTabsPermissionCheckQuery(gwtTabs, site), {skip: gwtTabs.length === 0});
-
-    return {
-        availableTabs: (loading || error) ? [] : gwtTabs.filter(tab => !tab.requiredPermission || Boolean(data?.jcr?.nodeByPath?.[tab.id])),
-        loading,
-        error
+export const useEngineTabAvailability = ({nodeData, site, mode}) => {
+    const engineTabDefs = {
+        editroles: {icon: <EditRole/>},
+        liveroles: {icon: <LiveRole/>},
+        versioning: {icon: <Version/>},
+        workflow: {icon: <Workflow/>}
     };
+    const engineTabIds = Object.keys(engineTabDefs);
+
+    // Preserve order of engineTabIds; insert icons to gwtTabs for use in the dropdown
+    const allGwtTabs = (mode === Constants.routes.baseEditRoute && nodeData) ? getGwtEngineTabs(nodeData) : [];
+    const gwtTabsById = Object.fromEntries(allGwtTabs.map(tab => [tab.id, tab]));
+    const gwtTabs = engineTabIds
+        .map(id => gwtTabsById[id] && {...gwtTabsById[id], icon: engineTabDefs[id].icon})
+        .filter(Boolean);
+
+    const {loading, error, data} = useQuery(
+        engineTabsPermissionCheckQuery(gwtTabs, site),
+        {skip: gwtTabs.length === 0}
+    );
+
+    let engineTabs = [];
+    if (!loading && !error) {
+        engineTabs = gwtTabs.filter(tab => !tab.requiredPermission || Boolean(data?.jcr?.nodeByPath?.[tab.id]));
+    }
+
+    return {engineTabIds, engineTabs};
 };

--- a/src/javascript/ContentEditor/editorTabs/engineTabs/useEngineTabAvailability.spec.jsx
+++ b/src/javascript/ContentEditor/editorTabs/engineTabs/useEngineTabAvailability.spec.jsx
@@ -1,7 +1,6 @@
 import {useEngineTabAvailability} from './useEngineTabAvailability';
 import {useQuery} from '@apollo/client';
 import {getGwtEngineTabs} from './engineTabs.utils';
-import {useContentEditorContext} from '~/ContentEditor/contexts/ContentEditor/ContentEditor.context';
 
 jest.mock('./engineTabs.utils', () => {
     return {
@@ -21,19 +20,22 @@ jest.mock('./engineTabs.permission.gql-query', () => {
     };
 });
 
-jest.mock('~/ContentEditor/contexts/ContentEditor/ContentEditor.context', () => {
+jest.mock('@jahia/moonstone', () => {
     return {
-        useContentEditorContext: jest.fn()
+        EditRole: () => null,
+        LiveRole: () => null,
+        Version: () => null,
+        Workflow: () => null
     };
 });
 
 describe('useEngineTabAvailability', () => {
     let useQueryResponse;
-    let contentEditorContext;
+    let hookArgs;
 
     beforeEach(() => {
         jest.clearAllMocks();
-        contentEditorContext = {
+        hookArgs = {
             mode: 'edit',
             site: 'digitall',
             nodeData: {
@@ -44,11 +46,9 @@ describe('useEngineTabAvailability', () => {
                 primaryNodeType: {name: 'jnt:content', supertypes: [], hasOrderableChildNodes: false}
             }
         };
-        useContentEditorContext.mockImplementation(() => contentEditorContext);
 
         getGwtEngineTabs.mockImplementation(() => [
-            {id: 'workflow', title: 'Workflow', requiredPermission: 'viewWorkflowTab'},
-            {id: 'usages', title: 'Usages'}
+            {id: 'workflow', title: 'Workflow', requiredPermission: 'viewWorkflowTab'}
         ]);
 
         useQueryResponse = {
@@ -66,50 +66,51 @@ describe('useEngineTabAvailability', () => {
     });
 
     it('should return the tab when it is available and permission is granted', () => {
-        const {availableTabs} = useEngineTabAvailability(['workflow']);
+        const {engineTabs} = useEngineTabAvailability(hookArgs);
 
-        expect(availableTabs).toHaveLength(1);
-        expect(availableTabs[0].id).toBe('workflow');
+        expect(engineTabs).toHaveLength(1);
+        expect(engineTabs[0].id).toBe('workflow');
     });
 
     it('should not return the tab when the permission is denied', () => {
         useQueryResponse.data = {jcr: {nodeByPath: {workflow: false}}};
 
-        const {availableTabs} = useEngineTabAvailability(['workflow']);
+        const {engineTabs} = useEngineTabAvailability(hookArgs);
 
-        expect(availableTabs).toHaveLength(0);
+        expect(engineTabs).toHaveLength(0);
     });
 
     it('should return tabs without required permission without querying permissions', () => {
-        const {availableTabs} = useEngineTabAvailability(['usages']);
+        getGwtEngineTabs.mockImplementation(() => [
+            {id: 'versioning', title: 'Versioning'}
+        ]);
 
-        expect(availableTabs).toHaveLength(1);
-        expect(availableTabs[0].id).toBe('usages');
+        const {engineTabs} = useEngineTabAvailability(hookArgs);
+
+        expect(engineTabs).toHaveLength(1);
+        expect(engineTabs[0].id).toBe('versioning');
     });
 
     it('should not return the tab when GWT does not provide it', () => {
         getGwtEngineTabs.mockImplementation(() => []);
 
-        const {availableTabs} = useEngineTabAvailability(['workflow']);
+        const {engineTabs} = useEngineTabAvailability(hookArgs);
 
-        expect(availableTabs).toHaveLength(0);
+        expect(engineTabs).toHaveLength(0);
     });
 
     it('should not return any tab outside of edit mode', () => {
-        contentEditorContext.mode = 'create';
+        const {engineTabs} = useEngineTabAvailability({...hookArgs, mode: 'create'});
 
-        const {availableTabs} = useEngineTabAvailability(['workflow']);
-
-        expect(availableTabs).toHaveLength(0);
+        expect(engineTabs).toHaveLength(0);
         expect(getGwtEngineTabs).not.toHaveBeenCalled();
     });
 
     it('should return no tabs while the permission query is loading', () => {
         useQueryResponse.loading = true;
 
-        const {availableTabs, loading} = useEngineTabAvailability(['workflow']);
+        const {engineTabs} = useEngineTabAvailability(hookArgs);
 
-        expect(loading).toBe(true);
-        expect(availableTabs).toHaveLength(0);
+        expect(engineTabs).toHaveLength(0);
     });
 });

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/EmptyListComponent/EmptyListComponent.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/EmptyListComponent/EmptyListComponent.jsx
@@ -11,7 +11,10 @@ const EMPTY_LIST_QUERY = gql`
     query PreviewEmptyListCheck($path: String!) {
         jcr {
             nodeByPath(path: $path) {
+                uuid
+                workspace
                 primaryNodeType {
+                    name
                     hasOrderableChildNodes
                 }
                 previewSubNodes: children(typesFilter: {types: ["jnt:file", "jnt:folder", "jnt:content", "jnt:contentFolder"], multi: ANY}) {

--- a/src/javascript/JContent/SidePanel/ContentDetails/ContentDetails.jsx
+++ b/src/javascript/JContent/SidePanel/ContentDetails/ContentDetails.jsx
@@ -12,6 +12,8 @@ const GET_CONTENT_LINKS = gql`
     query getContentLinks($path: String!, $languages: [String]!) {
         live: jcr(workspace: LIVE) {
             nodeByPath(path: $path) {
+                uuid
+                workspace
                 vanityUrls(languages: $languages) {
                     url
                     active
@@ -23,6 +25,8 @@ const GET_CONTENT_LINKS = gql`
         }
         edit: jcr(workspace: EDIT) {
             nodeByPath(path: $path) {
+                uuid
+                workspace
                 vanityUrls(languages: $languages) {
                     url
                     active

--- a/src/javascript/JContent/SidePanel/ContentHistory/ContentHistory.gql-queries.js
+++ b/src/javascript/JContent/SidePanel/ContentHistory/ContentHistory.gql-queries.js
@@ -5,6 +5,7 @@ export const GetContentHistoryQuery = gql`
         jcr {
             nodeByPath(path: $path) {
                 uuid
+                workspace
                 history {
                     count(withLanguageNodes: $withLanguageNodes, action: $action)
                     entries(withLanguageNodes: $withLanguageNodes, action: $action, offset: $offset, limit: $limit) {


### PR DESCRIPTION
### Description

Add GWT versioning modal to CE modes dropdown

Refactored engine tab hook to contain all GWT engine tab-related code.
  - Preserve display order for engine tabs

No cypress tests added as this is only support for released versions, and not for snapshot. Require manual test

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
