### PR TITLE
fix: use correct language for all CE labels

### DIFF
--- a/.chachalog/dT-AQRam.md
+++ b/.chachalog/dT-AQRam.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": patch
+---
+
+Fixed choicelists to use labels in UI language instead of content language.

--- a/src/javascript/ContentEditor/SelectorTypes/registerSelectorTypesOnChange.js
+++ b/src/javascript/ContentEditor/SelectorTypes/registerSelectorTypesOnChange.js
@@ -77,7 +77,7 @@ export const registerSelectorTypesOnChange = registry => {
                             nodeType: dependentPropertiesField.nodeType,
                             fieldName: dependentPropertiesField.propertyName,
                             context: context,
-                            uilang: onChangeContext.lang,
+                            uilang: onChangeContext.uilang || onChangeContext.lang,
                             language: onChangeContext.lang
                         }
                     }).then(({data}) => ({

--- a/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.jsx
+++ b/src/javascript/ContentEditor/contexts/ContentEditor/ContentEditor.context.jsx
@@ -106,6 +106,7 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
         return {
             path: nodeData.path,
             lang,
+            uilang: uiLanguage,
             browserLang,
             site,
             mode,
@@ -141,6 +142,7 @@ export const ContentEditorContextProvider = ({useFormDefinition, overrides, chil
         ranAllHooks,
         nodeData,
         lang,
+        uiLanguage,
         browserLang,
         site,
         mode,

--- a/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
+++ b/src/main/java/org/jahia/modules/contenteditor/api/forms/EditorFormServiceImpl.java
@@ -220,7 +220,7 @@ public class EditorFormServiceImpl implements EditorFormService {
                             field.setSelectorOptionsMap(replaceBySubstitutor(field.getSelectorOptionsMap()));
                         }
 
-                        field.setValueConstraints(getValueConstraints(primaryNodeType, field, existingNode, parentNode, locale, new HashMap<>()));
+                        field.setValueConstraints(getValueConstraints(primaryNodeType, field, existingNode, parentNode, uiLocale, new HashMap<>()));
                     }
                     fieldSet.setFields(fieldSet.getFields().stream()
                         .filter(Field::isVisible)
@@ -314,7 +314,9 @@ public class EditorFormServiceImpl implements EditorFormService {
         return value;
     }
 
-    private List<FieldValueConstraint> getValueConstraints(ExtendedNodeType primaryNodeType, Field editorFormField, JCRNodeWrapper existingNode, JCRNodeWrapper parentNode, Locale locale, Map<String, Object> extendContext) throws RepositoryException {
+    // Takes the UI locale, not the content locale: choicelist display values are editor labels
+    // and must follow the UI language, like all other form labels (see initializeLabel calls).
+    private List<FieldValueConstraint> getValueConstraints(ExtendedNodeType primaryNodeType, Field editorFormField, JCRNodeWrapper existingNode, JCRNodeWrapper parentNode, Locale uiLocale, Map<String, Object> extendContext) throws RepositoryException {
         ExtendedPropertyDefinition propertyDefinition = editorFormField.getExtendedPropertyDefinition();
         // selectorOptionsMap is null when a field has no selector options set (consistent with the
         // null checks in getEditorForm and Field.mergeWith); normalize to an empty map to avoid NPEs.
@@ -332,7 +334,7 @@ public class EditorFormServiceImpl implements EditorFormService {
             List<ChoiceListValue> initialChoiceListValues = new ArrayList<>();
             for (Map.Entry<String, Object> entry : selectorOptions.entrySet()) {
                 if (initializers.containsKey(entry.getKey())) {
-                    initialChoiceListValues = initializers.get(entry.getKey()).getChoiceListValues(propertyDefinition, (String) entry.getValue(), initialChoiceListValues, locale, context);
+                    initialChoiceListValues = initializers.get(entry.getKey()).getChoiceListValues(propertyDefinition, (String) entry.getValue(), initialChoiceListValues, uiLocale, context);
                 }
             }
 
@@ -415,7 +417,7 @@ public class EditorFormServiceImpl implements EditorFormService {
                 .flatMap(fieldSet -> fieldSet.getFields().stream())
                 .filter(field -> (fieldNodeType.equals(field.getDeclaringNodeType()) || primaryNodeType.equals(field.getDeclaringNodeType())) && fieldName.equals(field.getName()))
                 .findFirst()
-                .map(ThrowingFunction.unchecked(field -> getValueConstraints(nodeType, field, node, parentNode, locale, extendContext)))
+                .map(ThrowingFunction.unchecked(field -> getValueConstraints(nodeType, field, node, parentNode, uiLocale, extendContext)))
                 .orElse(Collections.emptyList());
         } catch (RepositoryException e) {
             throw new EditorFormException("Error while building field constraints for" + " node: " + nodeUuidOrPath + ", node type: " + primaryNodeType + ", parent node: " + parentNodeUuidOrPath + ", field node type: " + fieldNodeType + ", field name: " + fieldName, e);

--- a/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/insertionPointsTest.cy.ts
@@ -22,7 +22,7 @@ const assertButtonByRole = (pageBuilder, role: string) => {
 };
 
 const clickButtonByRole = (pageBuilder, role: string) => {
-    pageBuilder.iframe().get().find(`button[data-sel-role="${role}"]`).filter(':visible').click();
+    pageBuilder.iframe().get().find(`button[data-sel-role="${role}"]`).filter(':visible').click({force: true});
 };
 
 /**

--- a/tests/cypress/e2e/selectorTypes/resourceBundleChoicelistLocale.cy.ts
+++ b/tests/cypress/e2e/selectorTypes/resourceBundleChoicelistLocale.cy.ts
@@ -1,0 +1,155 @@
+import gql from 'graphql-tag';
+import {addNode, createSite, createUser, deleteSite, deleteUser, enableModule, grantRoles} from '@jahia/cypress';
+import {JContent} from '../../page-object';
+import {ChoiceListField} from '../../page-object/fields';
+
+interface ValueConstraint {
+    displayValue: string;
+    value: { string: string };
+}
+
+describe('resourceBundle choicelist labels follow the editor UI locale', () => {
+    const siteKey = 'rbChoicelistLocaleSite';
+    const nodeName = 'rbChoicelist';
+    const nodePath = `/sites/${siteKey}/contents/${nodeName}`;
+    const frenchUser = 'rbChoicelistFrUser';
+
+    const frLabels = {'text-start': 'Début', 'text-center': 'Centre', 'text-end': 'Fin'};
+    const enLabels = {'text-start': 'Start', 'text-center': 'Center', 'text-end': 'End'};
+
+    const editFormQuery = gql`
+        query rbChoicelistEditForm($uiLocale: String!, $locale: String!, $path: String!) {
+            forms {
+                editForm(uiLocale: $uiLocale, locale: $locale, uuidOrPath: $path) {
+                    sections {
+                        fieldSets {
+                            fields {
+                                name
+                                valueConstraints {
+                                    displayValue
+                                    value {
+                                        string
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    `;
+
+    const fieldConstraintsQuery = gql`
+        query rbChoicelistFieldConstraints($path: String, $parentPath: String!, $primaryNodeType: String!, $nodeType: String!, $fieldName: String!, $context: [InputContextEntryInput], $uiLocale: String!, $locale: String!) {
+            forms {
+                fieldConstraints(nodeUuidOrPath: $path, parentNodeUuidOrPath: $parentPath, primaryNodeType: $primaryNodeType, fieldNodeType: $nodeType, fieldName: $fieldName, context: $context, uiLocale: $uiLocale, locale: $locale) {
+                    displayValue
+                    value {
+                        string
+                    }
+                }
+            }
+        }
+    `;
+
+    const getConstraints = (resp, fieldName: string): ValueConstraint[] => resp?.data?.forms?.editForm?.sections
+        .flatMap(section => section.fieldSets)
+        .flatMap(fieldSet => fieldSet.fields)
+        .find(field => field.name === fieldName)
+        ?.valueConstraints;
+
+    const assertConstraints = (constraints: ValueConstraint[], expected: Record<string, string>) => {
+        expect(constraints).to.have.length(Object.keys(expected).length);
+        constraints.forEach(constraint => {
+            expect(constraint.displayValue).to.eq(expected[constraint.value.string]);
+        });
+    };
+
+    before(() => {
+        createSite(siteKey);
+        enableModule('jcontent-test-module', siteKey);
+        createUser(frenchUser, 'password', [{name: 'preferredLanguage', value: 'fr'}]);
+        grantRoles(`/sites/${siteKey}`, ['editor'], frenchUser, 'USER');
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: nodeName,
+            primaryNodeType: 'cent:resourceBundleChoicelist'
+        });
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession();
+    });
+
+    after(() => {
+        deleteUser(frenchUser);
+        deleteSite(siteKey);
+        cy.logout();
+    });
+
+    it('editForm resolves choicelist displayValues with the UI locale, not the content locale', () => {
+        cy.apollo({
+            query: editFormQuery,
+            variables: {uiLocale: 'fr', locale: 'en', path: nodePath}
+        }).should(resp => {
+            assertConstraints(getConstraints(resp, 'captionAlignment'), frLabels);
+        });
+
+        cy.apollo({
+            query: editFormQuery,
+            variables: {uiLocale: 'en', locale: 'en', path: nodePath}
+        }).should(resp => {
+            assertConstraints(getConstraints(resp, 'captionAlignment'), enLabels);
+        });
+    });
+
+    it('fieldConstraints resolves refetched displayValues with the UI locale, not the content locale', () => {
+        cy.apollo({
+            query: fieldConstraintsQuery,
+            variables: {
+                path: nodePath,
+                parentPath: `/sites/${siteKey}/contents`,
+                primaryNodeType: 'cent:resourceBundleChoicelist',
+                nodeType: 'cent:resourceBundleChoicelist',
+                fieldName: 'dependentChoice',
+                context: [
+                    {key: 'dependentProperties', value: 'mainChoice'},
+                    {key: 'mainChoice', value: 'a'}
+                ],
+                uiLocale: 'fr',
+                locale: 'en'
+            }
+        }).should(resp => {
+            assertConstraints(resp?.data?.forms?.fieldConstraints, {x: 'Valeur X', y: 'Valeur Y'});
+        });
+    });
+
+    it('shows option labels in the UI language when editing content in another language', () => {
+        cy.login(frenchUser, 'password');
+        const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+        const contentEditor = jcontent.editComponentByRowName(nodeName);
+
+        const field = contentEditor.getField(ChoiceListField, 'cent:resourceBundleChoicelist_captionAlignment');
+        field.get().should('contain.text', 'Alignement');
+        field.shouldHaveOptionLabels(frLabels);
+    });
+
+    it('keeps option labels in the UI language after a dependent choicelist refetch', () => {
+        cy.login(frenchUser, 'password');
+        const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+        const contentEditor = jcontent.editComponentByRowName(nodeName);
+
+        cy.intercept('POST', '**/modules/graphql', req => {
+            if (JSON.stringify(req.body).includes('fieldConstraints')) {
+                req.alias = 'fieldConstraints';
+            }
+        });
+
+        // Changing mainChoice triggers a fieldConstraints refetch of dependentChoice's constraints
+        contentEditor.getField(ChoiceListField, 'cent:resourceBundleChoicelist_mainChoice').selectValue('b');
+        cy.wait('@fieldConstraints');
+
+        contentEditor.getField(ChoiceListField, 'cent:resourceBundleChoicelist_dependentChoice')
+            .shouldHaveOptionLabels({x: 'Valeur X', y: 'Valeur Y'});
+    });
+});

--- a/tests/cypress/page-object/categoryManager.ts
+++ b/tests/cypress/page-object/categoryManager.ts
@@ -36,7 +36,9 @@ export class CategoryManager extends JContent {
 
     createCategoryNav(parentName: string, fields: {title: string, name?: string}) {
         const accordionItem = this.getAccordionItem();
-        accordionItem.getTreeItem(parentName).click();
+        const parentItem = accordionItem.getTreeItem(parentName);
+        parentItem.click();
+        parentItem.shouldBeSelected();
         getComponentByRole(Button, 'jnt:category').click(); // New Category header menu
         this.editFields(fields).create();
         this.getTable().getRowByName(fields.name || fields.title).should('be.visible');

--- a/tests/cypress/page-object/fields/choiceListField.ts
+++ b/tests/cypress/page-object/fields/choiceListField.ts
@@ -89,6 +89,18 @@ export class ChoiceListField extends Field {
     }
 
     /**
+     * Opens the dropdown, asserts that each given option value displays the expected label and closes the dropdown.
+     * @param options Expected displayed label per option value.
+     */
+    shouldHaveOptionLabels(options: Record<string, string>): void {
+        this.openDropdown();
+        Object.entries(options).forEach(([value, label]) => {
+            this.get().find(`.moonstone-menuItem[data-value="${value}"]`).should('have.text', label);
+        });
+        this.closeDropdown();
+    }
+
+    /**
      * Opens the dropdown, asserts that the available values in the choice list match the provided list exactly (order and content) and closes the dropdown.
      * Opens the dropdown to check and closes it after.
      * @param values The exact set of values expected to be available.

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -307,3 +307,11 @@
  extends = jnt:page
  - pageType (string)
 
+
+// resourceBundle choicelist labels must follow the editor UI locale, not the content locale.
+// captionAlignment covers the initial form load; the mainChoice/dependentChoice pair covers the
+// dependentProperties refetch (fieldConstraints), which re-resolves resourceBundle labels server-side.
+[cent:resourceBundleChoicelist] > jnt:content, jmix:basicContent
+ - captionAlignment (string, choicelist[resourceBundle]) = 'text-start' autocreated indexed=no < 'text-start', 'text-center', 'text-end'
+ - mainChoice (string, choicelist[resourceBundle]) = 'a' indexed=no < 'a', 'b'
+ - dependentChoice (string, choicelist[resourceBundle, dependentProperties='mainChoice']) indexed=no < 'x', 'y'

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/resources/jcontent-test-module_en.properties
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/resources/jcontent-test-module_en.properties
@@ -26,3 +26,15 @@ cent_testPropOverridesB.testprop.ui.tooltip = Test Tooltip for Prop Overrides B
 
 validation.constraints.upload.constraint1=This is a validation constraint1 test.
 validation.constraints.upload.constraint2=<script>alert("constraint2");</script> test
+
+cent_resourceBundleChoicelist=Resource bundle choicelist
+cent_resourceBundleChoicelist.captionAlignment=Alignment
+cent_resourceBundleChoicelist.captionAlignment.text-start=Start
+cent_resourceBundleChoicelist.captionAlignment.text-center=Center
+cent_resourceBundleChoicelist.captionAlignment.text-end=End
+cent_resourceBundleChoicelist.mainChoice=Main choice
+cent_resourceBundleChoicelist.mainChoice.a=Option A
+cent_resourceBundleChoicelist.mainChoice.b=Option B
+cent_resourceBundleChoicelist.dependentChoice=Dependent choice
+cent_resourceBundleChoicelist.dependentChoice.x=Value X
+cent_resourceBundleChoicelist.dependentChoice.y=Value Y

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/resources/jcontent-test-module_fr.properties
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/resources/jcontent-test-module_fr.properties
@@ -6,3 +6,15 @@ cent_defaultValueTest.defaultI18nDate=defaultI18nDate
 cent_defaultValueTest.defaultI18nDateAutocreated=defaultI18nDateAutocreated
 cent_defaultValueTest.defaultI18nString=defaultI18nString
 kiss=Bisous
+
+cent_resourceBundleChoicelist=Liste de choix resource bundle
+cent_resourceBundleChoicelist.captionAlignment=Alignement
+cent_resourceBundleChoicelist.captionAlignment.text-start=Début
+cent_resourceBundleChoicelist.captionAlignment.text-center=Centre
+cent_resourceBundleChoicelist.captionAlignment.text-end=Fin
+cent_resourceBundleChoicelist.mainChoice=Choix principal
+cent_resourceBundleChoicelist.mainChoice.a=Choix A
+cent_resourceBundleChoicelist.mainChoice.b=Choix B
+cent_resourceBundleChoicelist.dependentChoice=Choix dépendant
+cent_resourceBundleChoicelist.dependentChoice.x=Valeur X
+cent_resourceBundleChoicelist.dependentChoice.y=Valeur Y

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/resources/jcontent-test-module_fr.properties
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/resources/jcontent-test-module_fr.properties
@@ -9,12 +9,12 @@ kiss=Bisous
 
 cent_resourceBundleChoicelist=Liste de choix resource bundle
 cent_resourceBundleChoicelist.captionAlignment=Alignement
-cent_resourceBundleChoicelist.captionAlignment.text-start=Début
+cent_resourceBundleChoicelist.captionAlignment.text-start=D\u00e9but
 cent_resourceBundleChoicelist.captionAlignment.text-center=Centre
 cent_resourceBundleChoicelist.captionAlignment.text-end=Fin
 cent_resourceBundleChoicelist.mainChoice=Choix principal
 cent_resourceBundleChoicelist.mainChoice.a=Choix A
 cent_resourceBundleChoicelist.mainChoice.b=Choix B
-cent_resourceBundleChoicelist.dependentChoice=Choix dépendant
+cent_resourceBundleChoicelist.dependentChoice=Choix d\u00e9pendant
 cent_resourceBundleChoicelist.dependentChoice.x=Valeur X
 cent_resourceBundleChoicelist.dependentChoice.y=Valeur Y


### PR DESCRIPTION
### Description
This PR fixes CE to use uiLocale for choice lists.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
