### PR TITLE
build: ensure types are correctly published to npmjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "author": "Jahia Core Team <core@jahia.com>",
   "license": "MIT",
   "files": [
-    "types/bundled"
+    "types/bundled/**"
   ],
   "dx-extends": {
     "@jahia/jahia-ui-root": "^0.0.1"


### PR DESCRIPTION
`types` used to work, but `types/bundled` does not, weird but easy to fix (checked with publint, skipping CI and forcing merge)