### PR TITLE
fix: prevent scroll rollback caused by ck5 floating header

### DIFF
--- a/.chachalog/w6GAV1CS.md
+++ b/.chachalog/w6GAV1CS.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": patch
+---
+
+Addressed a scroll rollback bug when Content Editor is in two-column layout, e.g., translate layout. (#2583)

--- a/src/javascript/ContentEditor/editorTabs/useResizeWatcher.jsx
+++ b/src/javascript/ContentEditor/editorTabs/useResizeWatcher.jsx
@@ -50,6 +50,19 @@ export const useResizeWatcher = ({columnSelector}) => {
 const areDifferent = (a, b) => Math.abs(a - b) > 1;
 
 /**
+ * Restores the scroll position of a column if it has changed.
+ * Extracted to reduce cognitive complexity of `processResizeEntries`.
+ *
+ * @param {Element|undefined} column
+ * @param {number} scrollPosition
+ */
+const restoreScrollPositions = (column, scrollPosition) => {
+    if (column && scrollPosition !== undefined && areDifferent(column.scrollTop, scrollPosition)) {
+        column.scrollTop = scrollPosition;
+    }
+};
+
+/**
  * Util function to bind columnSelector to the resize processing logic to be used in useCallback fn.
  *
  * @param {"left-column"|"right-column"} columnSelector
@@ -101,12 +114,7 @@ function processResizeEntries(columnSelector) {
         }
 
         // Restore pre-layout update scroll positions to avoid weird jumps
-        if (leftColumn && savedLeftScrollTop !== undefined && areDifferent(leftColumn.scrollTop, savedLeftScrollTop)) {
-            leftColumn.scrollTop = savedLeftScrollTop;
-        }
-
-        if (rightColumn && savedRightScrollTop !== undefined && areDifferent(rightColumn.scrollTop, savedRightScrollTop)) {
-            rightColumn.scrollTop = savedRightScrollTop;
-        }
+        restoreScrollPositions(leftColumn, savedLeftScrollTop);
+        restoreScrollPositions(rightColumn, savedRightScrollTop);
     };
 }

--- a/src/javascript/ContentEditor/editorTabs/useResizeWatcher.jsx
+++ b/src/javascript/ContentEditor/editorTabs/useResizeWatcher.jsx
@@ -90,7 +90,7 @@ function processResizeEntries(columnSelector) {
             const pairHeight = elPair?.scrollHeight || 0;
             const minHeight = Math.max(currentHeight, pairHeight);
 
-            // Only set minHeight when the gap exceeds the tolerance
+            // Only set minHeight if there's a difference
             if (areDifferent(currentHeight, minHeight)) {
                 el.style.minHeight = `${minHeight}px`;
             }

--- a/src/javascript/ContentEditor/editorTabs/useResizeWatcher.jsx
+++ b/src/javascript/ContentEditor/editorTabs/useResizeWatcher.jsx
@@ -41,11 +41,30 @@ export const useResizeWatcher = ({columnSelector}) => {
 };
 
 /**
+ * Compares pixel values with a tolerance of 1px.
+ * We used to do `a !== b` but it triggered unnecessary reflows on high DPI screens.
+ *
+ * @param {number} a
+ * @param {number} b
+ */
+const areDifferent = (a, b) => Math.abs(a - b) > 1;
+
+/**
  * Util function to bind columnSelector to the resize processing logic to be used in useCallback fn.
+ *
+ * @param {"left-column"|"right-column"} columnSelector
  */
 function processResizeEntries(columnSelector) {
     return entries => {
         const processedFields = new Set();
+
+        // When the height of a block changes, the navigator may decide to update the scroll position
+        // not to confuse users. Unfortunately, this browser behavior does the opposite. Instead we
+        // preserve the scroll position of both columns, restore them at the end of the layout update.
+        const leftColumn = document.querySelector('[data-sel-role="left-column"]');
+        const rightColumn = document.querySelector('[data-sel-role="right-column"]');
+        const savedLeftScrollTop = leftColumn?.scrollTop;
+        const savedRightScrollTop = rightColumn?.scrollTop;
 
         for (const entry of entries) {
             const el = entry.target;
@@ -72,14 +91,23 @@ function processResizeEntries(columnSelector) {
             const pairHeight = elPair?.scrollHeight || 0;
             const minHeight = Math.max(currentHeight, pairHeight);
 
-            // Only set minHeight if there's a difference
-            if (currentHeight !== minHeight) {
+            // Only set minHeight when the gap exceeds the tolerance
+            if (areDifferent(currentHeight, minHeight)) {
                 el.style.minHeight = `${minHeight}px`;
             }
 
-            if (elPair && pairHeight !== minHeight) {
+            if (elPair && areDifferent(pairHeight, minHeight)) {
                 elPair.style.minHeight = `${minHeight}px`;
             }
+        }
+
+        // Restore pre-layout update scroll positions to avoid weird jumps
+        if (leftColumn && savedLeftScrollTop !== undefined && leftColumn.scrollTop !== savedLeftScrollTop) {
+            leftColumn.scrollTop = savedLeftScrollTop;
+        }
+
+        if (rightColumn && savedRightScrollTop !== undefined && rightColumn.scrollTop !== savedRightScrollTop) {
+            rightColumn.scrollTop = savedRightScrollTop;
         }
     };
 }

--- a/src/javascript/ContentEditor/editorTabs/useResizeWatcher.jsx
+++ b/src/javascript/ContentEditor/editorTabs/useResizeWatcher.jsx
@@ -101,11 +101,11 @@ function processResizeEntries(columnSelector) {
         }
 
         // Restore pre-layout update scroll positions to avoid weird jumps
-        if (leftColumn && savedLeftScrollTop !== undefined && leftColumn.scrollTop !== savedLeftScrollTop) {
+        if (leftColumn && savedLeftScrollTop !== undefined && areDifferent(leftColumn.scrollTop, savedLeftScrollTop)) {
             leftColumn.scrollTop = savedLeftScrollTop;
         }
 
-        if (rightColumn && savedRightScrollTop !== undefined && rightColumn.scrollTop !== savedRightScrollTop) {
+        if (rightColumn && savedRightScrollTop !== undefined && areDifferent(rightColumn.scrollTop, savedRightScrollTop)) {
             rightColumn.scrollTop = savedRightScrollTop;
         }
     };

--- a/src/javascript/ContentEditor/editorTabs/useResizeWatcher.jsx
+++ b/src/javascript/ContentEditor/editorTabs/useResizeWatcher.jsx
@@ -58,9 +58,8 @@ function processResizeEntries(columnSelector) {
     return entries => {
         const processedFields = new Set();
 
-        // When the height of a block changes, the navigator may decide to update the scroll position
-        // not to confuse users. Unfortunately, this browser behavior does the opposite. Instead we
-        // preserve the scroll position of both columns, restore them at the end of the layout update.
+        // When the height of a block changes, the navigator may decide to update the scroll position not to confuse users. Unfortunately, this browser behavior causes weird scroll rollbacks.
+        // Instead we preserve the scroll position of both columns, restore them at the end of the layout update.
         const leftColumn = document.querySelector('[data-sel-role="left-column"]');
         const rightColumn = document.querySelector('[data-sel-role="right-column"]');
         const savedLeftScrollTop = leftColumn?.scrollTop;


### PR DESCRIPTION
Closes #2485:

Save scroll position before resizing fields / restore it afterwards

Confirmed to be working by @romain-pm 