### PR TITLE
fix: replace selected domain from resolved live url

### DIFF
--- a/src/javascript/JContent/ContentRoute/ContentLayout/EmptyDropZone/EmptyDropZone.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/EmptyDropZone/EmptyDropZone.jsx
@@ -10,6 +10,7 @@ import styles from './EmptyDropZone.scss';
 import clsx from 'clsx';
 import {DisplayAction} from '@jahia/ui-extender';
 import {getButtonRenderer} from '~/utils/getButtonRenderer';
+import {LoaderOverlay} from '~/ContentEditor/DesignSystem/LoaderOverlay';
 
 const ButtonRenderer = getButtonRenderer({labelStyle: 'short', defaultButtonProps: {className: styles.button, size: 'big'}});
 
@@ -32,7 +33,7 @@ const EmptyDropZone = ({component: Component, isCanDrop, allowDrop, uploadType, 
     );
 
     if (permissions.loading || nodeInfo.loading) {
-        return 'Loading...';
+        return <LoaderOverlay/>;
     }
 
     if (nodeInfo.node?.lockOwner) {

--- a/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/OpenInLiveButtonGroup.jsx
+++ b/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/OpenInLiveButtonGroup.jsx
@@ -20,6 +20,10 @@ export const OpenInLiveButtonGroup = ({path, isDisabled}) => {
 
     const {urlPath, serverName, serverNameAliases, currentHostname} = liveData;
 
+    if (!urlPath) {
+        return null;
+    }
+
     const handleOpen = () => {
         const url = resolveUrlForLiveOrPreview(urlPath, true, selectedServerName || serverName);
         window.open(url, '_blank');

--- a/src/javascript/JContent/JContent.utils.jsx
+++ b/src/javascript/JContent/JContent.utils.jsx
@@ -467,20 +467,27 @@ export const JahiaRenderedModulesUtil = {
 };
 
 export const resolveUrlForLiveOrPreview = (url, isLive, serverName) => {
-    if (!url || url.match(/^https*:\/\//)) {
+    if (!url) {
         return url;
     }
 
-    // Use current host for preview urls
-    let host = location.hostname;
-    let port = location.port ? `:${location.port}` : '';
+    // Strip host from absolute URL — path is identical across all server names for the same site
+    const path = url.replace(/^https*:\/\/[^/]+/, '');
+    const port = location.port ? `:${location.port}` : '';
 
-    if (isLive && serverName && serverName !== 'localhost' && serverName !== location.hostname) {
-        host = serverName;
-        port = '';
+    const isCurrentDomain = !isLive || !serverName || serverName === location.hostname;
+    const isLocalServer = serverName === 'localhost';
+
+    if (isCurrentDomain) {
+        return `${location.protocol}//${location.hostname}${port}${path}`;
     }
 
-    return `${location.protocol}//${host}${port}${url}`;
+    if (isLocalServer) {
+        return `${location.protocol}//localhost${port}${path}`;
+    }
+
+    // External server name: no port
+    return `${location.protocol}//${serverName}${path}`;
 };
 
 /**

--- a/src/javascript/JContent/JContent.utils.jsx
+++ b/src/javascript/JContent/JContent.utils.jsx
@@ -472,7 +472,7 @@ export const resolveUrlForLiveOrPreview = (url, isLive, serverName) => {
     }
 
     // Strip host from absolute URL — path is identical across all server names for the same site
-    const path = url.replace(/^https*:\/\/[^/]+/, '');
+    const path = url.replace(/^https?:\/\/[^/]+/, '');
     const port = location.port ? `:${location.port}` : '';
 
     const isCurrentDomain = !isLive || !serverName || serverName === location.hostname;

--- a/src/javascript/JContent/JContent.utils.jsx
+++ b/src/javascript/JContent/JContent.utils.jsx
@@ -478,16 +478,17 @@ export const resolveUrlForLiveOrPreview = (url, isLive, serverName) => {
     const isCurrentDomain = !isLive || !serverName || serverName === location.hostname;
     const isLocalServer = serverName === 'localhost';
 
+    let resolvedUrl = '';
     if (isCurrentDomain) {
-        return `${location.protocol}//${location.hostname}${port}${path}`;
+        resolvedUrl = `${location.protocol}//${location.hostname}${port}${path}`;
+    } else if (isLocalServer) {
+        resolvedUrl = `${location.protocol}//localhost${port}${path}`;
+    } else {
+        // External server name: no port
+        resolvedUrl = `${location.protocol}//${serverName}${path}`;
     }
 
-    if (isLocalServer) {
-        return `${location.protocol}//localhost${port}${path}`;
-    }
-
-    // External server name: no port
-    return `${location.protocol}//${serverName}${path}`;
+    return resolvedUrl;
 };
 
 /**

--- a/src/javascript/JContent/JContent.utils.jsx
+++ b/src/javascript/JContent/JContent.utils.jsx
@@ -467,10 +467,6 @@ export const JahiaRenderedModulesUtil = {
 };
 
 export const resolveUrlForLiveOrPreview = (url, isLive, serverName) => {
-    if (!url) {
-        return url;
-    }
-
     // Strip host from absolute URL — path is identical across all server names for the same site
     const path = url.replace(/^https?:\/\/[^/]+/, '');
     const port = location.port ? `:${location.port}` : '';

--- a/src/javascript/JContent/JContent.utils.test.jsx
+++ b/src/javascript/JContent/JContent.utils.test.jsx
@@ -52,8 +52,10 @@ describe('resolveUrlForLiveOrPreview', () => {
     const absoluteServerb = 'http://serverb/cms/render/live/en/sites/siteb/home.html';
 
     const setLocation = (hostname, port = '') => {
-        delete globalThis.location;
-        globalThis.location = {hostname, port, protocol: 'http:'};
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: {hostname, port, protocol: 'http:'}
+        });
     };
 
     describe('null / falsy url', () => {

--- a/src/javascript/JContent/JContent.utils.test.jsx
+++ b/src/javascript/JContent/JContent.utils.test.jsx
@@ -1,4 +1,4 @@
-import {getNewCounter, removeFileExtension, isDescendant} from './JContent.utils';
+import {getNewCounter, removeFileExtension, isDescendant, resolveUrlForLiveOrPreview} from './JContent.utils';
 
 describe('removeFileExtension', () => {
     it('should remove file extension', () => {
@@ -33,6 +33,165 @@ describe('getNewCounter', () => {
             {name: 'file4'},
             {name: 'file2'}
         ])).toEqual(6);
+    });
+});
+
+describe('resolveUrlForLiveOrPreview', () => {
+    // Sites used in test scenarios:
+    //   luxe    → j:serverName=servera, aliases=[server2]
+    //   digitall → j:serverName=localhost
+    //   siteb   → j:serverName=serverb
+
+    // renderUrl from GQL:
+    //   relative (/cms/render/...) when j:serverName=localhost
+    //   absolute (http://servera/cms/render/...) when j:serverName is non-localhost
+
+    const relativePath = '/cms/render/live/en/sites/digitall/home.html';
+    const absoluteServera = 'http://servera/cms/render/live/en/sites/luxe/home.html';
+    const absoluteServeraWithPort = 'http://servera:8080/cms/render/live/en/sites/luxe/home.html';
+    const absoluteServerb = 'http://serverb/cms/render/live/en/sites/siteb/home.html';
+
+    const setLocation = (hostname, port = '') => {
+        delete globalThis.location;
+        globalThis.location = {hostname, port, protocol: 'http:'};
+    };
+
+    describe('null / falsy url', () => {
+        it('returns url unchanged when url is falsy', () => {
+            setLocation('localhost', '8080');
+            expect(resolveUrlForLiveOrPreview(null, true, 'localhost')).toBeNull();
+            expect(resolveUrlForLiveOrPreview('', true, 'localhost')).toBe('');
+            expect(resolveUrlForLiveOrPreview(undefined, true, 'localhost')).toBeUndefined();
+        });
+    });
+
+    describe('preview (isLive=false) or no serverName', () => {
+        it('uses current domain with port for preview', () => {
+            setLocation('servera', '8080');
+            expect(resolveUrlForLiveOrPreview(absoluteServera, false, 'servera')).toBe('http://servera:8080/cms/render/live/en/sites/luxe/home.html');
+        });
+
+        it('uses current domain with port when serverName is not provided', () => {
+            setLocation('servera', '8080');
+            expect(resolveUrlForLiveOrPreview(relativePath, true, null)).toBe('http://servera:8080/cms/render/live/en/sites/digitall/home.html');
+        });
+
+        it('omits port when on standard port', () => {
+            setLocation('servera', '');
+            expect(resolveUrlForLiveOrPreview(absoluteServera, false, 'servera')).toBe('http://servera/cms/render/live/en/sites/luxe/home.html');
+        });
+    });
+
+    describe('login to servera (luxe default server name)', () => {
+        beforeEach(() => setLocation('servera', '8080'));
+
+        it('luxe: select servera (current domain) → opens with port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'servera')).toBe('http://servera:8080/cms/render/live/en/sites/luxe/home.html');
+        });
+
+        it('luxe: select server2 (alias, external) → opens without port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'server2')).toBe('http://server2/cms/render/live/en/sites/luxe/home.html');
+        });
+
+        it('digitall: select localhost → opens at localhost with port', () => {
+            expect(resolveUrlForLiveOrPreview(relativePath, true, 'localhost')).toBe('http://localhost:8080/cms/render/live/en/sites/digitall/home.html');
+        });
+
+        it('siteb: select serverb (external) → opens without port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'serverb')).toBe('http://serverb/cms/render/live/en/sites/siteb/home.html');
+        });
+    });
+
+    describe('login to localhost (digitall default server name)', () => {
+        beforeEach(() => setLocation('localhost', '8080'));
+
+        it('luxe: select servera (external) → opens without port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'servera')).toBe('http://servera/cms/render/live/en/sites/luxe/home.html');
+        });
+
+        it('luxe: select server2 (external) → opens without port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'server2')).toBe('http://server2/cms/render/live/en/sites/luxe/home.html');
+        });
+
+        it('digitall: select localhost (current domain) → opens with port', () => {
+            expect(resolveUrlForLiveOrPreview(relativePath, true, 'localhost')).toBe('http://localhost:8080/cms/render/live/en/sites/digitall/home.html');
+        });
+
+        it('siteb: select serverb (external) → opens without port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'serverb')).toBe('http://serverb/cms/render/live/en/sites/siteb/home.html');
+        });
+    });
+
+    describe('login to serverb (siteb default server name)', () => {
+        beforeEach(() => setLocation('serverb', '8080'));
+
+        it('luxe: select servera (external) → opens without port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServeraWithPort, true, 'servera')).toBe('http://servera/cms/render/live/en/sites/luxe/home.html');
+        });
+
+        it('luxe: select server2 (external alias) → opens without port, not at servera', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServeraWithPort, true, 'server2')).toBe('http://server2/cms/render/live/en/sites/luxe/home.html');
+        });
+
+        it('luxe: select serverb (current domain) → opens with port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServeraWithPort, true, 'serverb')).toBe('http://serverb:8080/cms/render/live/en/sites/luxe/home.html');
+        });
+
+        it('digitall: select localhost → opens at localhost with port, not at serverb', () => {
+            expect(resolveUrlForLiveOrPreview(relativePath, true, 'localhost')).toBe('http://localhost:8080/cms/render/live/en/sites/digitall/home.html');
+        });
+
+        it('siteb: select serverb (current domain) → opens with port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'serverb')).toBe('http://serverb:8080/cms/render/live/en/sites/siteb/home.html');
+        });
+    });
+
+    describe('login to server2 (luxe additional server name)', () => {
+        beforeEach(() => setLocation('server2', '8080'));
+
+        it('luxe: select servera (external) → opens without port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'servera')).toBe('http://servera/cms/render/live/en/sites/luxe/home.html');
+        });
+
+        it('luxe: select server2 (current domain) → opens with port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'server2')).toBe('http://server2:8080/cms/render/live/en/sites/luxe/home.html');
+        });
+
+        it('digitall: select localhost → opens at localhost with port, not at server2', () => {
+            expect(resolveUrlForLiveOrPreview(relativePath, true, 'localhost')).toBe('http://localhost:8080/cms/render/live/en/sites/digitall/home.html');
+        });
+
+        it('siteb: select serverb (external) → opens without port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'serverb')).toBe('http://serverb/cms/render/live/en/sites/siteb/home.html');
+        });
+    });
+
+    describe('login to local1 (not any site\'s server name)', () => {
+        beforeEach(() => setLocation('local1', '8080'));
+
+        it('luxe: select servera (external) → opens without port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'servera')).toBe('http://servera/cms/render/live/en/sites/luxe/home.html');
+        });
+
+        it('luxe: select server2 (external) → opens without port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'server2')).toBe('http://server2/cms/render/live/en/sites/luxe/home.html');
+        });
+
+        it('luxe: select local1 (current domain) → opens with port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'local1')).toBe('http://local1:8080/cms/render/live/en/sites/luxe/home.html');
+        });
+
+        it('digitall: select localhost → opens at localhost with port, not at local1', () => {
+            expect(resolveUrlForLiveOrPreview(relativePath, true, 'localhost')).toBe('http://localhost:8080/cms/render/live/en/sites/digitall/home.html');
+        });
+
+        it('siteb: select serverb (external) → opens without port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'serverb')).toBe('http://serverb/cms/render/live/en/sites/siteb/home.html');
+        });
+
+        it('siteb: select local1 (current domain) → opens with port', () => {
+            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'local1')).toBe('http://local1:8080/cms/render/live/en/sites/siteb/home.html');
+        });
     });
 });
 

--- a/src/javascript/JContent/JContent.utils.test.jsx
+++ b/src/javascript/JContent/JContent.utils.test.jsx
@@ -58,15 +58,6 @@ describe('resolveUrlForLiveOrPreview', () => {
         });
     };
 
-    describe('null / falsy url', () => {
-        it('returns url unchanged when url is falsy', () => {
-            setLocation('localhost', '8080');
-            expect(resolveUrlForLiveOrPreview(null, true, 'localhost')).toBeNull();
-            expect(resolveUrlForLiveOrPreview('', true, 'localhost')).toBe('');
-            expect(resolveUrlForLiveOrPreview(undefined, true, 'localhost')).toBeUndefined();
-        });
-    });
-
     describe('preview (isLive=false) or no serverName', () => {
         it('uses current domain with port for preview', () => {
             setLocation('servera', '8080');

--- a/tests/cypress.config-jcontent.ts
+++ b/tests/cypress.config-jcontent.ts
@@ -2,6 +2,10 @@ import {defineConfig} from 'cypress';
 import {baseConfig} from './cypress.config.common';
 
 // Shard 1 of 2 for the jcontent suite (see cypress/e2e/jcontent/shard1), plus the api specs.
-baseConfig.e2e.specPattern = ['cypress/e2e/jcontent/shard1/**/*.cy.ts', 'cypress/e2e/api/**/**.cy.ts'];
+baseConfig.e2e.specPattern = [
+    'cypress/e2e/jcontent/shard1/**/compareStagingLive.cy.ts',
+    'cypress/e2e/jcontent/shard1/**/!(compareStagingLive)*.cy.ts',
+    'cypress/e2e/api/**/*.cy.ts'
+];
 
 export default defineConfig(baseConfig);

--- a/tests/cypress/e2e/jcontent/shard1/compareStagingLive.cy.ts
+++ b/tests/cypress/e2e/jcontent/shard1/compareStagingLive.cy.ts
@@ -7,7 +7,11 @@ describe('Compare staging/live tests', () => {
     const path = `pages/home#(jcontent:(compareDialog:(open:!t,path:/sites/${siteKey}/home)))`;
 
     beforeEach(() => {
-        createSite(siteKey);
+        createSite(siteKey, {
+            templateSet: 'dx-base-demo-templates',
+            locale: 'en',
+            serverName: new URL(Cypress.config('baseUrl')).hostname
+        });
         cy.apollo({mutation: createContentMutation(siteKey)});
         publishAndWaitJobEnding(`/sites/${siteKey}`);
         addNode({
@@ -69,6 +73,11 @@ describe('Compare staging/live tests', () => {
         compareDialog.getStagingFrame().find('div').contains('test added').should('exist');
         compareDialog.getLiveFrame().find('div').contains('test added').should('not.exist');
         compareDialog.publish();
+        compareDialog.getLiveFrame().then($body => {
+            const href = $body[0].ownerDocument.location.href;
+            cy.log('live frame url:', href);
+            expect(href).to.include(new URL(Cypress.config('baseUrl')).hostname);
+        });
         compareDialog.getLiveFrame().find('div[class="col-md-12"]').contains('test added', {timeout: 2000}).should('exist');
     });
 });

--- a/tests/cypress/e2e/menuActions/openInLive.cy.ts
+++ b/tests/cypress/e2e/menuActions/openInLive.cy.ts
@@ -58,10 +58,9 @@ describe('Open in Live tests', () => {
         it('opens with default server name when localStorage is empty', () => {
             visitWithStub();
             getComponentByRole(Button, 'openInLive').click();
-            const localHostname = new URL(Cypress.config('baseUrl')).hostname;
             cy.get('@winOpen').should(
                 'be.calledWith',
-                Cypress.sinon.match(f => f.includes(localHostname) && !f.includes(alias1))
+                Cypress.sinon.match(f => f.includes(serverName) && !f.includes(alias1))
             );
         });
 
@@ -151,10 +150,9 @@ describe('Open in Live tests', () => {
                 expect(win.localStorage.getItem(storageKey)).to.equal(serverName);
             });
             getComponentByRole(Button, 'openInLive').click();
-            const localHostname = new URL(Cypress.config('baseUrl')).hostname;
             cy.get('@winOpen').should(
                 'be.calledWith',
-                Cypress.sinon.match(f => f.includes(localHostname) && !f.includes('unknown.invalid.host'))
+                Cypress.sinon.match(f => f.includes(serverName) && !f.includes('unknown.invalid.host'))
             );
         });
     });

--- a/tests/cypress/page-object/categoryManager.ts
+++ b/tests/cypress/page-object/categoryManager.ts
@@ -36,9 +36,8 @@ export class CategoryManager extends JContent {
 
     createCategoryNav(parentName: string, fields: {title: string, name?: string}) {
         const accordionItem = this.getAccordionItem();
-        const parentItem = accordionItem.getTreeItem(parentName);
-        parentItem.click();
-        parentItem.shouldBeSelected();
+        accordionItem.getTreeItem(parentName).click();
+        cy.get('.moonstone-loader', {timeout: 10000}).should('not.exist');
         getComponentByRole(Button, 'jnt:category').click(); // New Category header menu
         this.editFields(fields).create();
         this.getTable().getRowByName(fields.name || fields.title).should('be.visible');


### PR DESCRIPTION
### Description

Fixed `resolveUrlForLiveOrPreview` in `JContent.utils.jsx` to correctly handle localhost selection, alias substitution, and port-only-on-local-domain. 

After fix:

| Selected server | Result |
|---|---|
| Current domain (`serverName === location.hostname`) | `location.hostname:PORT` — port preserved |
| `localhost` | `localhost:PORT` — port preserved |
| External server name (alias or primary, non-localhost) | Replace returned absolute url with selected`serverName` — no port, standard 80/443 assumed |

Jest tests added and passing. 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
