### PR TITLE
feat: side-by-side diff indicator on the compare column (#2556)

### DIFF
--- a/src/javascript/ContentEditor/actions/contenteditor/translate/translateFieldAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/translateFieldAction.jsx
@@ -4,12 +4,19 @@ import {useContentEditorConfigContext, useContentEditorContext} from '~/ContentE
 import {ArrowLeft} from '@jahia/moonstone';
 import styles from './styles.scss';
 
-export const TranslateFieldActionComponent = ({field, value, render: Render}) => {
+export const TranslateFieldActionComponent = ({field, value, hasDiff, render: Render}) => {
     const {sideBySideContext} = useContentEditorConfigContext();
     const {setI18nContext} = useContentEditorContext();
 
-    const {enabled, translateLang, hasWritePermission, lockedAndCannotBeEdited} = sideBySideContext || {};
+    const {enabled, translateLang, hasWritePermission, lockedAndCannotBeEdited, showDiff} = sideBySideContext || {};
     if (!enabled || !field.i18n || !translateLang) {
+        return;
+    }
+
+    // In diff mode (issue #2556) the restore arrow is shown only where the value differs from the
+    // compared node — copying an identical value would be a no-op. Outside diff mode the arrow keeps
+    // showing on every valued field (unchanged Translate-tab behaviour).
+    if (showDiff && !hasDiff) {
         return;
     }
 
@@ -53,6 +60,7 @@ export const TranslateFieldActionComponent = ({field, value, render: Render}) =>
 TranslateFieldActionComponent.propTypes = {
     field: PropTypes.object.isRequired,
     value: PropTypes.any,
+    hasDiff: PropTypes.bool,
     render: PropTypes.func.isRequired
 };
 

--- a/src/javascript/ContentEditor/actions/contenteditor/translate/translateFieldAction.spec.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/translate/translateFieldAction.spec.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import {shallow} from '@jahia/test-framework';
+import {TranslateFieldActionComponent} from './translateFieldAction';
+import {useContentEditorConfigContext, useContentEditorContext} from '~/ContentEditor/contexts';
+
+jest.mock('~/ContentEditor/contexts', () => ({
+    useContentEditorConfigContext: jest.fn(),
+    useContentEditorContext: jest.fn()
+}));
+
+// A no-op stand-in for the button renderer; we only assert whether/how the arrow is rendered.
+const Render = () => null;
+
+describe('TranslateFieldActionComponent', () => {
+    const i18nField = {name: 'nt_prop', i18n: true};
+    let setI18nContext;
+
+    const render = (sideBySideContext, props = {}) => {
+        useContentEditorConfigContext.mockReturnValue({sideBySideContext});
+        useContentEditorContext.mockReturnValue({setI18nContext});
+        return shallow(
+            <TranslateFieldActionComponent field={i18nField} value="source" render={Render} {...props}/>
+        );
+    };
+
+    // Whether the restore arrow is rendered at all.
+    const hasArrow = wrapper => wrapper.find(Render).exists();
+
+    beforeEach(() => {
+        setI18nContext = jest.fn();
+    });
+
+    it('renders no arrow when side-by-side is disabled', () => {
+        expect(hasArrow(render({enabled: false, translateLang: 'en'}))).toBe(false);
+    });
+
+    it('renders no arrow for a non-i18n field', () => {
+        useContentEditorConfigContext.mockReturnValue({sideBySideContext: {enabled: true, translateLang: 'en'}});
+        useContentEditorContext.mockReturnValue({setI18nContext});
+        const wrapper = shallow(
+            <TranslateFieldActionComponent field={{name: 'x', i18n: false}} value="source" render={Render}/>
+        );
+        expect(hasArrow(wrapper)).toBe(false);
+    });
+
+    it('renders no arrow without a translate language', () => {
+        expect(hasArrow(render({enabled: true}))).toBe(false);
+    });
+
+    describe('outside diff mode (translate tab behaviour is unchanged)', () => {
+        const sbs = {enabled: true, translateLang: 'en', hasWritePermission: true};
+
+        it('renders the restore arrow even when hasDiff is false', () => {
+            const wrapper = render(sbs, {hasDiff: false});
+            expect(hasArrow(wrapper)).toBe(true);
+            expect(wrapper.find(Render).props().dataSelRole).toBe('translate-field');
+        });
+
+        it('enables the arrow from value + write permission', () => {
+            expect(render(sbs).find(Render).props().enabled).toBe(true);
+        });
+
+        it('disables the arrow when locked', () => {
+            const wrapper = render({...sbs, lockedAndCannotBeEdited: true});
+            expect(wrapper.find(Render).props().enabled).toBe(false);
+        });
+    });
+
+    describe('in diff mode (showDiff)', () => {
+        const sbs = {enabled: true, translateLang: 'en', hasWritePermission: true, showDiff: true};
+
+        it('renders the arrow only where the field differs', () => {
+            expect(hasArrow(render(sbs, {hasDiff: true}))).toBe(true);
+        });
+
+        it('renders no arrow where the field does not differ', () => {
+            expect(hasArrow(render(sbs, {hasDiff: false}))).toBe(false);
+        });
+    });
+
+    it('copies the value into the i18n context on click', () => {
+        const wrapper = render({enabled: true, translateLang: 'en', hasWritePermission: true});
+        wrapper.find(Render).props().onClick();
+        expect(setI18nContext).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.container.diff.spec.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.container.diff.spec.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import {shallow} from '@jahia/test-framework';
+
+import {FieldContainer} from './Field.container';
+import {registerSelectorTypes} from '~/ContentEditor/SelectorTypes';
+import {registry} from '@jahia/ui-extender';
+import {useFormikContext} from 'formik';
+import {useContentEditorConfigContext} from '~/ContentEditor/contexts';
+
+jest.mock('formik');
+jest.mock('~/ContentEditor/contexts', () => ({
+    ...jest.requireActual('~/ContentEditor/contexts'),
+    useContentEditorConfigContext: jest.fn()
+}));
+jest.mock('~/JContent/ContentRoute/ContentLayout/ContentTable/reactTable', () => ({}));
+jest.mock('~/JContent/ContentRoute/ContentLayout/queryHandlers', () => ({FilesQueryHandler: {}}));
+jest.mock('react-dnd-html5-backend', () => ({getEmptyImage: jest.fn().mockReturnValue({})}));
+
+// Side-by-side diff mode (issue #2556): FieldContainer flags a field whose value differs from the
+// compared node (sideBySideContext.targetNodeData) with a diff bar class and passes `hasDiff` to the
+// translateField action. propertyHasChanged (real) does the comparison.
+describe('FieldContainer side-by-side diff', () => {
+    registerSelectorTypes(registry);
+
+    const field = {
+        name: 'field1',
+        propertyName: 'prop',
+        nodeType: 'nt',
+        requiredType: 'STRING',
+        selectorType: 'Text',
+        i18n: true,
+        selectorOptions: []
+    };
+    // Compared (live) node has 'live' for this property.
+    const targetNodeData = {properties: [{name: 'prop', value: 'live', definition: {declaringNodeType: {name: 'nt'}}}]};
+    const diffContext = {enabled: true, showDiff: true, targetNodeData};
+
+    const renderWith = (sideBySideContext, sourceValue) => {
+        useFormikContext.mockReturnValue({values: {field1: sourceValue}});
+        useContentEditorConfigContext.mockReturnValue({sideBySideContext});
+        return shallow(<FieldContainer field={field}/>);
+    };
+
+    it('marks a differing field with the diff bar and flags the action', () => {
+        const wrapper = renderWith(diffContext, 'source'); // Differs from 'live'
+        expect(wrapper.find('DisplayAction').props().hasDiff).toBe(true);
+        expect(wrapper.find('div').first().props().className).toContain('fieldContainerDiff');
+    });
+
+    it('does not mark a field whose value matches the compared node', () => {
+        const wrapper = renderWith(diffContext, 'live'); // Equal
+        expect(wrapper.find('DisplayAction').props().hasDiff).toBe(false);
+        expect(wrapper.find('div').first().props().className).not.toContain('fieldContainerDiff');
+    });
+
+    it('stays inert when showDiff is off (e.g. the plain translate panel)', () => {
+        const wrapper = renderWith({enabled: true, targetNodeData}, 'source');
+        expect(wrapper.find('DisplayAction').props().hasDiff).toBe(false);
+        expect(wrapper.find('div').first().props().className).not.toContain('fieldContainerDiff');
+    });
+});

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.container.diff.spec.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.container.diff.spec.jsx
@@ -41,21 +41,25 @@ describe('FieldContainer side-by-side diff', () => {
         return shallow(<FieldContainer field={field}/>);
     };
 
-    it('marks a differing field with the diff bar and flags the action', () => {
+    it('marks a differing field with the diff bar, a non-colour title cue and flags the action', () => {
         const wrapper = renderWith(diffContext, 'source'); // Differs from 'live'
         expect(wrapper.find('DisplayAction').props().hasDiff).toBe(true);
         expect(wrapper.find('div').first().props().className).toContain('fieldContainerDiff');
+        // WCAG 1.4.1: the bar (colour) is backed by a title cue on the flagged field.
+        expect(wrapper.find('div').first().props().title).toBe('translated_label.contentEditor.edit.action.translate.fieldDiff');
     });
 
     it('does not mark a field whose value matches the compared node', () => {
         const wrapper = renderWith(diffContext, 'live'); // Equal
         expect(wrapper.find('DisplayAction').props().hasDiff).toBe(false);
         expect(wrapper.find('div').first().props().className).not.toContain('fieldContainerDiff');
+        expect(wrapper.find('div').first().props().title).toBeUndefined();
     });
 
     it('stays inert when showDiff is off (e.g. the plain translate panel)', () => {
         const wrapper = renderWith({enabled: true, targetNodeData}, 'source');
         expect(wrapper.find('DisplayAction').props().hasDiff).toBe(false);
         expect(wrapper.find('div').first().props().className).not.toContain('fieldContainerDiff');
+        expect(wrapper.find('div').first().props().title).toBeUndefined();
     });
 });

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.container.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.container.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import * as PropTypes from 'prop-types';
+import clsx from 'clsx';
 import {FieldPropTypes} from '~/ContentEditor/ContentEditor.proptypes';
 import {resolveSelectorType} from '~/ContentEditor/SelectorTypes/resolveSelectorType';
 import {Field} from './Field';
 import styles from './styles.scss';
 import {DisplayAction} from '@jahia/ui-extender';
-import {ButtonRendererNoLabel} from '~/ContentEditor/utils';
+import {ButtonRendererNoLabel, propertyHasChanged} from '~/ContentEditor/utils';
+import {useContentEditorConfigContext} from '~/ContentEditor/contexts';
 import {useFormikContext} from 'formik';
 
 export const FieldContainer = React.memo(({field, inputContext}) => {
@@ -19,14 +21,24 @@ export const FieldContainer = React.memo(({field, inputContext}) => {
         ...inputContext
     }), [inputContext, selectorType]);
     const {values} = useFormikContext();
+    const {sideBySideContext} = useContentEditorConfigContext();
+
+    // Side-by-side diff mode (opt-in via sideBySideContext.showDiff): flag fields whose value in this
+    // read-only compare column differs from the compared live node (sideBySideContext.targetNodeData),
+    // so the column shows a diff bar and the restore arrow appears only where there is something to
+    // restore. Off in the main edit form and in side-by-side without showDiff -> renders as before.
+    const diffMode = Boolean(sideBySideContext?.enabled && sideBySideContext?.showDiff);
+    const hasDiff = Boolean(diffMode && sideBySideContext.targetNodeData &&
+        propertyHasChanged(values[field.name], field, sideBySideContext.targetNodeData));
 
     return (
-        <div className={styles.fieldContainer}>
+        <div className={clsx(styles.fieldContainer, diffMode && hasDiff && styles.fieldContainerDiff)}>
             {context.displayActions && <DisplayAction
                 actionKey="translateField"
                 render={ButtonRendererNoLabel}
                 field={field}
                 value={values[field.name]}
+                hasDiff={hasDiff}
             />}
             <Field
                 idInput={field.name}

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.container.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.container.jsx
@@ -9,6 +9,7 @@ import {DisplayAction} from '@jahia/ui-extender';
 import {ButtonRendererNoLabel, propertyHasChanged} from '~/ContentEditor/utils';
 import {useContentEditorConfigContext} from '~/ContentEditor/contexts';
 import {useFormikContext} from 'formik';
+import {useTranslation} from 'react-i18next';
 
 export const FieldContainer = React.memo(({field, inputContext}) => {
     const selectorType = resolveSelectorType(field);
@@ -22,6 +23,7 @@ export const FieldContainer = React.memo(({field, inputContext}) => {
     }), [inputContext, selectorType]);
     const {values} = useFormikContext();
     const {sideBySideContext} = useContentEditorConfigContext();
+    const {t} = useTranslation('jcontent');
 
     // Side-by-side diff mode (opt-in via sideBySideContext.showDiff): flag fields whose value in this
     // read-only compare column differs from the compared live node (sideBySideContext.targetNodeData),
@@ -31,8 +33,15 @@ export const FieldContainer = React.memo(({field, inputContext}) => {
     const hasDiff = Boolean(diffMode && sideBySideContext.targetNodeData &&
         propertyHasChanged(values[field.name], field, sideBySideContext.targetNodeData));
 
+    // WCAG 1.4.1: the blue bar alone signals "changed" by colour. Add a non-colour cue (a title/tooltip
+    // surfaced to assistive tech) so the difference is perceivable on fields with no arrow (non-i18n).
+    const diffTitle = (diffMode && hasDiff) ? t('label.contentEditor.edit.action.translate.fieldDiff') : undefined;
+
     return (
-        <div className={clsx(styles.fieldContainer, diffMode && hasDiff && styles.fieldContainerDiff)}>
+        <div
+            className={clsx(styles.fieldContainer, diffMode && hasDiff && styles.fieldContainerDiff)}
+            title={diffTitle}
+        >
             {context.displayActions && <DisplayAction
                 actionKey="translateField"
                 render={ButtonRendererNoLabel}

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/styles.scss
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/styles.scss
@@ -6,3 +6,22 @@
     flex-direction: row;
     align-items: stretch;
 }
+
+// Side-by-side diff mode (issue #2556): a blue vertical bar on the left edge of a field whose value
+// differs from the compared node, marking what changed in the read-only compare column.
+.fieldContainerDiff {
+    padding-left: var(--spacing-small);
+
+    &::before {
+        content: '';
+
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+
+        width: 2px;
+
+        background-color: var(--color-accent);
+    }
+}

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -640,7 +640,8 @@
           "translate": {
             "name": "Übersetzen",
             "sourceLanguage": "Ausgangssprache",
-            "translateToLanguage": "Übersetzen nach"
+            "translateToLanguage": "Übersetzen nach",
+            "fieldDiff": "Der Wert weicht von der verglichenen Version ab"
           },
           "goBack": {
             "edit": {

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -647,7 +647,8 @@
           "translate": {
             "name": "Translate",
             "sourceLanguage": "Source language",
-            "translateToLanguage": "Translate to"
+            "translateToLanguage": "Translate to",
+            "fieldDiff": "Value differs from the compared version"
           },
           "goBack": {
             "edit": {

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -641,7 +641,8 @@
           "translate": {
             "name": "Traduire",
             "sourceLanguage": "Langue source",
-            "translateToLanguage": "Traduire vers"
+            "translateToLanguage": "Traduire vers",
+            "fieldDiff": "La valeur diffère de la version comparée"
           },
           "goBack": {
             "edit": {


### PR DESCRIPTION
Closes #2556

### What
Add an opt-in **difference indicator** to the side-by-side compare UI, gated behind a new **`sideBySideContext.showDiff`** flag:
- a **blue left-bar** on each compare-column field whose value differs from the compared live node;
- the restore/copy **arrow shown only on differing fields** (in diff mode).

### Why
The compare UI (Translate tab, and content-versioning's version panel which reuses `sideBySideContext` + the per-field `translateField` arrow) had **no diff mechanism**: the arrow showed on every valued i18n field, with no cue for what actually changed. The design ([Figma](https://www.figma.com/design/AENNk51AJJl9748mDTHMNy/Versioning?node-id=4954-15442)) marks only differing fields with a blue bar + restore arrow.

### How
- `FieldContainer` computes `hasDiff` via the existing `propertyHasChanged(sourceValue, field, sideBySideContext.targetNodeData)` primitive (compares the compare-column value against the live node's **saved** value), applies a `.fieldContainerDiff` bar class, and passes `hasDiff` to the `translateField` action.
- `translateFieldAction` renders the arrow only when `!showDiff || hasDiff`.
- New `.fieldContainerDiff` SCSS (blue `var(--color-accent)` left-bar).

### Behaviour / scope
**Fully gated — no change anywhere today.** With `showDiff` unset (the main edit form and the current Translate tab) behaviour is identical: no bar, arrow on every valued field. Consumers opt in by setting `showDiff` + `targetNodeData`:
- **content-versioning's version panel** (separate change) — resolves its documented "restore on every valued field" limitation on PR #193;
- the **Translate tab** could opt in under #2514 (deliberately not flipped here, to avoid changing shipped Translate behaviour).

Design decision: compare against the live node's **saved** value (reachable, reuses `propertyHasChanged`); it doesn't reflect unsaved live edits until save — acceptable for the version-compare "what changed since this version" case.

### Verification
- New `translateFieldAction.spec.jsx` — 9 tests (arrow gating: disabled/non-i18n/no-lang → none; translate mode unchanged incl. hasDiff=false; diff mode → arrow only when differs; click still copies).
- New `Field.container.diff.spec.jsx` — 3 tests (bar class + `hasDiff` prop; inert when `showDiff` off).
- Existing `Field.container.spec.jsx` unchanged (4).
- Full ContentEditor jest suite green (578 tests); ESLint + Stylelint clean.

---
Closes Jahia/content-versioning#179
