### PR TITLE
fix: apply textarea height from the field definition (#2437)

### DIFF
--- a/.chachalog/A-boJwxx.md
+++ b/.chachalog/A-boJwxx.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": patch
+---
+
+Apply the height set in a textarea field definition (textarea[height='...']) instead of ignoring it (#2437)

--- a/.chachalog/A-boJwxx.md
+++ b/.chachalog/A-boJwxx.md
@@ -1,6 +1,6 @@
 ---
 # Allowed version bumps: patch, minor, major
-"@jahia/jcontent": patch
+"@jahia/jcontent": minor
 ---
 
 Apply the height set in a textarea field definition (textarea[height='...']) instead of ignoring it (#2437)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ The repo extends `@jahia/eslint-config` (`.eslintrc.json`). Key rules to always 
 - **Strict equality only**: use `===` and `!==`. **Never** use `==` or `!=`, even when comparing to `null`/`undefined`.
   - To check "null or undefined", prefer `value == null` is **NOT allowed** — instead use `value === null || value === undefined`, or simply `!value` when truthy/falsy semantics are acceptable.
 - **Prefer optional chaining** over negation guards for null/undefined property access. Use `obj?.prop` instead of `!obj || obj.prop` patterns.
+- **Prefer the `Number` static methods** over the global functions: always use `Number.parseInt`, `Number.parseFloat`, `Number.isNaN`, `Number.isFinite` instead of the globals `parseInt`, `parseFloat`, `isNaN`, `isFinite` (flagged by SonarQube).
 - 4-space indentation. No tabs.
 - Single quotes for strings. Backticks only for template literals.
 - Always include semicolons.

--- a/src/javascript/ContentEditor/SelectorTypes/TextAreaField/TextAreaField.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/TextAreaField/TextAreaField.jsx
@@ -4,9 +4,15 @@ import {TextArea} from '~/ContentEditor/DesignSystem/TextArea';
 import {FieldPropTypes} from '~/ContentEditor/ContentEditor.proptypes';
 
 export const TextAreaField = ({id, value, field, onChange, onBlur}) => {
+    // The `height` selector option (e.g. textarea[height='220']) sets the textarea height in px.
+    // When it is absent or not a number, no height is set and the textarea keeps its natural size.
+    const heightOption = parseInt(field.selectorOptions?.find(option => option.name === 'height')?.value, 10);
+    const style = Number.isNaN(heightOption) ? undefined : {height: heightOption, maxHeight: heightOption};
+
     return (
         <TextArea id={id}
                   name={id}
+                  style={style}
                   aria-labelledby={`${field.name}-label`}
                   value={value || ''}
                   readOnly={field.readOnly}

--- a/src/javascript/ContentEditor/SelectorTypes/TextAreaField/TextAreaField.jsx
+++ b/src/javascript/ContentEditor/SelectorTypes/TextAreaField/TextAreaField.jsx
@@ -6,7 +6,7 @@ import {FieldPropTypes} from '~/ContentEditor/ContentEditor.proptypes';
 export const TextAreaField = ({id, value, field, onChange, onBlur}) => {
     // The `height` selector option (e.g. textarea[height='220']) sets the textarea height in px.
     // When it is absent or not a number, no height is set and the textarea keeps its natural size.
-    const heightOption = parseInt(field.selectorOptions?.find(option => option.name === 'height')?.value, 10);
+    const heightOption = Number.parseInt(field.selectorOptions?.find(option => option.name === 'height')?.value, 10);
     const style = Number.isNaN(heightOption) ? undefined : {height: heightOption, maxHeight: heightOption};
 
     return (

--- a/src/javascript/ContentEditor/SelectorTypes/TextAreaField/TextAreaField.spec.js
+++ b/src/javascript/ContentEditor/SelectorTypes/TextAreaField/TextAreaField.spec.js
@@ -49,4 +49,21 @@ describe('TextArea component', () => {
         expect(props.onChange.mock.calls.length).toBe(1);
         expect(props.onChange).toHaveBeenCalledWith('text');
     });
+
+    it('should not set any height style when no height option is set', () => {
+        const cmp = shallow(<TextAreaField {...props}/>);
+        expect(cmp.props().style).toBeUndefined();
+    });
+
+    it('should apply the height selector option to height and maxHeight', () => {
+        props.field.selectorOptions = [{name: 'height', value: '220'}];
+        const cmp = shallow(<TextAreaField {...props}/>);
+        expect(cmp.props().style).toEqual({height: 220, maxHeight: 220});
+    });
+
+    it('should not set any height style for a non-numeric height option', () => {
+        props.field.selectorOptions = [{name: 'height', value: 'not-a-number'}];
+        const cmp = shallow(<TextAreaField {...props}/>);
+        expect(cmp.props().style).toBeUndefined();
+    });
 });

--- a/tests/cypress/e2e/selectorTypes/textArea.cy.ts
+++ b/tests/cypress/e2e/selectorTypes/textArea.cy.ts
@@ -1,0 +1,30 @@
+import {createSite, deleteSite, enableModule} from '@jahia/cypress';
+import {JContent} from '../../page-object';
+import {Field} from '../../page-object/fields';
+
+describe('TextArea field', () => {
+    const siteKey = 'textAreaSite';
+
+    before(() => {
+        createSite(siteKey);
+        enableModule('jcontent-test-module', siteKey);
+    });
+
+    after(() => {
+        deleteSite(siteKey);
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession();
+    });
+
+    // Definition of cent:textArea: area1 (string, textarea[height='220'])
+    it('should apply the height selector option to the textarea', () => {
+        const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+        const contentEditor = jcontent.createContent('cent:textArea');
+        const field = contentEditor.getField(Field, 'cent:textArea_area1', false);
+
+        // The definition value (220) must reach the rendered textarea
+        field.get().find('textarea').should('have.css', 'max-height', '220px');
+    });
+});

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -271,6 +271,9 @@
  + * (cent:childObject1)
  + * (cent:childObject2)
 
+[cent:textArea] > jnt:content, jmix:basicContent, jmix:editorialContent
+  - area1 (string, textarea[height='220'])
+
 [cent:oneMultipleWithLimitTwo] > jnt:content, jmix:basicContent, jmix:editorialContent
  - someProperty (string)
  + * (cent:childObject1)


### PR DESCRIPTION
### Description
Allow to set textarea height if it is available in selectorOptions. The height will be set as max height and it will not be possible to make it larger with UI.
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
