### PR TITLE
fix: make document search on file name case-insensitive

### DIFF
--- a/.chachalog/40Gkwvhz.md
+++ b/.chachalog/40Gkwvhz.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Make document search on file name case-insensitive (#2558)

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/SearchQueryHandler.gql-queries.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/SearchQueryHandler.gql-queries.js
@@ -13,7 +13,7 @@ export const SearchQuery = gql`
                         any: [
                             {contains: $searchTerms}
                             {contains: $searchTerms, property: "j:tagList"}
-                            {like: $nodeNameSearchTerms, property: "j:nodename"}
+                            {like: $nodeNameSearchTerms, property: "j:nodename", function: LOWER_CASE}
                         ]
                     }
                 },

--- a/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/SearchQueryHandler.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/queryHandlers/SearchQueryHandler.js
@@ -11,7 +11,10 @@ export const SearchQueryHandler = {
         searchPath,
         nodeType: (searchContentType || 'jmix:searchable'),
         searchTerms,
-        nodeNameSearchTerms: `%${searchTerms}%`,
+        // LOWER_CASE on the j:nodename LIKE constraint lowercases the column server-side, so the
+        // pattern must be lowercased too for the match to work — keeps file-name search case-insensitive
+        // and consistent with the (analyzer-based) content search.
+        nodeNameSearchTerms: `%${(searchTerms || '').toLowerCase()}%`,
         language: lang,
         displayLanguage: uilang,
         offset: pagination.currentPage * pagination.pageSize,

--- a/tests/cypress/e2e/jcontent/shard2/search.cy.ts
+++ b/tests/cypress/e2e/jcontent/shard2/search.cy.ts
@@ -7,6 +7,8 @@ describe('Search tests', () => {
     before(function () {
         cy.executeGroovy('jcontent/createSite.groovy', {SITEKEY: 'jcontentSite'});
         cy.apollo({mutationFile: 'jcontent/createContent.graphql'});
+        // Two nodes whose system names differ only by case, to check name search is case-insensitive
+        cy.apollo({mutationFile: 'jcontent/createCaseSensitiveContent.graphql'});
     });
 
     after(function () {
@@ -83,6 +85,26 @@ describe('Search tests', () => {
                 .verifyResults(['Very Rich text to find with tag'])
                 .verifyResultType('Rich text')
                 .verifyTotalCount(1);
+        });
+
+        // Regression: name search must be case-insensitive, like content search. Both an uppercase
+        // and a lowercase term must return both nodes whose names differ only by case.
+        it('Test name search is case-insensitive with an uppercase term', function () {
+            basicSearch
+                .searchTerm('Bercy')
+                .searchInWholeSite()
+                .executeSearch()
+                .verifyResults(['upperCaseDoc', 'lowerCaseDoc'])
+                .verifyTotalCount(2);
+        });
+
+        it('Test name search is case-insensitive with a lowercase term', function () {
+            basicSearch
+                .searchTerm('bercy')
+                .searchInWholeSite()
+                .executeSearch()
+                .verifyResults(['upperCaseDoc', 'lowerCaseDoc'])
+                .verifyTotalCount(2);
         });
     });
 

--- a/tests/cypress/fixtures/jcontent/createCaseSensitiveContent.graphql
+++ b/tests/cypress/fixtures/jcontent/createCaseSensitiveContent.graphql
@@ -1,0 +1,22 @@
+mutation createCaseSensitiveContent($parentPath: String! = "/sites/jcontentSite/home/area-main") {
+    jcr {
+        mutateNode(pathOrId: $parentPath) {
+            addChildrenBatch(
+                nodes: [
+                    {
+                        name: "Bercyclette"
+                        primaryNodeType: "jnt:bigText"
+                        properties: [{ name: "text", language: "en", value: "upperCaseDoc marker" }]
+                    }
+                    {
+                        name: "bercyclette"
+                        primaryNodeType: "jnt:bigText"
+                        properties: [{ name: "text", language: "en", value: "lowerCaseDoc marker" }]
+                    }
+                ]
+            ) {
+                uuid
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
Allow j:nodename to be searched case insensitive for better search results in Media folder.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
