### PR TITLE
test: cover accordionContentActions export/import entries (#2471)

### DIFF
--- a/src/javascript/JContent.assignActionAndMenuTargets.js
+++ b/src/javascript/JContent.assignActionAndMenuTargets.js
@@ -43,7 +43,7 @@ export const addContextMenuTargetToActions = (targetName, actions) => {
     assignTargetsForActions({[targetName]: actions}, registry);
 };
 
-const actionTargetAssignments = {
+export const actionTargetAssignments = {
     '--contentActions': ['createPage', 'createNavMenuItemMenu', 'contentActionsSeparator1', 'createContent', 'replaceFile', 'locate', 'preview', 'createContentFolder', 'rename', 'edit', 'editPage', 'zip', 'editAdvanced', 'editSource', 'editPageAdvanced', 'unzip', 'openInPageBuilder', 'openInRepositoryExplorer', 'editImage', 'createFolder', 'downloadFile', 'copy', 'copyPageMenu', 'cut', 'paste', 'pasteReference', 'fileUpload', 'publishDeletion', 'delete', 'deletePermanently', 'undelete', 'exportPage', 'export', 'downloadAsZip', 'import', 'lock', 'unlock', 'clearAllLocks', 'publishMenu', 'flushPageCache', 'flushSiteCache', 'contentActionsSeparator2', 'subContents'],
     createMenuActions: [
         'createPage',

--- a/src/javascript/JContent.assignActionAndMenuTargets.test.js
+++ b/src/javascript/JContent.assignActionAndMenuTargets.test.js
@@ -1,0 +1,9 @@
+import {actionTargetAssignments} from './JContent.assignActionAndMenuTargets';
+
+describe('accordionContentActions', () => {
+    it('should include export, exportPage and import', () => {
+        expect(actionTargetAssignments.accordionContentActions).toContain('export');
+        expect(actionTargetAssignments.accordionContentActions).toContain('exportPage');
+        expect(actionTargetAssignments.accordionContentActions).toContain('import');
+    });
+});


### PR DESCRIPTION
### Description
Unit test for the config change in #2553 (fixes #2471): `accordionContentActions` was missing
`export`/`exportPage`/`import`, so Page Builder's accordion tree menu didn't offer them for a
`navMenuText` node. Adds a direct assertion on the array so this can't silently regress.

`actionTargetAssignments` is exported (was module-private) so it's directly testable.

### Checklist
#### Source code
- [x] No breaking change
#### Tests
- [x] Unit test added