### PR TITLE
docs: describe findAvailableNodeName GraphQL arguments

### DIFF
--- a/src/main/java/org/jahia/modules/contenteditor/graphql/extensions/JCRNodeContentEditorExtensions.java
+++ b/src/main/java/org/jahia/modules/contenteditor/graphql/extensions/JCRNodeContentEditorExtensions.java
@@ -63,7 +63,7 @@ public class JCRNodeContentEditorExtensions {
     @GraphQLField
     @GraphQLName("findAvailableNodeName")
     @GraphQLDescription("Returns the next available name for a node, appending if needed numbers.")
-    public String findAvailableNodeName(@GraphQLName("nodeType") String nodeTypeName, @GraphQLName("language") String language) {
+    public String findAvailableNodeName(@GraphQLName("nodeType") @GraphQLDescription("Node type used to generate the base name") String nodeTypeName, @GraphQLName("language") @GraphQLDescription("Language used to resolve the node type label") String language) {
         try {
             ExtendedNodeType nodeType = NodeTypeRegistry.getInstance().getNodeType(nodeTypeName);
 


### PR DESCRIPTION
## Summary

Adds `@GraphQLDescription` to the two arguments of the `findAvailableNodeName` JCRNode extension field.

## Why

`findAvailableNodeName(nodeType, language)` (a content-editor extension on JCRNode) documents the field itself but not its arguments. They are reachable under `JahiaAdminQuery` via the Tag Manager backend, where `server-availability-manager`'s schema-description test requires every node to be documented. These two arguments were the last undocumented nodes flagged by that test (see `Jahia/server-availability-manager#251`).

## Changes

- `JCRNodeContentEditorExtensions#findAvailableNodeName`: `@GraphQLDescription` on the `nodeType` and `language` arguments.

## Validation

Built jcontent from this branch, deployed on a current `jahia-ee-dev:8-SNAPSHOT` (alongside the companion graphql-core fix), and ran SAM's `apiDescription.spec` → **passes** (undocumented-node count under `JahiaAdminQuery` reaches 0).

Refs Jahia/server-availability-manager#251
