### PR TITLE
fix(date-formatter): make options optional

### DIFF
--- a/packages/date-formatter/src/index.ts
+++ b/packages/date-formatter/src/index.ts
@@ -33,7 +33,7 @@ const formatMap = {
 
 export function formatDatetime(
   date: Parameters<typeof dayjs>[0],
-  options: {
+  options?: {
     /**
      * The format in which to display the date
      * @default 'short'


### PR DESCRIPTION
Small type fix in `date-formatter`, forcing merge