### PR TITLE
fix: Calculate insertion point only for elements with visible children

### DIFF
--- a/.chachalog/rVRoRCiB.md
+++ b/.chachalog/rVRoRCiB.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Calculate insertion point only for elements with visible children (#2588)

--- a/src/javascript/JContent/EditFrame/InsertionPoints.jsx
+++ b/src/javascript/JContent/EditFrame/InsertionPoints.jsx
@@ -14,11 +14,16 @@ const resolveParentPath = e => {
 };
 
 /**
- * A child only warrants an insertion point if it actually renders something visible: it must
- * contain at least one element that is not display:none. A fully hidden child would otherwise get
- * a stray insertion point positioned over nothing.
+ * A child only warrants an insertion point if it actually renders something. A child with no child
+ * elements (empty, or holding only text) qualifies. Otherwise at least one of its child elements
+ * must not be display:none — a child whose elements are all hidden would get a stray insertion
+ * point positioned over nothing.
  */
 const hasVisibleContent = e => {
+    if (e.children.length === 0) {
+        return true;
+    }
+
     const view = e.ownerDocument.defaultView;
     return [...e.children].some(child => view.getComputedStyle(child).display !== 'none');
 };

--- a/src/javascript/JContent/EditFrame/InsertionPoints.jsx
+++ b/src/javascript/JContent/EditFrame/InsertionPoints.jsx
@@ -14,6 +14,16 @@ const resolveParentPath = e => {
 };
 
 /**
+ * A child only warrants an insertion point if it actually renders something visible: it must
+ * contain at least one element that is not display:none. A fully hidden child would otherwise get
+ * a stray insertion point positioned over nothing.
+ */
+const hasVisibleContent = e => {
+    const view = e.ownerDocument.defaultView;
+    return [...e.children].some(child => view.getComputedStyle(child).display !== 'none');
+};
+
+/**
  * This function helps resolve required nodetypes for insertion points.
  *
  * Why is this necessary?
@@ -66,8 +76,9 @@ const InsertionPoints = ({currentDocument, clickedElement, nodes, addIntervalCal
 
     // Get all children of the clicked element that are [type="existingNode"] and add insertion points for each (insertion points appear on top)
     const childrenElem = [...currentDocument.querySelectorAll(`[data-jahia-parent=${clickedElement.element.id}]`)]
-        // Need to make sure that existingNode is not a weakreference but a subnode, which we can do by checking subpath
-        .filter(e => e.getAttribute('path')?.startsWith(clickedPath) && e.getAttribute('type') !== 'placeholder')
+        // Need to make sure that existingNode is not a weakreference but a subnode, which we can do by checking subpath.
+        // Also require the child to render at least one visible element, otherwise its insertion point has nothing to anchor to.
+        .filter(e => e.getAttribute('path')?.startsWith(clickedPath) && e.getAttribute('type') !== 'placeholder' && hasVisibleContent(e))
         .map(e => {
             const parentPath = resolveParentPath(e);
             return {


### PR DESCRIPTION
### Description
Calculate insertion point only for elements with visible children so that for elements like slider we don't end up seeing many insertion points which insert the same element.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
