### PR TITLE
fix: ensure visibility purge job correctly stops/restarts on Tomcat restart

### DIFF
--- a/.chachalog/c_z2KIwZ.md
+++ b/.chachalog/c_z2KIwZ.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": patch
+---
+
+Ensure visibility purge job correctly stops/restarts on Tomcat restart (#2568)

--- a/src/main/java/org/jahia/modules/visibility/job/VisibilityActionPurgeJob.java
+++ b/src/main/java/org/jahia/modules/visibility/job/VisibilityActionPurgeJob.java
@@ -1,70 +1,21 @@
 package org.jahia.modules.visibility.job;
 
-import org.jahia.exceptions.JahiaRuntimeException;
 import org.jahia.services.content.rules.OrphanedActionPurgeJob;
-import org.jahia.services.scheduler.BackgroundJob;
-import org.jahia.services.scheduler.SchedulerService;
-import org.jahia.settings.SettingsBean;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
-import org.quartz.*;
+import org.quartz.JobDataMap;
 
-import java.text.ParseException;
 import java.util.Set;
 
 /**
  * Background task that purges orphaned visibility actions (in case the corresponding node was deleted).
+ * <p>
+ * <b>NB:</b> This job is instantiated directly by Quartz, so OSGi dependency injection is not available here.
+ * Its scheduling (and unscheduling) is handled by the OSGi component {@link VisibilityActionPurgeJobRegistration}.
  *
  * @author Sergiy Shyrkov
  * @author Jerome Blanchard
+ * @see VisibilityActionPurgeJobRegistration
  */
-@Component(immediate = true)
 public class VisibilityActionPurgeJob extends OrphanedActionPurgeJob {
-
-    private static final String JOB_DESCRIPTION = "Cancels (unschedules) and removes orphaned visibility action jobs in case the corresponding node is no longer present";
-    private static final String JOB_GROUP = "Maintenance";
-    private static final String CRON_TRIGGER_NAME = "VisibilityActionPurgeJobTrigger";
-    private static final String CRON_EXPRESSION = "0 5 * * * ?";
-    private static final String JOB_GROUP_NAMES_KEY = "jobGroupNames";
-    private static final Set<String> JOB_GROUP_NAMES = Set.of("ActionJob.startDateVisibilityAction", "ActionJob.endDateVisibilityAction",
-                    "ActionJob.startDayOfWeekVisibilityAction", "ActionJob.endDayOfWeekVisibilityAction",
-                    "ActionJob.startTimeOfDayVisibilityAction", "ActionJob.endTimeOfDayVisibilityAction");
-
-    private SchedulerService schedulerService;
-    private JobDetail jobDetail;
-
-    @Activate
-    public void start() {
-        jobDetail = BackgroundJob.createJahiaJob(JOB_DESCRIPTION, VisibilityActionPurgeJob.class);
-        jobDetail.setGroup(JOB_GROUP);
-        jobDetail.getJobDataMap().put(JOB_GROUP_NAMES_KEY, JOB_GROUP_NAMES);
-        try {
-            if (schedulerService.getAllJobs(jobDetail.getGroup()).isEmpty() && SettingsBean.getInstance().isProcessingServer()) {
-                Trigger trigger = new CronTrigger(CRON_TRIGGER_NAME, jobDetail.getGroup(), CRON_EXPRESSION);
-                schedulerService.getScheduler().scheduleJob(jobDetail, trigger);
-            }
-        } catch (SchedulerException | ParseException e) {
-            throw new JahiaRuntimeException(e);
-        }
-    }
-
-    @Deactivate
-    public void stop() {
-        try {
-            if (!schedulerService.getAllJobs(jobDetail.getGroup()).isEmpty() && SettingsBean.getInstance().isProcessingServer()) {
-                schedulerService.getScheduler().deleteJob(jobDetail.getName(), jobDetail.getGroup());
-            }
-        } catch (SchedulerException e) {
-            throw new JahiaRuntimeException(e);
-        }
-    }
-
-    @Reference
-    public void setSchedulerService(SchedulerService schedulerService) {
-        this.schedulerService = schedulerService;
-    }
 
     @Override
     protected Set<String> getJobGroupNames(JobDataMap data) {
@@ -75,5 +26,4 @@ public class VisibilityActionPurgeJob extends OrphanedActionPurgeJob {
             return super.getJobGroupNames(data);
         }
     }
-
 }

--- a/src/main/java/org/jahia/modules/visibility/job/VisibilityActionPurgeJobRegistration.java
+++ b/src/main/java/org/jahia/modules/visibility/job/VisibilityActionPurgeJobRegistration.java
@@ -1,0 +1,86 @@
+package org.jahia.modules.visibility.job;
+
+import org.jahia.services.scheduler.SchedulerService;
+import org.jahia.settings.SettingsBean;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.quartz.CronTrigger;
+import org.quartz.JobDetail;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.ParseException;
+import java.util.Set;
+
+/**
+ * Registration of the {@link VisibilityActionPurgeJob} background job via OSGi.
+ * <p>
+ * <b>NB:</b> This component only handles the registration of the job; the execution itself
+ * (in {@link VisibilityActionPurgeJob}) does not have access to OSGi dependency injection.
+ *
+ * @see VisibilityActionPurgeJob
+ */
+@Component(immediate = true)
+public class VisibilityActionPurgeJobRegistration {
+
+    private static final Logger logger = LoggerFactory.getLogger(VisibilityActionPurgeJobRegistration.class);
+
+    private static final String GROUP_NAME = "Maintenance";
+    private static final String JOB_NAME = "visibilityActionPurgeJob";
+    private static final String JOB_DESCRIPTION = "Cancels (unschedules) and removes orphaned visibility action jobs in case the corresponding node is no longer present";
+    private static final String CRON_TRIGGER_NAME = "VisibilityActionPurgeJobTrigger";
+    private static final String CRON_EXPRESSION = "0 5 * * * ?";
+    private static final String JOB_GROUP_NAMES_KEY = "jobGroupNames";
+    private static final Set<String> JOB_GROUP_NAMES = Set.of("ActionJob.startDateVisibilityAction", "ActionJob.endDateVisibilityAction",
+                    "ActionJob.startDayOfWeekVisibilityAction", "ActionJob.endDayOfWeekVisibilityAction",
+                    "ActionJob.startTimeOfDayVisibilityAction", "ActionJob.endTimeOfDayVisibilityAction");
+
+    private SchedulerService schedulerService;
+    private JobDetail jobDetail;
+
+    @Activate
+    public void start() throws VisibilityJobRegistrationException {
+        // Fixed name -> can be retrieved after restart
+        jobDetail = new JobDetail(JOB_NAME, GROUP_NAME, VisibilityActionPurgeJob.class, false, true, false);
+        jobDetail.setDescription(JOB_DESCRIPTION);
+        jobDetail.getJobDataMap().put(JOB_GROUP_NAMES_KEY, JOB_GROUP_NAMES);
+        if (SettingsBean.getInstance().isProcessingServer()) {
+            try {
+                // Delete the old job at startup if exists
+                schedulerService.getScheduler().deleteJob(JOB_NAME, GROUP_NAME);
+                Trigger trigger = new CronTrigger(CRON_TRIGGER_NAME, jobDetail.getGroup(), CRON_EXPRESSION);
+                schedulerService.getScheduler().scheduleJob(jobDetail, trigger);
+                logger.info("Visibility action purge {} job registered", jobDetail.getName());
+            } catch (SchedulerException | ParseException e) {
+                throw new VisibilityJobRegistrationException("Unable to register the visibility action purge job", e);
+            }
+        }
+    }
+
+    @Deactivate
+    public void stop() throws VisibilityJobRegistrationException {
+        // If Jahia is shutting down, the scheduler is already stopped -> we do nothing.
+        // The job will be cleaned at the next startup. It could be found with the fixed name
+        if (schedulerService.getScheduler() == null) {
+            return;
+        }
+        try {
+            if (!schedulerService.getAllJobs(jobDetail.getGroup()).isEmpty() && SettingsBean.getInstance().isProcessingServer()) {
+                schedulerService.getScheduler().deleteJob(jobDetail.getName(), jobDetail.getGroup());
+                logger.info("Visibility action purge {} job unregistered", jobDetail.getName());
+            }
+        } catch (SchedulerException e) {
+            throw new VisibilityJobRegistrationException("Unable to unregister the visibility action purge job", e);
+        }
+    }
+
+    @Reference
+    public void setSchedulerService(SchedulerService schedulerService) {
+        this.schedulerService = schedulerService;
+    }
+
+}

--- a/src/main/java/org/jahia/modules/visibility/job/VisibilityJobRegistrationException.java
+++ b/src/main/java/org/jahia/modules/visibility/job/VisibilityJobRegistrationException.java
@@ -1,0 +1,14 @@
+package org.jahia.modules.visibility.job;
+
+/**
+ * Thrown when the {@link VisibilityActionPurgeJob} background job cannot be
+ * registered or unregistered from the scheduler.
+ *
+ * @see VisibilityActionPurgeJobRegistration
+ */
+public class VisibilityJobRegistrationException extends Exception {
+
+    public VisibilityJobRegistrationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
## Context

Ensures the visibility purge job behaves correctly across Tomcat restarts.

Relates to Jahia/jahia-private#4978

## Changes

- **`VisibilityActionPurgeJob`** — stripped of all OSGi/scheduling logic. It is now a plain Quartz job (instantiated directly by Quartz, no OSGi injection), keeping only the `getJobGroupNames` execution logic.
- **`VisibilityActionPurgeJobRegistration`** (new) — dedicated OSGi `@Component` handling registration/unregistration:
  - Registers the job with a **fixed name** (`visibilityActionPurgeJob`) so it can be retrieved after a restart.
  - **Deletes the stale job at startup** before rescheduling, avoiding duplicate/orphaned jobs.
  - On deactivation, **skips unscheduling when the scheduler is already stopped** (Jahia shutting down) — cleanup then happens at next startup via the fixed name.
- **`VisibilityJobRegistrationException`** (new) — dedicated checked exception replacing the previous `JahiaRuntimeException` usage.
