### PR TITLE
fix: Update publication status and action checks for jmix:nolive content

### DIFF
--- a/.chachalog/1DQAR8a0.md
+++ b/.chachalog/1DQAR8a0.md
@@ -1,0 +1,5 @@
+---
+"@jahia/jcontent": minor
+---
+
+Fixed an issue that prevented jmix:nolive content from being deleted (#2567)

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderBadges/PublicationInfoBadge.spec.js
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/HeaderBadges/PublicationInfoBadge.spec.js
@@ -37,7 +37,8 @@ jest.mock('~/ContentEditor/contexts/PublicationInfo', () => {
         },
         {
             publicationInfoPolling: false,
-            publicationStatus: 'PUBLISHED'
+            publicationStatus: 'PUBLISHED',
+            existsInLive: true
         },
         {
             publicationInfoPolling: false,
@@ -58,6 +59,11 @@ jest.mock('~/ContentEditor/contexts/PublicationInfo', () => {
         {
             publicationInfoPolling: false,
             publicationStatus: 'UNKNOWN_STATUS'
+        },
+        {
+            publicationInfoPolling: false,
+            publicationStatus: 'PUBLISHED',
+            existsInLive: false
         }
     ];
     return {
@@ -138,6 +144,13 @@ describe('PublicationInfoBadge', () => {
         let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
 
         expect(wrapper.containsMatchingElement(<PublicationStatus type="warning" tooltip="translated_label.contentEditor.publicationStatusTooltip.unknown"/>)).toBeTruthy();
+        expect(wrapper.find('Status')).toHaveLength(1);
+    });
+
+    it('Should display "not published" badge when PUBLISHED but not in live (jmix:nolive)', () => {
+        let wrapper = shallow(<PublicationInfoBadge classes={{}}/>);
+
+        expect(wrapper.containsMatchingElement(<PublicationStatus type="notPublished"/>)).toBeTruthy();
         expect(wrapper.find('Status')).toHaveLength(1);
     });
 });

--- a/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.test.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentStatuses/ContentStatuses.test.jsx
@@ -32,7 +32,8 @@ describe('ContentStatuses', () => {
     it('should only render a \'Published\' status when published', () => {
         const node = {
             aggregatedPublicationInfo: {
-                publicationStatus: 'PUBLISHED'
+                publicationStatus: 'PUBLISHED',
+                existsInLive: true
             }
         };
         const wrapper = shallow(<ContentStatuses {...defaultProps} node={node}/>);
@@ -68,6 +69,19 @@ describe('ContentStatuses', () => {
         expect(wrapper.containsMatchingElement(<Status type="markedForDeletion" tooltip={expectedTooltip}/>)).toBeTruthy();
         expect(wrapper.containsMatchingElement(<Status type="notPublished"/>)).toBeTruthy();
         expect(wrapper.find('Status')).toHaveLength(2);
+    });
+
+    it('should render a \'Not Published\' status when published but not in live (jmix:nolive)', () => {
+        const node = {
+            aggregatedPublicationInfo: {
+                publicationStatus: 'PUBLISHED',
+                existsInLive: false
+            }
+        };
+        const wrapper = shallow(<ContentStatuses {...defaultProps} node={node}/>);
+
+        expect(wrapper.containsMatchingElement(<Status type="notPublished"/>)).toBeTruthy();
+        expect(wrapper.find('Status')).toHaveLength(1);
     });
 
     it('should render a \'Modified\' status when modified', () => {

--- a/src/javascript/JContent/JContent.actions.jsx
+++ b/src/javascript/JContent/JContent.actions.jsx
@@ -129,7 +129,7 @@ export const jContentActions = registry => {
         buttonIcon: <Cloud/>,
         buttonLabel: 'jcontent:label.contentManager.contentPreview.publishMenu',
         menuTarget: 'publishMenu',
-        hideOnNodeTypes: ['jnt:category'],
+        hideOnNodeTypes: ['jnt:category', 'jmix:nolive', 'jmix:autoPublish'],
         isMenuPreload: true
     });
     registry.add('action', 'publish', {

--- a/src/javascript/JContent/PublicationStatus/publicationStatusRenderer.jsx
+++ b/src/javascript/JContent/PublicationStatus/publicationStatusRenderer.jsx
@@ -230,6 +230,14 @@ export const publicationStatusByName = {
             return this.MARKED_FOR_DELETION;
         }
 
-        return this[node.aggregatedPublicationInfo.publicationStatus] || this.UNKNOWN;
+        const pubInfo = node.aggregatedPublicationInfo;
+
+        // 'jmix:nolive' case where status is PUBLISHED but the node does not exist in live
+        if (pubInfo.publicationStatus === 'PUBLISHED' &&
+            !pubInfo.existsInLive) {
+            return this.NOT_PUBLISHED;
+        }
+
+        return this[pubInfo.publicationStatus] || this.UNKNOWN;
     }
 };

--- a/src/javascript/JContent/actions/deleteActions/deletePermanentlyAction.jsx
+++ b/src/javascript/JContent/actions/deleteActions/deletePermanentlyAction.jsx
@@ -15,9 +15,7 @@ const checkActionOnNodes = res => {
 const checkAction = node => {
     const isCategory = (node['jnt:category'] || node.primaryNodeType?.name === 'jnt:category');
     const isMarkForDeletionAllowed = node.operationsSupport.markForDeletion &&
-        isMarkedForDeletion(node) &&
-        node.aggregatedPublicationInfo.publicationStatus === 'NOT_PUBLISHED' &&
-        (node.aggregatedPublicationInfo.existsInLive === undefined ? true : !node.aggregatedPublicationInfo.existsInLive);
+        isMarkedForDeletion(node) && !node.aggregatedPublicationInfo.existsInLive;
     const isAutoPublish = node['jmix:autoPublish'];
     return Boolean(isCategory || isMarkForDeletionAllowed || isAutoPublish);
 };

--- a/src/javascript/JContent/actions/publishAction.jsx
+++ b/src/javascript/JContent/actions/publishAction.jsx
@@ -73,14 +73,14 @@ function getButtonLabelParams(paths, language, res, t) {
 
 const constraintsByType = {
     publish: {
-        hideOnNodeTypes: ['jnt:virtualsite', 'jnt:contentFolder', 'nt:folder', 'jmix:autoPublish']
+        hideOnNodeTypes: ['jnt:virtualsite', 'jnt:contentFolder', 'nt:folder', 'jmix:autoPublish', 'jmix:nolive']
     },
     publishAll: {
         showOnNodeTypes: ['jnt:folder', 'jnt:contentFolder', 'jnt:page', 'jnt:navMenuText'],
-        hideOnNodeTypes: ['jmix:autoPublish']
+        hideOnNodeTypes: ['jmix:autoPublish', 'jmix:nolive']
     },
     unpublish: {
-        hideOnNodeTypes: ['jnt:virtualsite', 'jmix:autoPublish']
+        hideOnNodeTypes: ['jnt:virtualsite', 'jmix:autoPublish', 'jmix:nolive']
     }
 };
 

--- a/src/javascript/JContent/actions/publishDeletionAction.jsx
+++ b/src/javascript/JContent/actions/publishDeletionAction.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {useNodeChecks} from '@jahia/data-helper';
 import PropTypes from 'prop-types';
-import {isMarkedForDeletion} from '../JContent.utils';
+import {hasMixin, isMarkedForDeletion} from '../JContent.utils';
 import {useSelector} from 'react-redux';
 
 const checkActionOnNodes = res => {
@@ -9,15 +9,12 @@ const checkActionOnNodes = res => {
 };
 
 const checkAction = node => node.operationsSupport.publication &&
-    isMarkedForDeletion(node) &&
-    (node.aggregatedPublicationInfo.publicationStatus !== 'NOT_PUBLISHED' ||
-        (node.aggregatedPublicationInfo.publicationStatus === 'NOT_PUBLISHED' &&
-            (node.aggregatedPublicationInfo.existsInLive === undefined ? false : node.aggregatedPublicationInfo.existsInLive)));
+    isMarkedForDeletion(node) && (node.aggregatedPublicationInfo.publicationStatus !== 'NOT_PUBLISHED' || node.aggregatedPublicationInfo.existsInLive);
 
 export const PublishDeletionActionComponent = ({path, paths, node: prefetchedNode, isAllSubTree, isPublishingAllLanguages, buttonProps, render: Render, loading: Loading, ...others}) => {
     const language = useSelector(state => state.language);
 
-    const skip = !paths && Boolean(prefetchedNode) && !isMarkedForDeletion(prefetchedNode);
+    const skip = !paths && Boolean(prefetchedNode) && (!isMarkedForDeletion(prefetchedNode) || hasMixin(prefetchedNode, 'jmix:nolive'));
 
     const res = useNodeChecks({path, paths, language}, {
         skip,
@@ -25,7 +22,7 @@ export const PublishDeletionActionComponent = ({path, paths, node: prefetchedNod
         getAggregatedPublicationInfo: true,
         getOperationSupport: true,
         requiredPermission: ['publish'],
-        hideOnNodeTypes: ['jnt:virtualsite']
+        hideOnNodeTypes: ['jnt:virtualsite', 'jmix:nolive']
     }, {
         fetchPolicy: 'network-only'
     });
@@ -38,7 +35,7 @@ export const PublishDeletionActionComponent = ({path, paths, node: prefetchedNod
         return false;
     }
 
-    let isVisible = res.node ? checkAction(res.node) : checkActionOnNodes(res);
+    let isVisible = res.checksResult && (res.node ? checkAction(res.node) : checkActionOnNodes(res));
 
     return (
         <Render

--- a/src/javascript/JContent/actions/showPublicationManagerAction.jsx
+++ b/src/javascript/JContent/actions/showPublicationManagerAction.jsx
@@ -24,7 +24,7 @@ export const PublishManagerActionComponent = props => {
         getProperties: ['jcr:mixinTypes'],
         getSiteLanguages: true,
         getPermissions: ['publish', 'publication-start'],
-        hideOnNodeTypes: ['jnt:category', 'jmix:markedForDeletion']
+        hideOnNodeTypes: ['jnt:category', 'jmix:markedForDeletion', 'jmix:nolive', 'jmix:autoPublish']
     });
 
     if (res.loading) {

--- a/src/javascript/utils/contentStatus.js
+++ b/src/javascript/utils/contentStatus.js
@@ -18,16 +18,15 @@ export function setPublicationStatus(statuses, publicationStatus, existsInLive) 
             statuses.modified = true;
             statuses.published = true;
             break;
-        case PUBLISHED:
-            statuses.published = true;
-            break;
         case NOT_PUBLISHED:
         case UNPUBLISHED:
             statuses.published = false;
             break;
+        case PUBLISHED:
         case MARKED_FOR_DELETION:
-            // We look at existsInLive property to determine if the content is published or not
+            // For MARKED_FOR_DELETION, we look at existsInLive property to determine if the content is published or not
             // since publicationStatus is masked by the MARKED_FOR_DELETION status when content is published
+            // For PUBLISHED, we handle jmix:nolive case where status is PUBLISHED but content is not in live
             statuses.published = existsInLive;
             break;
         default:

--- a/tests/cypress/e2e/menuActions/deleteAdvanced.cy.ts
+++ b/tests/cypress/e2e/menuActions/deleteAdvanced.cy.ts
@@ -172,6 +172,38 @@ describe('delete tests', () => {
         contextMenu.shouldHaveItem('Delete (permanently)');
     });
 
+    it('allows to mark nolive node for deletion and delete permanently', () => {
+        const nodePath = `/sites/${siteKey}/contents/test-deleteContents/test-delete-nolive`;
+
+        cy.log('Verify nolive node exists before starting test');
+        cy.apollo({
+            query: gql`query { jcr { nodeByPath(path: "${nodePath}") {uuid}}}`
+        }).should(resp => {
+            expect(resp?.data.jcr.nodeByPath).not.to.be.null;
+        });
+
+        const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents/test-deleteContents');
+
+        cy.log('Check publication status shows not published before marking for deletion');
+        jcontent.getTable().getRowByName('test-delete-nolive').click();
+        jcontent.assertStatusType('notPublished');
+
+        cy.log('Mark node for deletion');
+        jcontent.getTable().getRowByName('test-delete-nolive').markForDeletion();
+
+        cy.log('Delete node permanently');
+        jcontent.getTable().getRowByName('test-delete-nolive').contextMenu().select('Delete (permanently)');
+        getComponent(DeletePermanentlyDialog).delete();
+
+        cy.log('Verify nolive node is deleted');
+        cy.apollo({
+            query: gql`query { jcr { nodeByPath(path: "${nodePath}") {uuid}}}`,
+            errorPolicy: 'ignore'
+        }).should(resp => {
+            expect(resp?.data.jcr.nodeByPath).to.be.null;
+        });
+    });
+
     it('Does not show delete action on locked nodes', () => {
         cy.apollo({mutation: gql`mutation lockNode {
                 jcr {

--- a/tests/cypress/fixtures/jcontent/menuActions/createDeleteContent.graphql
+++ b/tests/cypress/fixtures/jcontent/menuActions/createDeleteContent.graphql
@@ -56,6 +56,10 @@ mutation createDeleteContent {
                             primaryNodeType: "jnt:bigText"
                             properties: [{ name: "text", language: "en", value: "test 6" }]
                         }
+                        {
+                            name: "test-delete-nolive"
+                            primaryNodeType: "cent:testNoLiveNode"
+                        }
                     ]
                 ) {
                     uuid

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -32,6 +32,8 @@
 
 [cent:testTextField] > jnt:content, mix:title, jmix:basicContent, jmix:editorialContent, jmix:autoPublish
 
+[cent:testNoLiveNode] > jnt:content, jmix:basicContent, jmix:nolive
+
 [cent:defaultValueTest] > jnt:content, jmix:basicContent, jmix:editorialContent, mix:title noquery
  - defaultString (string) = 'Default string'
  - defaultI18nString (string) = 'Default i18n string' internationalized


### PR DESCRIPTION
### Description

Update publication and deletion action guard checks specifically for `jmix:nolive` content type. 

For legacy reasons, `jmix:nolive` has a unique property where publication info returns as PUBLISHED but does not exist in live. This needs to be taken into consideration in the checks for publication status.

Root cause: JCRPublicationService.getPublicationInfo() sets status=PUBLISHED for jmix:nolive nodes so they are treated as "already in sync" with live. Changing that value would break internal tree-traversal comparisons
(getTreeStatus, checkDescendantNodesAndReferences, needPublication, etc.) that rely on PUBLISHED=1 semantics.

 - allow delete permanently action 
 - hide publish actions and publish menu for 'jmix:nolive'

**Misc** 
 - also fix some publish action checks for 'jmix:autopublish'

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
