### PR TITLE
fix: keep accordion panel scrollbar visible on hover (#1600)

### DIFF
--- a/.chachalog/1Okubbxl.md
+++ b/.chachalog/1Okubbxl.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Keep accordion panel scrollbar visible on hover in Chrome (#2563)

--- a/src/javascript/JContent/ContentNavigation/ContentNavigation.jsx
+++ b/src/javascript/JContent/ContentNavigation/ContentNavigation.jsx
@@ -4,6 +4,7 @@ import {Accordion, SecondaryNav} from '@jahia/moonstone';
 import {useTranslation} from 'react-i18next';
 import {getRegistryTarget} from '../JContent.utils';
 import JContentConstants from '~/JContent/JContent.constants';
+import styles from './ContentNavigation.scss';
 
 const ContentNavigation = ({accordionItems, accordionItemTarget, mode, siteKey, handleNavigation, header, isReversed}) => {
     const {t} = useTranslation('jcontent');
@@ -30,7 +31,8 @@ const ContentNavigation = ({accordionItems, accordionItemTarget, mode, siteKey, 
     }
 
     return (
-        <SecondaryNav defaultSize={{height: '100%', width: '245px'}}
+        <SecondaryNav className={styles.nav}
+                      defaultSize={{height: '100%', width: '245px'}}
                       header={header}
                       isReversed={isReversed}
         >

--- a/src/javascript/JContent/ContentNavigation/ContentNavigation.scss
+++ b/src/javascript/JContent/ContentNavigation/ContentNavigation.scss
@@ -1,0 +1,24 @@
+.nav {
+    // The Jahia UI shell applies a global custom scrollbar whose thumb switches colour on hover
+    // (`::-webkit-scrollbar-thumb:hover`), which makes the thumb disappear in Chrome on the
+    // accordion panels (issue #1600). Re-declare the scrollbar for these panels and their
+    // scrollable children, keeping the same thumb colour on hover so it stays visible.
+    :global(.moonstone-accordionItem_content),
+    :global(.moonstone-accordionItem_content) * {
+        &::-webkit-scrollbar {
+            width: 0.5em;
+            height: 0.5em;
+        }
+
+        &::-webkit-scrollbar-track,
+        &::-webkit-scrollbar-corner {
+            background: none;
+        }
+
+        &::-webkit-scrollbar-thumb,
+        &::-webkit-scrollbar-thumb:hover {
+            border: 0;
+            background: var(--moon-color-gray);
+        }
+    }
+}


### PR DESCRIPTION

### Description
Keep accordion panel scrollbar visible on hover in Chrome. Previously the scroll bar would disappear on hover but would still be functional. 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
