### PR TITLE
feat: supported side-by-side source seam (SideBySideSourceProvider) (#2579)

### DIFF
--- a/src/javascript/ContentEditor/contexts/ContentEditorConfig/SideBySideSourceProvider.jsx
+++ b/src/javascript/ContentEditor/contexts/ContentEditorConfig/SideBySideSourceProvider.jsx
@@ -1,0 +1,51 @@
+import React, {useMemo} from 'react';
+import * as PropTypes from 'prop-types';
+import {ContentEditorConfigContextProvider, useContentEditorConfigContext} from './ContentEditorConfig.context';
+import {useContentEditorContext} from '~/ContentEditor/contexts/ContentEditor';
+
+/**
+ * Renders its children as a read-only "side-by-side source" column, next to the live edit form — the
+ * setup the Translate tab uses to show a source language, and the supported seam for modules that want
+ * the same thing (e.g. content-versioning restoring a value from a past version). See issue #2579.
+ *
+ * It reads the surrounding config and node contexts, builds the `sideBySideContext` (so consumers no
+ * longer hand-craft it), and provides an overridden config down the tree. Per-field restore arrows
+ * (`translateFieldAction`) light up for i18n fields, copying the source value into the live form's
+ * `translateLang`.
+ *
+ * @param translateLang the editable language a restored value is copied into; defaults to the current config language
+ * @param sourceLang    the language this source column renders in; defaults to the existing side-by-side language, then the config language
+ */
+export const SideBySideSourceProvider = ({translateLang, sourceLang, children}) => {
+    const baseConfig = useContentEditorConfigContext();
+    const {nodeData} = useContentEditorContext();
+
+    const hasWritePermission = nodeData?.hasWritePermission;
+    const lockedAndCannotBeEdited = nodeData?.lockedAndCannotBeEdited;
+
+    const config = useMemo(() => ({
+        ...baseConfig,
+        lang: sourceLang ?? baseConfig.sideBySideContext?.lang ?? baseConfig.lang,
+        sideBySideContext: {
+            ...baseConfig.sideBySideContext,
+            enabled: true,
+            readOnly: true,
+            translateLang: translateLang ?? baseConfig.lang,
+            // Permissions come from the editable node, not this read-only source column.
+            hasWritePermission,
+            lockedAndCannotBeEdited
+        }
+    }), [baseConfig, sourceLang, translateLang, hasWritePermission, lockedAndCannotBeEdited]);
+
+    return (
+        <ContentEditorConfigContextProvider config={config}>
+            {children}
+        </ContentEditorConfigContextProvider>
+    );
+};
+
+SideBySideSourceProvider.propTypes = {
+    translateLang: PropTypes.string,
+    sourceLang: PropTypes.string,
+    children: PropTypes.node.isRequired
+};

--- a/src/javascript/ContentEditor/contexts/ContentEditorConfig/SideBySideSourceProvider.spec.jsx
+++ b/src/javascript/ContentEditor/contexts/ContentEditorConfig/SideBySideSourceProvider.spec.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {shallow} from '@jahia/test-framework';
+import {SideBySideSourceProvider} from './SideBySideSourceProvider';
+import {ContentEditorConfigContextProvider, useContentEditorConfigContext} from './ContentEditorConfig.context';
+import {useContentEditorContext} from '~/ContentEditor/contexts/ContentEditor';
+
+jest.mock('./ContentEditorConfig.context', () => ({
+    useContentEditorConfigContext: jest.fn(),
+    ContentEditorConfigContextProvider: () => null
+}));
+jest.mock('~/ContentEditor/contexts/ContentEditor', () => ({
+    useContentEditorContext: jest.fn()
+}));
+
+describe('SideBySideSourceProvider', () => {
+    const child = <div id="child"/>;
+
+    const render = (baseConfig, nodeData, props = {}) => {
+        useContentEditorConfigContext.mockReturnValue(baseConfig);
+        useContentEditorContext.mockReturnValue({nodeData});
+        return shallow(<SideBySideSourceProvider {...props}>{child}</SideBySideSourceProvider>);
+    };
+
+    // The config object handed down to the overridden ContentEditorConfigContextProvider.
+    const providedConfig = wrapper => wrapper.find(ContentEditorConfigContextProvider).props().config;
+
+    it('builds a read-only side-by-side source config', () => {
+        const cfg = providedConfig(render({lang: 'fr'}, {hasWritePermission: true, lockedAndCannotBeEdited: false}));
+        expect(cfg.sideBySideContext).toMatchObject({
+            enabled: true,
+            readOnly: true,
+            translateLang: 'fr'
+        });
+    });
+
+    it('defaults the source language to the config language', () => {
+        expect(providedConfig(render({lang: 'fr'}, {})).lang).toBe('fr');
+    });
+
+    it('prefers an existing side-by-side language for the source column (Translate-tab behaviour)', () => {
+        expect(providedConfig(render({lang: 'fr', sideBySideContext: {lang: 'en'}}, {})).lang).toBe('en');
+    });
+
+    it('lets sourceLang / translateLang props override the defaults', () => {
+        const cfg = providedConfig(render({lang: 'fr'}, {}, {sourceLang: 'de', translateLang: 'it'}));
+        expect(cfg.lang).toBe('de');
+        expect(cfg.sideBySideContext.translateLang).toBe('it');
+    });
+
+    it('takes permissions from the editable node, not the read-only source', () => {
+        const cfg = providedConfig(render({lang: 'fr'}, {hasWritePermission: false, lockedAndCannotBeEdited: true}));
+        expect(cfg.sideBySideContext.hasWritePermission).toBe(false);
+        expect(cfg.sideBySideContext.lockedAndCannotBeEdited).toBe(true);
+    });
+
+    it('preserves the base config and any other side-by-side keys', () => {
+        const cfg = providedConfig(render({lang: 'fr', uuid: 'abc', sideBySideContext: {custom: 1}}, {}));
+        expect(cfg.uuid).toBe('abc');
+        expect(cfg.sideBySideContext.custom).toBe(1);
+    });
+
+    it('renders its children under the overridden config', () => {
+        const wrapper = render({lang: 'fr'}, {});
+        expect(wrapper.find(ContentEditorConfigContextProvider).props().children).toBe(child);
+    });
+});

--- a/src/javascript/ContentEditor/contexts/ContentEditorConfig/index.js
+++ b/src/javascript/ContentEditor/contexts/ContentEditorConfig/index.js
@@ -1,1 +1,2 @@
 export * from './ContentEditorConfig.context';
+export * from './SideBySideSourceProvider';

--- a/src/javascript/ContentEditor/editorTabs/TranslatePanel/SourceContentPanel.jsx
+++ b/src/javascript/ContentEditor/editorTabs/TranslatePanel/SourceContentPanel.jsx
@@ -1,81 +1,16 @@
-import React, {useMemo} from 'react';
-import {
-    ContentEditorConfigContextProvider,
-    useContentEditorConfigContext,
-    useContentEditorContext
-} from '~/ContentEditor/contexts';
-import PropTypes from 'prop-types';
+import React from 'react';
+import {SideBySideSourceProvider} from '~/ContentEditor/contexts';
 import {SourceContentFormBuilder} from './SourceContentFormBuilder';
 
 /**
- * Wrapper component for displaying the source content in a translation workflow.
- * This component extracts the current configuration and content editor contexts
- * and passes them to the inner component that will override them for source content display.
- * This is done in order to be able to memoize the context configuration and avoid unnecessary re-renders.
+ * Displays the source content in a translation workflow: a read-only side-by-side source column next
+ * to the live edit form. The side-by-side wiring lives in the shared {@link SideBySideSourceProvider}
+ * (issue #2579), whose defaults reproduce this tab's behaviour — source language from the existing
+ * side-by-side language (falling back to the editable one), which is also the language a restored
+ * value is copied into.
  */
-export const SourceContentPanel = () => {
-    const ceConfigContext = useContentEditorConfigContext();
-    const ceContext = useContentEditorContext();
-
-    return (
-        <SourceContentPanelInner
-            baseConfig={ceConfigContext}
-            baseContext={ceContext}
-        />
-    );
-};
-
-/**
- * Configures and renders the source content panel with the appropriate context for translation.
- * This component:
- * - Creates a modified configuration context for translation purposes
- * - Sets up the side-by-side context with the source language
- * - Configures read-only mode for the source content
- * - Preserves permission information from the original context
- * - Renders the SourceContentFormBuilder with overridden configuration
- */
-const SourceContentPanelInner = ({baseConfig, baseContext}) => {
-    const contextConfig = useMemo(() => ({
-        ...baseConfig,
-        // Fall back to the current editable language when no explicit source language is set
-        lang: baseConfig.sideBySideContext?.lang ?? baseConfig.lang,
-        sideBySideContext: {
-            ...baseConfig.sideBySideContext,
-            enabled: true,
-            readOnly: true,
-            translateLang: baseConfig.lang, // Editable language
-            // We set this based on the editable nodeData (from baseContext), not read-only nodeData
-            hasWritePermission: baseContext.nodeData?.hasWritePermission,
-            lockedAndCannotBeEdited: baseContext.nodeData?.lockedAndCannotBeEdited
-        }
-    }), [
-        baseConfig,
-        baseContext.nodeData?.hasWritePermission,
-        baseContext.nodeData?.lockedAndCannotBeEdited
-    ]);
-
-    return (
-        <ContentEditorConfigContextProvider config={contextConfig}>
-            <SourceContentFormBuilder/>
-        </ContentEditorConfigContextProvider>
-    );
-};
-
-SourceContentPanelInner.propTypes = {
-    baseConfig: PropTypes.shape({
-        sideBySideContext: PropTypes.shape({
-            lang: PropTypes.string
-        }),
-        lang: PropTypes.string.isRequired,
-        i18nContext: PropTypes.object.isRequired,
-        setI18nContext: PropTypes.func.isRequired,
-        resetI18nContext: PropTypes.func.isRequired
-    }).isRequired,
-    baseContext: PropTypes.shape({
-        nodeData: PropTypes.shape({
-            hasWritePermission: PropTypes.bool,
-            lockedAndCannotBeEdited: PropTypes.bool
-        })
-    }).isRequired
-};
-
+export const SourceContentPanel = () => (
+    <SideBySideSourceProvider>
+        <SourceContentFormBuilder/>
+    </SideBySideSourceProvider>
+);

--- a/src/javascript/ContentEditor/editorTabs/TranslatePanel/SourceContentPanel.spec.jsx
+++ b/src/javascript/ContentEditor/editorTabs/TranslatePanel/SourceContentPanel.spec.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {shallow} from '@jahia/test-framework';
+import {SourceContentPanel} from './SourceContentPanel';
+import {SideBySideSourceProvider} from '~/ContentEditor/contexts';
+import {SourceContentFormBuilder} from './SourceContentFormBuilder';
+
+jest.mock('~/ContentEditor/contexts', () => ({
+    SideBySideSourceProvider: ({children}) => children
+}));
+jest.mock('./SourceContentFormBuilder', () => ({
+    SourceContentFormBuilder: () => null
+}));
+
+describe('SourceContentPanel', () => {
+    it('renders the source form inside the shared side-by-side source provider', () => {
+        const wrapper = shallow(<SourceContentPanel/>);
+        const provider = wrapper.find(SideBySideSourceProvider);
+        expect(provider.exists()).toBe(true);
+        expect(provider.find(SourceContentFormBuilder).exists()).toBe(true);
+    });
+});


### PR DESCRIPTION
## What

Adds `SideBySideSourceProvider` — a supported jContent seam for rendering a **read-only side-by-side source column** next to the live edit form, so consuming modules no longer have to hand-craft the internal `sideBySideContext` object.

Motivated by content-versioning's version panel, which restores a value from a past version by faking a side-by-side source (see the [PR review](https://github.com/Jahia/content-versioning/pull/193) and Jahia/content-versioning#179). jContent's own Translate tab was building the *same* object independently.

## Changes

- **New `SideBySideSourceProvider`** (`contexts/ContentEditorConfig/`) — reads the surrounding config + node contexts, builds and memoizes `sideBySideContext` (`enabled`/`readOnly`/`translateLang` + permissions taken from the editable node), and provides the overridden config down the tree. Named `translateLang` / `sourceLang` props; the defaults reproduce the Translate tab's behaviour. Exported through the federation barrel (`@jahia/jcontent`).
- **Dogfood** — `SourceContentPanel` (Translate tab) now uses the provider instead of hand-building the context; behaviour-preserving (89 → 16 lines).

Consumers go from hand-crafting the context to:

```tsx
<SideBySideSourceProvider translateLang={lang}>
    <FormBuilder mode="edit"/>
</SideBySideSourceProvider>
```

## Out of scope (intentionally)

- The issue's *eventual* goals — restoring **shared (non-i18n)** properties, and a dedicated restore action — are not built here. The seam is forward-compatible with them, and with #2556's `showDiff`/`targetNodeData` (add named props once that lands).
- The **content-versioning consumer wiring** is a separate follow-up, blocked on a released jContent version bumped in its deps.

## Tests

- New `SideBySideSourceProvider.spec.jsx` (built config + prop overrides + base-config preservation) and `SourceContentPanel.spec.jsx` (dogfood wiring). Affected + surrounding suites green; eslint clean; webpack build compiles.

Closes #2579
