### PR TITLE
fix: refresh handlers after switching CE language

### DIFF
--- a/.chachalog/qLangSwDep.md
+++ b/.chachalog/qLangSwDep.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": patch
+---
+
+Dependent fields driven by unsaved changes (internal link page picker, dependent constraints) are kept when switching the editing language

--- a/src/javascript/ContentEditor/SelectorTypes/registerSelectorTypesOnChange.js
+++ b/src/javascript/ContentEditor/SelectorTypes/registerSelectorTypesOnChange.js
@@ -34,6 +34,25 @@ function recreate(sections) {
     });
 }
 
+// Latest FieldConstraints request id per dependent field, per sections generation. Concurrent
+// requests for the same field (e.g. the value transitions around a language switch) can resolve
+// out of order; only the last-issued one may apply.
+const constraintsTickets = new WeakMap();
+
+const takeTicket = (sections, fieldName) => {
+    let byField = constraintsTickets.get(sections);
+    if (!byField) {
+        byField = new Map();
+        constraintsTickets.set(sections, byField);
+    }
+
+    const ticket = (byField.get(fieldName) || 0) + 1;
+    byField.set(fieldName, ticket);
+    return ticket;
+};
+
+const isLatestTicket = (sections, fieldName, ticket) => constraintsTickets.get(sections)?.get(fieldName) === ticket;
+
 export const registerSelectorTypesOnChange = registry => {
     registry.add('selectorType.onChange', 'dependentProperties', {
         targets: ['*'],
@@ -68,6 +87,8 @@ export const registerSelectorTypesOnChange = registry => {
                         value: currentValue === null ? [] : currentValue
                     });
 
+                    const ticket = takeTicket(sections, dependentPropertiesField.name);
+
                     return onChangeContext.client.query({
                         query: FieldConstraints,
                         variables: {
@@ -82,24 +103,23 @@ export const registerSelectorTypesOnChange = registry => {
                         }
                     }).then(({data}) => ({
                         data,
-                        dependentPropertiesField
+                        dependentPropertiesField,
+                        ticket
                     }));
                 }
 
                 return undefined;
             })).then(results => {
                 let updated = false;
-                results.forEach(({data, dependentPropertiesField}) => {
-                    if (data) {
-                        if (data?.forms?.fieldConstraints) {
-                            const fieldToUpdate = getFields(sections).find(f => f.name === dependentPropertiesField.name);
-                            if (fieldToUpdate && !arrayEquals(fieldToUpdate.valueConstraints, data.forms.fieldConstraints)) {
-                                // Update field in place (for those who keep a constant ref on sectionsContext)
-                                fieldToUpdate.valueConstraints = data.forms.fieldConstraints;
-                                // And recreate the full sections object to make change detection work
-                                recreate(sections);
-                                updated = true;
-                            }
+                results.forEach(({data, dependentPropertiesField, ticket}) => {
+                    if (data?.forms?.fieldConstraints && isLatestTicket(sections, dependentPropertiesField.name, ticket)) {
+                        const fieldToUpdate = getFields(sections).find(f => f.name === dependentPropertiesField.name);
+                        if (fieldToUpdate && !arrayEquals(fieldToUpdate.valueConstraints, data.forms.fieldConstraints)) {
+                            // Update field in place (for those who keep a constant ref on sectionsContext)
+                            fieldToUpdate.valueConstraints = data.forms.fieldConstraints;
+                            // And recreate the full sections object to make change detection work
+                            recreate(sections);
+                            updated = true;
                         }
                     }
                 });

--- a/src/javascript/ContentEditor/SelectorTypes/registerSelectorTypesOnChange.js
+++ b/src/javascript/ContentEditor/SelectorTypes/registerSelectorTypesOnChange.js
@@ -53,6 +53,23 @@ const takeTicket = (sections, fieldName) => {
 
 const isLatestTicket = (sections, fieldName, ticket) => constraintsTickets.get(sections)?.get(fieldName) === ticket;
 
+const applyFieldConstraints = (results, sections) => {
+    let updated = false;
+    results.forEach(({data, dependentPropertiesField, ticket}) => {
+        if (data?.forms?.fieldConstraints && isLatestTicket(sections, dependentPropertiesField.name, ticket)) {
+            const fieldToUpdate = getFields(sections).find(f => f.name === dependentPropertiesField.name);
+            if (fieldToUpdate && !arrayEquals(fieldToUpdate.valueConstraints, data.forms.fieldConstraints)) {
+                // Update field in place (for those who keep a constant ref on sectionsContext)
+                fieldToUpdate.valueConstraints = data.forms.fieldConstraints;
+                // And recreate the full sections object to make change detection work
+                recreate(sections);
+                updated = true;
+            }
+        }
+    });
+    return updated;
+};
+
 export const registerSelectorTypesOnChange = registry => {
     registry.add('selectorType.onChange', 'dependentProperties', {
         targets: ['*'],
@@ -110,20 +127,7 @@ export const registerSelectorTypesOnChange = registry => {
 
                 return undefined;
             })).then(results => {
-                let updated = false;
-                results.forEach(({data, dependentPropertiesField, ticket}) => {
-                    if (data?.forms?.fieldConstraints && isLatestTicket(sections, dependentPropertiesField.name, ticket)) {
-                        const fieldToUpdate = getFields(sections).find(f => f.name === dependentPropertiesField.name);
-                        if (fieldToUpdate && !arrayEquals(fieldToUpdate.valueConstraints, data.forms.fieldConstraints)) {
-                            // Update field in place (for those who keep a constant ref on sectionsContext)
-                            fieldToUpdate.valueConstraints = data.forms.fieldConstraints;
-                            // And recreate the full sections object to make change detection work
-                            recreate(sections);
-                            updated = true;
-                        }
-                    }
-                });
-                if (updated) {
+                if (applyFieldConstraints(results, sections)) {
                     onChangeContext.onSectionsUpdate();
                     console.debug(`Triggering update to field ${field.name} due to dependentProperties change.`);
                 }

--- a/src/javascript/ContentEditor/SelectorTypes/registerSelectorTypesOnChange.spec.js
+++ b/src/javascript/ContentEditor/SelectorTypes/registerSelectorTypesOnChange.spec.js
@@ -1,0 +1,106 @@
+import {registerSelectorTypesOnChange} from './registerSelectorTypesOnChange';
+import {getFields} from '~/ContentEditor/utils/fields.utils';
+
+describe('dependentProperties onChange', () => {
+    const pageConstraints = [
+        {value: {string: 'jnt:page'}, displayValue: 'jnt:page'},
+        {value: {string: 'jmix:mainResource'}, displayValue: 'jmix:mainResource'}
+    ];
+    const staleConstraints = [{value: {string: 'stale'}, displayValue: 'stale'}];
+
+    let handler;
+    let sections;
+    let linkTypeField;
+    let onChangeContext;
+
+    const deferred = () => {
+        let resolve;
+        const promise = new Promise(r => {
+            resolve = r;
+        });
+        return {promise, resolve};
+    };
+
+    const flush = () => new Promise(resolve => {
+        setTimeout(resolve, 0);
+    });
+
+    const getLinknodeConstraints = () => getFields(sections).find(f => f.name === 'nt_linknode').valueConstraints;
+
+    beforeEach(() => {
+        registerSelectorTypesOnChange({
+            add: (type, key, definition) => {
+                if (key === 'dependentProperties') {
+                    handler = definition;
+                }
+            }
+        });
+
+        linkTypeField = {
+            name: 'nt_linkType',
+            propertyName: 'j:linkType',
+            nodeType: 'nt:test',
+            selectorOptions: [],
+            valueConstraints: []
+        };
+        sections = [{
+            name: 'content',
+            fieldSets: [{
+                name: 'nt:test',
+                fields: [
+                    linkTypeField,
+                    {
+                        name: 'nt_linknode',
+                        propertyName: 'j:linknode',
+                        nodeType: 'nt:test',
+                        selectorOptions: [{name: 'dependentProperties', value: 'j:linkType'}],
+                        valueConstraints: []
+                    }
+                ]
+            }]
+        }];
+        onChangeContext = {
+            sections,
+            formik: {values: {}},
+            onSectionsUpdate: jest.fn(),
+            mode: 'create',
+            nodeTypeName: 'nt:test',
+            nodeData: {uuid: 'parent-uuid'},
+            lang: 'en',
+            uilang: 'en',
+            client: {query: jest.fn()}
+        };
+    });
+
+    it('should update the dependent field constraints from the query result', async () => {
+        onChangeContext.client.query.mockResolvedValue({data: {forms: {fieldConstraints: pageConstraints}}});
+
+        handler.onChange(undefined, 'internal', linkTypeField, onChangeContext);
+        await flush();
+
+        expect(getLinknodeConstraints()).toEqual(pageConstraints);
+        expect(onChangeContext.onSectionsUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should ignore a stale response resolving after a newer one', async () => {
+        const first = deferred();
+        const second = deferred();
+        onChangeContext.client.query
+            .mockReturnValueOnce(first.promise)
+            .mockReturnValueOnce(second.promise);
+
+        handler.onChange(undefined, 'none', linkTypeField, onChangeContext);
+        handler.onChange('none', 'internal', linkTypeField, onChangeContext);
+
+        // The newer request resolves first...
+        second.resolve({data: {forms: {fieldConstraints: pageConstraints}}});
+        await flush();
+        expect(getLinknodeConstraints()).toEqual(pageConstraints);
+
+        // ...then the older one; its result must not overwrite the newer constraints
+        first.resolve({data: {forms: {fieldConstraints: staleConstraints}}});
+        await flush();
+        expect(getLinknodeConstraints()).toEqual(pageConstraints);
+        expect(onChangeContext.onSectionsUpdate).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.jsx
@@ -250,6 +250,22 @@ export const Field = ({inputContext, idInput, selectorType, field}) => {
 
     const currentValue = values[field.name];
 
+    // Sections are replaced with a fresh server copy when the form reloads without remounting
+    // (language switch, see ContentEditorSection.context). That copy is computed from persisted
+    // state only, so it loses client-side handler effects (dependent valueConstraints, addMixin
+    // fieldset moves). Re-fire the registered handlers exactly as a fresh mount would; declared
+    // before the [currentValue] effect so a same-commit value+sections change fires only once.
+    const lastSectionsRef = useRef(sectionsContext.sections);
+    useEffect(() => {
+        if (lastSectionsRef.current !== sectionsContext.sections) {
+            lastSectionsRef.current = sectionsContext.sections;
+            onChangeValue.current = undefined;
+            if (currentValue !== null && currentValue !== undefined) {
+                registeredOnChangeRef.current(currentValue);
+            }
+        }
+    }, [sectionsContext.sections, currentValue]);
+
     useEffect(() => {
         if (initialValue.current !== null && initialValue.current !== undefined) {
             // Init

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.jsx
@@ -250,22 +250,6 @@ export const Field = ({inputContext, idInput, selectorType, field}) => {
 
     const currentValue = values[field.name];
 
-    // Sections are replaced with a fresh server copy when the form reloads without remounting
-    // (language switch, see ContentEditorSection.context). That copy is computed from persisted
-    // state only, so it loses client-side handler effects (dependent valueConstraints, addMixin
-    // fieldset moves). Re-fire the registered handlers exactly as a fresh mount would; declared
-    // before the [currentValue] effect so a same-commit value+sections change fires only once.
-    const lastSectionsRef = useRef(sectionsContext.sections);
-    useEffect(() => {
-        if (lastSectionsRef.current !== sectionsContext.sections) {
-            lastSectionsRef.current = sectionsContext.sections;
-            onChangeValue.current = undefined;
-            if (currentValue !== null && currentValue !== undefined) {
-                registeredOnChangeRef.current(currentValue);
-            }
-        }
-    }, [sectionsContext.sections, currentValue]);
-
     useEffect(() => {
         if (initialValue.current !== null && initialValue.current !== undefined) {
             // Init
@@ -278,9 +262,20 @@ export const Field = ({inputContext, idInput, selectorType, field}) => {
         };
     }, [count]);
 
+    // Sections are replaced with a fresh server copy when the form reloads without remounting
+    // (language switch, see ContentEditorSection.context). That copy is computed from persisted
+    // state only, so it loses client-side handler effects (dependent valueConstraints, addMixin
+    // fieldset moves). Forgetting the last notified value makes the call below re-fire the
+    // handlers exactly as a fresh mount would, even when the field value itself is unchanged.
+    const lastSectionsRef = useRef(sectionsContext.sections);
     useEffect(() => {
+        if (lastSectionsRef.current !== sectionsContext.sections) {
+            lastSectionsRef.current = sectionsContext.sections;
+            onChangeValue.current = undefined;
+        }
+
         registeredOnChangeRef.current(currentValue);
-    }, [currentValue]);
+    }, [currentValue, sectionsContext.sections]);
 
     const firstField = sectionsContext.sections ? sectionsContext.sections[0]?.fieldSets[0]?.fields[0] === field : false;
 

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.spec.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/FormBuilder/Field/Field.spec.jsx
@@ -17,6 +17,13 @@ jest.mock('~/ContentEditor/contexts/ContentEditor/ContentEditor.context', () => 
     };
 });
 
+let mockSectionsContext;
+jest.mock('~/ContentEditor/contexts/ContentEditorSection/ContentEditorSection.context', () => {
+    return {
+        useContentEditorSectionContext: () => (mockSectionsContext)
+    };
+});
+
 jest.mock('@apollo/client');
 
 jest.mock('react', () => {
@@ -92,6 +99,8 @@ describe('Field component', () => {
             idInput: 'FieldID'
         };
 
+        mockSectionsContext = {};
+
         result = {data: {forms: {fieldConstraints: []}}};
         useQuery.mockReturnValue(result);
     });
@@ -141,6 +150,70 @@ describe('Field component', () => {
         expect(result[0]).toBe(onChangePreviousValue);
         expect(result[1]).toBe(onChangeCurrentValue);
         expect(formik.setFieldValue).toHaveBeenCalledWith('text', onChangeCurrentValue);
+    });
+
+    it('should re-fire registered onChange when sections are reloaded', () => {
+        const calls = [];
+        registry.add('selectorType.onChange', 'sectionsReloadCallbacks', {
+            targets: ['DatePicker'],
+            onChange: (previousValue, currentValue) => {
+                calls.push([previousValue, currentValue]);
+            }
+        });
+
+        defaultProps.input = props => <Text {...props}/>;
+        defaultProps.field.multiple = false;
+        useFormikContext.mockReturnValue({
+            errors: {},
+            touched: {},
+            values: {text: 'internal'},
+            setFieldValue: jest.fn(),
+            setFieldTouched: jest.fn()
+        });
+        mockSectionsContext = {sections: [{name: 'content', fieldSets: []}]};
+
+        const cmp = shallowWithTheme(
+            <Field {...defaultProps}/>,
+            {},
+            dsGenericTheme
+        );
+
+        // Init fires the handlers once
+        expect(calls).toEqual([[undefined, 'internal']]);
+        calls.length = 0;
+
+        // Re-render with unchanged sections: no re-fire
+        cmp.setProps({idInput: 'FieldID'});
+        expect(calls).toEqual([]);
+
+        // Sections replaced by a reload (e.g. language switch): mount-like re-fire
+        mockSectionsContext = {sections: [{name: 'content', fieldSets: []}]};
+        cmp.setProps({idInput: 'FieldID'});
+        expect(calls).toEqual([[undefined, 'internal']]);
+    });
+
+    it('should not re-fire onChange on sections reload when field has no value', () => {
+        const calls = [];
+        registry.add('selectorType.onChange', 'sectionsReloadNoValueCallbacks', {
+            targets: ['DatePicker'],
+            onChange: (previousValue, currentValue) => {
+                calls.push([previousValue, currentValue]);
+            }
+        });
+
+        defaultProps.input = props => <Text {...props}/>;
+        defaultProps.field.multiple = false;
+        mockSectionsContext = {sections: [{name: 'content', fieldSets: []}]};
+
+        const cmp = shallowWithTheme(
+            <Field {...defaultProps}/>,
+            {},
+            dsGenericTheme
+        );
+
+        mockSectionsContext = {sections: [{name: 'content', fieldSets: []}]};
+        cmp.setProps({idInput: 'FieldID'});
+        expect(calls).toEqual([]);
     });
 
     it('should render a "Shared in all languages" when field is not i18n and site have multiple languages', () => {

--- a/tests/cypress/e2e/contentEditor/shard1/languageSwitchDependentFields.cy.ts
+++ b/tests/cypress/e2e/contentEditor/shard1/languageSwitchDependentFields.cy.ts
@@ -57,11 +57,13 @@ describe('Language switch keeps dependent fields driven by unsaved changes', () 
         picker.select();
         pickerField.assertValue('Home');
 
-        // Switch to French without saving: the unsaved link type must keep the picker in the form
+        // Switch to French without saving: the unsaved link type must keep the picker in the form.
+        // The card label is the target's displayName resolved in the editing language; the home
+        // page has no French title, so it falls back to the node name 'home'.
         contentEditor.getLanguageSwitcher().selectLangByValue('fr');
         cy.wait('@createForm');
         linknodeIsVisible();
-        contentEditor.getPickerField(linknodeField).assertValue('Home');
+        contentEditor.getPickerField(linknodeField).assertValue('home');
 
         // And survive the round trip back to English
         contentEditor.getLanguageSwitcher().selectLangByValue('en');

--- a/tests/cypress/e2e/contentEditor/shard1/languageSwitchDependentFields.cy.ts
+++ b/tests/cypress/e2e/contentEditor/shard1/languageSwitchDependentFields.cy.ts
@@ -1,0 +1,72 @@
+import {createSite, deleteSite} from '@jahia/cypress';
+import {JContent} from '../../../page-object';
+
+// The internal-link page picker (j:linknode) only renders as a picker once the dependentProperties
+// handler has fetched its valueConstraints from the unsaved j:linkType value. Switching the editing
+// language reloads the form from persisted state, so those client-computed constraints (and the
+// addMixin fieldset placement) must be restored without a save (see #2447 regression).
+describe('Language switch keeps dependent fields driven by unsaved changes', () => {
+    const siteKey = 'langSwitchDependentFields';
+    const linkTypeField = 'jnt:imageReferenceLink_j:linkType';
+    const linknodeField = 'jmix:internalLink_j:linknode';
+
+    const linknodeIsEditorialLinkPicker = () => {
+        cy.get(`[data-sel-content-editor-field="${linknodeField}"]`, {timeout: 10000})
+            .should('be.visible')
+            .and('have.attr', 'data-sel-content-editor-field-picker-type', 'editoriallink');
+    };
+
+    before(() => {
+        createSite(siteKey, {
+            languages: 'en,fr',
+            templateSet: 'dx-base-demo-templates',
+            serverName: 'localhost',
+            locale: 'en'
+        });
+    });
+
+    after(() => {
+        cy.logout();
+        deleteSite(siteKey);
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession();
+    });
+
+    it('keeps the internal link page picker when switching language without saving', () => {
+        const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+        const contentEditor = jcontent.createContent('jnt:imageReferenceLink');
+
+        cy.intercept('POST', '**/modules/graphql', req => {
+            if (JSON.stringify(req.body).includes('fieldConstraints')) {
+                req.alias = 'fieldConstraints';
+            }
+        });
+
+        contentEditor.getChoiceListField(linkTypeField).selectValue('internal');
+        cy.wait('@fieldConstraints');
+        linknodeIsEditorialLinkPicker();
+
+        const pickerField = contentEditor.getPickerField(linknodeField);
+        const picker = pickerField.open();
+        picker.wait();
+        picker.getTable().getRowByName('home').get().click();
+        picker.select();
+        pickerField.assertValue('Home');
+
+        // Switch to French without saving: the unsaved link type must keep driving the picker
+        contentEditor.getLanguageSwitcher().selectLangByValue('fr');
+        cy.wait('@fieldConstraints');
+        linknodeIsEditorialLinkPicker();
+        contentEditor.getPickerField(linknodeField).assertValue('Home');
+
+        // And survive the round trip back to English
+        contentEditor.getLanguageSwitcher().selectLangByValue('en');
+        cy.wait('@fieldConstraints');
+        linknodeIsEditorialLinkPicker();
+        contentEditor.getPickerField(linknodeField).assertValue('Home');
+
+        contentEditor.cancelAndDiscard();
+    });
+});

--- a/tests/cypress/e2e/contentEditor/shard1/languageSwitchDependentFields.cy.ts
+++ b/tests/cypress/e2e/contentEditor/shard1/languageSwitchDependentFields.cy.ts
@@ -1,19 +1,17 @@
 import {createSite, deleteSite} from '@jahia/cypress';
 import {JContent} from '../../../page-object';
 
-// The internal-link page picker (j:linknode) only renders as a picker once the dependentProperties
-// handler has fetched its valueConstraints from the unsaved j:linkType value. Switching the editing
-// language reloads the form from persisted state, so those client-computed constraints (and the
-// addMixin fieldset placement) must be restored without a save (see #2447 regression).
+// Selecting link type 'internal' activates the jmix:internalLink mixin: the addMixin onChange
+// handler places the j:linknode page picker into the form. Switching the editing language reloads
+// the form from persisted state, so this client-side placement (and dependent valueConstraints in
+// general) must be restored while the change is still unsaved (#2447 regression).
 describe('Language switch keeps dependent fields driven by unsaved changes', () => {
     const siteKey = 'langSwitchDependentFields';
     const linkTypeField = 'jnt:imageReferenceLink_j:linkType';
     const linknodeField = 'jmix:internalLink_j:linknode';
 
-    const linknodeIsEditorialLinkPicker = () => {
-        cy.get(`[data-sel-content-editor-field="${linknodeField}"]`, {timeout: 10000})
-            .should('be.visible')
-            .and('have.attr', 'data-sel-content-editor-field-picker-type', 'editoriallink');
+    const linknodeIsVisible = () => {
+        cy.get(`[data-sel-content-editor-field="${linknodeField}"]`, {timeout: 10000}).should('be.visible');
     };
 
     before(() => {
@@ -36,17 +34,21 @@ describe('Language switch keeps dependent fields driven by unsaved changes', () 
 
     it('keeps the internal link page picker when switching language without saving', () => {
         const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
-        const contentEditor = jcontent.createContent('jnt:imageReferenceLink');
 
+        // The form definition is refetched on every language switch; waiting on it anchors the
+        // assertions after the reload, when the stale form is replaced (and the picker would be
+        // lost without the fix).
         cy.intercept('POST', '**/modules/graphql', req => {
-            if (JSON.stringify(req.body).includes('fieldConstraints')) {
-                req.alias = 'fieldConstraints';
+            if (JSON.stringify(req.body).includes('createForm')) {
+                req.alias = 'createForm';
             }
         });
 
+        const contentEditor = jcontent.createContent('jnt:imageReferenceLink');
+        cy.wait('@createForm');
+
         contentEditor.getChoiceListField(linkTypeField).selectValue('internal');
-        cy.wait('@fieldConstraints');
-        linknodeIsEditorialLinkPicker();
+        linknodeIsVisible();
 
         const pickerField = contentEditor.getPickerField(linknodeField);
         const picker = pickerField.open();
@@ -55,16 +57,16 @@ describe('Language switch keeps dependent fields driven by unsaved changes', () 
         picker.select();
         pickerField.assertValue('Home');
 
-        // Switch to French without saving: the unsaved link type must keep driving the picker
+        // Switch to French without saving: the unsaved link type must keep the picker in the form
         contentEditor.getLanguageSwitcher().selectLangByValue('fr');
-        cy.wait('@fieldConstraints');
-        linknodeIsEditorialLinkPicker();
+        cy.wait('@createForm');
+        linknodeIsVisible();
         contentEditor.getPickerField(linknodeField).assertValue('Home');
 
         // And survive the round trip back to English
         contentEditor.getLanguageSwitcher().selectLangByValue('en');
-        cy.wait('@fieldConstraints');
-        linknodeIsEditorialLinkPicker();
+        cy.wait('@createForm');
+        linknodeIsVisible();
         contentEditor.getPickerField(linknodeField).assertValue('Home');
 
         contentEditor.cancelAndDiscard();


### PR DESCRIPTION
### Description
This PR fixes a bug where the language is switched in CE form, and some pickers loose internal state.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
