### PR TITLE
feat: support a badge/count on Content Editor header tabs (#2555)

### DIFF
--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/EditPanelHeader.jsx
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/EditPanelHeader.jsx
@@ -11,6 +11,7 @@ import {EditPanelLanguageSwitcher} from '../EditPanelLanguageSwitcher';
 import {HeaderBadges} from '../HeaderBadges';
 import PropTypes from 'prop-types';
 import {ContentPath} from './ContentPath';
+import {buildTabOption} from './editHeaderTabOptions';
 import {HeaderButtonActions, HeaderThreeDotsActions} from '../HeaderActions';
 import {ContentTypeChip} from '../ContentTypeChip';
 import {useNodeChecks} from '@jahia/data-helper';
@@ -50,12 +51,7 @@ export const EditPanelHeader = ({
     const {openTabs: openEngineTab, confirmationDialog: engineConfirmationDialog} = useOpenEngineTabsWithConfirmation(engineTabIds);
     const hasEngineEntries = res.checksResult && engineTabs.length > 0;
 
-    const tabOptions = tabs.map(tab => ({
-        value: tab.value,
-        label: t(tab.buttonLabel),
-        iconStart: tab.buttonIcon,
-        attributes: {'data-sel-role': tab.dataSelRole}
-    }));
+    const tabOptions = tabs.map(tab => buildTabOption(tab, t));
 
     // The moonstone Dropdown supports either a flat list or groups only, so entries switch
     // to grouped form (with an unlabeled group on top) once the advanced options section shows

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/editHeaderTabOptions.js
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/editHeaderTabOptions.js
@@ -1,0 +1,21 @@
+/**
+ * Builds the moonstone Dropdown option for a Content Editor header tab (a `editHeaderTabsActions`
+ * registry action).
+ *
+ * Besides the usual `buttonLabel` / `buttonIcon`, a tab may contribute an optional **`buttonBadge`** —
+ * a React element rendered after the label as the option's trailing `iconEnd` (e.g. a live per-node
+ * version count on the content-versioning tab, issue #2555). The badge is owned by the contributing
+ * module, which fetches whatever it needs to display; tabs that omit it render exactly as before
+ * (`iconEnd` stays undefined).
+ *
+ * @param {object} tab a resolved header-tab action
+ * @param {function} t the i18n translator (buttonLabel is an i18n key)
+ * @returns {import('@jahia/moonstone').DropdownDataOption}
+ */
+export const buildTabOption = (tab, t) => ({
+    value: tab.value,
+    label: t(tab.buttonLabel),
+    iconStart: tab.buttonIcon,
+    iconEnd: tab.buttonBadge,
+    attributes: {'data-sel-role': tab.dataSelRole}
+});

--- a/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/editHeaderTabOptions.spec.js
+++ b/src/javascript/ContentEditor/ContentEditor/EditPanel/EditPanelHeader/editHeaderTabOptions.spec.js
@@ -1,0 +1,34 @@
+import {buildTabOption} from './editHeaderTabOptions';
+
+describe('buildTabOption', () => {
+    const t = key => `t(${key})`;
+    const baseTab = {
+        value: 'version-history',
+        buttonLabel: 'ns:label.tab.versionHistory',
+        buttonIcon: 'icon-element',
+        dataSelRole: 'tab-version-history'
+    };
+
+    it('maps a tab action to a moonstone Dropdown option', () => {
+        expect(buildTabOption(baseTab, t)).toEqual({
+            value: 'version-history',
+            label: 't(ns:label.tab.versionHistory)',
+            iconStart: 'icon-element',
+            iconEnd: undefined,
+            attributes: {'data-sel-role': 'tab-version-history'}
+        });
+    });
+
+    it('translates the buttonLabel i18n key', () => {
+        expect(buildTabOption(baseTab, t).label).toBe('t(ns:label.tab.versionHistory)');
+    });
+
+    it('surfaces a contributed buttonBadge as the trailing iconEnd', () => {
+        const badge = {$$typeof: Symbol.for('react.element')}; // Stand-in for a React element
+        expect(buildTabOption({...baseTab, buttonBadge: badge}, t).iconEnd).toBe(badge);
+    });
+
+    it('leaves iconEnd undefined when the tab contributes no badge', () => {
+        expect(buildTabOption(baseTab, t).iconEnd).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Closes #2555

### What
Add an optional **`buttonBadge`** field to Content Editor header-tab actions (target `editHeaderTabsActions`). It is a React element rendered after the tab's label as the moonstone Dropdown option's trailing **`iconEnd`**.

### Why
Header-tab actions could only contribute a static i18n `buttonLabel` + icon (`EditPanelHeader.jsx`, `tabs.map(...)`), and `registerDropdownOptions` honours only `buttonLabel`/`buttonIcon`/`value`/`dataSelRole`/`displayableComponent`/`isDisplayable`/`editPanelHeaderProps`. So a module had **no** way to show a dynamic indicator on its tab — e.g. the content-versioning "Version" tab reading the node's version count ([content-versioning#179](https://github.com/Jahia/content-versioning/issues/179), [Figma](https://www.figma.com/design/AENNk51AJJl9748mDTHMNy/Versioning?node-id=4933-13932): "Version" + a count badge).

### How
- New `editHeaderTabOptions.js` — a small pure `buildTabOption(tab, t)` helper that maps a tab action to a Dropdown option and surfaces `tab.buttonBadge` as `iconEnd`. JSDoc documents the `buttonBadge` contract for module authors.
- `EditPanelHeader.jsx` uses the helper (net −4 lines).
- The contributing module owns the badge and its data; tabs that omit `buttonBadge` render exactly as before (`iconEnd` undefined).

### Scope decision
Badge slot only — **no count-based disabling** in jcontent, because the count is async and module-owned (jcontent can't compute it in its synchronous option map). The consumer renders a greyed "0" badge and relies on the version panel's existing empty state; clicking a zero-count tab still works. (The Figma "disabled at 0" look is achieved via the greyed badge + empty state.)

### Verification
- New `editHeaderTabOptions.spec.js` (4 tests: option mapping, i18n label, `buttonBadge` → `iconEnd`, no badge → `iconEnd` undefined).
- Full ContentEditor jest suite green (575 tests); ESLint clean.
- Existing tabs (Edit / Translate) unaffected.

### Follow-up (separate, not in this PR)
Wiring the **content-versioning** tab to supply a live version-count badge is a change in that repo (it already fetches the version list; it can expose a lightweight count) — tracked with content-versioning#179.

---
Closes Jahia/content-versioning#179
