### PR TITLE
feat: add permissions & UI fixes for usages tab in sidebar

### DIFF
--- a/src/javascript/JContent/PublicationStatus/PublicationStatus.jsx
+++ b/src/javascript/JContent/PublicationStatus/PublicationStatus.jsx
@@ -1,43 +1,60 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Typography} from '@jahia/moonstone';
+import {Tooltip} from '@material-ui/core';
 import {publicationStatusByName} from './publicationStatusRenderer';
 import {useTranslation} from 'react-i18next';
 import classNames from 'clsx';
 import styles from './PublicationStatus.scss';
 
-export const PublicationStatus = ({node, className, style}) => {
+export const PublicationStatus = ({node, className, style, isCompact}) => {
     const {t, i18n} = useTranslation('jcontent');
     const publicationStatus = publicationStatusByName.getStatus(node);
     const publicationStatusClass = publicationStatus.getContentClass(styles);
     const publicationStatusBodyClass = publicationStatus.getBodyClass(styles);
-    if (node.operationsSupport.publication) {
+    if (!node.operationsSupport.publication) {
+        return false;
+    }
+
+    // Compact variant for narrow layouts: only the colored bar, the details
+    // move from the hover-expanding panel to a tooltip
+    if (isCompact) {
         return (
             <div className={classNames(styles.root, className)} style={style || {}}>
-                <div className={classNames(styles.border, publicationStatusClass)}/>
-                <div className={classNames(styles.publicationInfoWrapper, publicationStatusBodyClass)}>
-                    <div className={styles.publicationInfo}
+                <Tooltip title={<Typography variant="caption">{publicationStatus.geti18nDetailsMessage(node, t, i18n.language)}</Typography>}>
+                    <div className={classNames(styles.border, publicationStatusClass)}
                          data-cm-role="publication-info"
                          data-cm-value={node.aggregatedPublicationInfo.publicationStatus}
-                    >
-                        {publicationStatus.getIcon({className: styles.spacing, size: 'default'})}
-
-                        <Typography variant="caption" className={styles.spacing}>
-                            {publicationStatus.geti18nDetailsMessage(node, t, i18n.language)}
-                        </Typography>
-                    </div>
-                </div>
+                    />
+                </Tooltip>
             </div>
         );
     }
 
-    return false;
+    return (
+        <div className={classNames(styles.root, className)} style={style || {}}>
+            <div className={classNames(styles.border, publicationStatusClass)}/>
+            <div className={classNames(styles.publicationInfoWrapper, publicationStatusBodyClass)}>
+                <div className={styles.publicationInfo}
+                     data-cm-role="publication-info"
+                     data-cm-value={node.aggregatedPublicationInfo.publicationStatus}
+                >
+                    {publicationStatus.getIcon({className: styles.spacing, size: 'default'})}
+
+                    <Typography variant="caption" className={styles.spacing}>
+                        {publicationStatus.geti18nDetailsMessage(node, t, i18n.language)}
+                    </Typography>
+                </div>
+            </div>
+        </div>
+    );
 };
 
 PublicationStatus.propTypes = {
     node: PropTypes.object.isRequired,
     style: PropTypes.any,
-    className: PropTypes.string
+    className: PropTypes.string,
+    isCompact: PropTypes.bool
 };
 
 export default PublicationStatus;

--- a/src/javascript/JContent/SidePanel/ContentUsages/ContentUsages.jsx
+++ b/src/javascript/JContent/SidePanel/ContentUsages/ContentUsages.jsx
@@ -1,10 +1,13 @@
 import React, {useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Chip, DataTable, Typography, Warning} from '@jahia/moonstone';
+import {DisplayAction} from '@jahia/ui-extender';
 import {useSidePanelContext} from '~/JContent/SidePanel';
 import {useUsages} from '~/UsagesTable/useUsages';
 import {LoaderOverlay} from '~/ContentEditor/DesignSystem/LoaderOverlay';
 import {NodeIcon} from '~/utils';
+import {ButtonRendererNoLabel} from '~/utils/getButtonRenderer';
+import PublicationStatus from '~/JContent/PublicationStatus';
 import styles from './ContentUsages.scss';
 
 const MAX_BADGES = 2;
@@ -62,6 +65,13 @@ export const ContentUsages = () => {
 
     const columns = [
         {
+            key: 'status',
+            label: '',
+            width: '16px',
+            cellProps: {className: styles.statusCellTd},
+            render: ({data}) => <PublicationStatus isCompact node={data} className={styles.statusBar}/>
+        },
+        {
             key: 'displayName',
             label: t('jcontent:label.contentManager.listColumns.name'),
             isSortable: true,
@@ -80,6 +90,19 @@ export const ContentUsages = () => {
             label: t('jcontent:label.contentEditor.sidePanel.language'),
             width: '120px',
             render: ({data}) => localeChips(data.locales, t)
+        },
+        {
+            key: 'actions',
+            label: '',
+            width: '48px',
+            render: ({data}) => (
+                <div onClick={e => e.stopPropagation()}>
+                    <DisplayAction actionKey="contentItemActionsMenu"
+                                   path={data.path}
+                                   render={ButtonRendererNoLabel}
+                                   buttonProps={{variant: 'ghost', size: 'default'}}/>
+                </div>
+            )
         }
     ];
 

--- a/src/javascript/JContent/SidePanel/ContentUsages/ContentUsages.scss
+++ b/src/javascript/JContent/SidePanel/ContentUsages/ContentUsages.scss
@@ -13,6 +13,22 @@
     margin-bottom: var(--spacing-medium);
 }
 
+/* The publication status bar is absolutely positioned against the cell and
+   must be allowed to span the full row height */
+td.statusCellTd {
+    position: relative;
+
+    padding: 0;
+    overflow: visible;
+}
+
+.statusBar {
+    top: 0;
+    left: 0;
+
+    height: 100%;
+}
+
 .nameCell {
     display: flex;
     gap: var(--spacing-small);

--- a/src/javascript/JContent/SidePanel/registerSidePanelTabs.js
+++ b/src/javascript/JContent/SidePanel/registerSidePanelTabs.js
@@ -35,6 +35,8 @@ export const registerSidePanelTabs = actionsRegistry => {
         dataSelRole: 'tab-usages',
         displayableComponent: ContentUsages,
         hideOnNodeTypes: ['jnt:virtualsite'],
+        // Same permission as the usages entry of the former advanced options screen
+        requiredPermission: ['viewUsagesTab'],
         // In Content Editor the tab only makes sense in edit mode: in create mode
         // ctx.path points to the parent node
         isDisplayable: ({isJContent, mode}) => Boolean(isJContent) || mode === Constants.routes.baseEditRoute

--- a/tests/cypress/e2e/contentEditor/shard1/sidePanelUsages.cy.ts
+++ b/tests/cypress/e2e/contentEditor/shard1/sidePanelUsages.cy.ts
@@ -1,5 +1,5 @@
 import {ContentEditor, JContent, SidePanel} from '../../../page-object';
-import {addNode} from '@jahia/cypress';
+import {addNode, createUser, deleteUser, grantRoles} from '@jahia/cypress';
 
 describe('Content editor side panel usages tab', () => {
     const ceSidePanel = new SidePanel().inCE();
@@ -53,6 +53,20 @@ describe('Content editor side panel usages tab', () => {
         ceSidePanel.getUsagesRows().should('have.length', 16);
         // The multi-language usage shows overflowing language chips (2 shown + '+1')
         ceSidePanel.getUsagesTable().should('contain.text', '+1');
+
+        // Each row shows the compact publication status bar
+        ceSidePanel.getUsagesRows().first()
+            .find('[data-cm-role="publication-info"]')
+            .should('have.attr', 'data-cm-value');
+
+        // Each row has the standard three-dot content actions menu
+        ceSidePanel.getUsagesRows().first()
+            .find('[data-sel-role="contentItemActionsMenu"]')
+            .click();
+        cy.get('#menuHolder .moonstone-menu:not(.moonstone-hidden)')
+            .should('be.visible')
+            .and('contain.text', 'Edit');
+        cy.get('.moonstone-menu_overlay').click();
     });
 
     it('displays the empty state when the content has no usages', () => {
@@ -63,5 +77,46 @@ describe('Content editor side panel usages tab', () => {
 
         ceSidePanel.switchToUsagesTab();
         ceSidePanel.getByRole('usages-empty').should('contain.text', 'No usages');
+    });
+
+    describe('permission enforcement', () => {
+        const permissionTester = {username: 'usagesPermTester', password: 'Usages_Perm_1!'};
+
+        before(() => {
+            cy.loginAndStoreSession();
+            createUser(permissionTester.username, permissionTester.password);
+            grantRoles('/sites/digitall', ['editor'], permissionTester.username, 'USER');
+        });
+
+        after(() => {
+            cy.loginAndStoreSession();
+            cy.executeGroovy('contentEditor/usages/removeUsagesPermission.groovy');
+            deleteUser(permissionTester.username);
+        });
+
+        const openEmptyTextInAdvancedMode = () => {
+            const jcontent = JContent.visit('digitall', 'en', 'content-folders/contents');
+            jcontent.editComponentByRowName('side-panel-usages-empty-text');
+            new ContentEditor().switchToAdvancedMode();
+        };
+
+        it('hides the Usages tab when the user lacks the viewUsagesTab permission', () => {
+            cy.loginAndStoreSession(permissionTester.username, permissionTester.password);
+            openEmptyTextInAdvancedMode();
+
+            ceSidePanel.getByRole('side-panel').should('be.visible');
+            ceSidePanel.getByRole('tab-details').should('be.visible');
+            ceSidePanel.getByRole('tab-usages').should('not.exist');
+        });
+
+        it('shows the Usages tab once the viewUsagesTab permission is granted', () => {
+            cy.loginAndStoreSession();
+            cy.executeGroovy('contentEditor/usages/addUsagesPermission.groovy');
+
+            cy.loginAndStoreSession(permissionTester.username, permissionTester.password);
+            openEmptyTextInAdvancedMode();
+
+            ceSidePanel.getByRole('tab-usages').should('be.visible');
+        });
     });
 });

--- a/tests/cypress/e2e/jcontent/shard2/sidePanelUsages.cy.ts
+++ b/tests/cypress/e2e/jcontent/shard2/sidePanelUsages.cy.ts
@@ -38,6 +38,20 @@ describe('jContent side panel usages tab', () => {
 
         sidePanel.getUsagesTable().should('be.visible');
         sidePanel.getUsagesRows().should('have.length.at.least', 1);
+
+        // Each row shows the compact publication status bar
+        sidePanel.getUsagesRows().first()
+            .find('[data-cm-role="publication-info"]')
+            .should('have.attr', 'data-cm-value');
+
+        // Each row has the standard three-dot content actions menu
+        sidePanel.getUsagesRows().first()
+            .find('[data-sel-role="contentItemActionsMenu"]')
+            .click();
+        cy.get('#menuHolder .moonstone-menu:not(.moonstone-hidden)')
+            .should('be.visible')
+            .and('contain.text', 'Edit');
+        cy.get('.moonstone-menu_overlay').click();
     });
 
     it('displays the empty state for an item without usages', () => {

--- a/tests/cypress/fixtures/contentEditor/usages/addUsagesPermission.groovy
+++ b/tests/cypress/fixtures/contentEditor/usages/addUsagesPermission.groovy
@@ -1,0 +1,17 @@
+import org.jahia.services.content.JCRTemplate
+import javax.jcr.Node
+
+// Grant the viewUsagesTab permission to the editor role so that non-root
+// test users can access the usages side panel tab.
+JCRTemplate.getInstance().doExecuteWithSystemSession { session ->
+    Node role = session.getNode('/roles/editor')
+    String[] perms = role.hasProperty('j:permissionNames') ?
+        role.getProperty('j:permissionNames').getValues().collect { it.getString() } as String[] :
+        new String[0]
+    if (!perms.contains('viewUsagesTab')) {
+        List<String> updated = new ArrayList<>(perms.toList())
+        updated.add('viewUsagesTab')
+        role.setProperty('j:permissionNames', updated as String[])
+        session.save()
+    }
+}

--- a/tests/cypress/fixtures/contentEditor/usages/removeUsagesPermission.groovy
+++ b/tests/cypress/fixtures/contentEditor/usages/removeUsagesPermission.groovy
@@ -1,0 +1,16 @@
+import org.jahia.services.content.JCRTemplate
+import javax.jcr.Node
+
+// Remove the viewUsagesTab permission from the editor role
+// to restore the default state after tests.
+JCRTemplate.getInstance().doExecuteWithSystemSession { session ->
+    Node role = session.getNode('/roles/editor')
+    if (role.hasProperty('j:permissionNames')) {
+        List<String> perms = role.getProperty('j:permissionNames').getValues().collect { it.getString() }
+        if (perms.contains('viewUsagesTab')) {
+            perms.remove('viewUsagesTab')
+            role.setProperty('j:permissionNames', perms as String[])
+            session.save()
+        }
+    }
+}


### PR DESCRIPTION
### Description
This PR adds the usage permission gate for the usages sidebar and some UI fixes for it.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
