### PR TITLE
feat: Show the functional staging and live URLs for files in sidepanel

### DIFF
--- a/.chachalog/czL6Is8J.md
+++ b/.chachalog/czL6Is8J.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Show the functional staging and live URLs for files in the content details technical information, and remove the not-yet-mature links section

--- a/.chachalog/czL6Is8J.md
+++ b/.chachalog/czL6Is8J.md
@@ -1,6 +1,0 @@
----
-# Allowed version bumps: patch, minor, major
-"@jahia/jcontent": minor
----
-
-Show the functional staging and live URLs for files in the content details technical information, and remove the not-yet-mature links section

--- a/src/javascript/JContent/SidePanel/ContentDetails/ContentDetails.jsx
+++ b/src/javascript/JContent/SidePanel/ContentDetails/ContentDetails.jsx
@@ -136,6 +136,8 @@ const encodePathSegments = path => (path || '')
     .map(segment => encodeURIComponent(segment))
     .join('/');
 
+// Retained for an upcoming rework of the links section; not rendered for now as it is not yet mature.
+// eslint-disable-next-line no-unused-vars
 const ContentLinks = () => {
     const {t} = useTranslation('jcontent');
     const {nodeData, siteInfo, hasPreview} = useSidePanelContext();
@@ -236,6 +238,43 @@ const ContentLinks = () => {
     );
 };
 
+// Links section for files: shows the functional staging and live URLs. Built with the same logic
+// as the download dialog's "copy URL" (see DownloadFileDialog).
+const FileLinks = () => {
+    const {t} = useTranslation('jcontent');
+    const {nodeData} = useSidePanelContext();
+
+    const isFile = nodeData?.primaryNodeType?.name === 'jnt:file' ||
+        (nodeData?.primaryNodeType?.supertypes || []).some(type => type.name === 'jnt:file');
+
+    if (!isFile) {
+        return null;
+    }
+
+    const contextPath = window.contextJsParameters?.contextPath || '';
+    const buildFileUrl = mode => new URL(`${contextPath}/files/${mode}${nodeData.path}`, window.location.href).toString();
+    const stagingUrl = buildFileUrl('default');
+    const liveUrl = buildFileUrl('live');
+
+    return (
+        <div className={styles.section} data-sel-role="details-section" data-sel-content="links">
+            <Typography variant="subheading" className={styles.sectionTitle}>
+                {t('jcontent:label.contentEditor.sidePanel.links')}
+            </Typography>
+            <LinkRow
+                label={t('jcontent:label.contentEditor.sidePanel.linksDefault')}
+                displayValue={stagingUrl}
+                copyValue={stagingUrl}
+            />
+            <LinkRow
+                label={t('jcontent:label.contentEditor.sidePanel.linksLive')}
+                displayValue={liveUrl}
+                copyValue={liveUrl}
+            />
+        </div>
+    );
+};
+
 export const ContentDetails = () => {
     const {t} = useTranslation('jcontent');
     const {nodeData, technicalInfo, details} = useSidePanelContext();
@@ -271,7 +310,7 @@ export const ContentDetails = () => {
                 </div>
             )}
 
-            <ContentLinks/>
+            <FileLinks/>
 
             {technicalInfo && technicalInfo.length > 0 && (
                 <div className={styles.section} data-sel-role="details-section" data-sel-content="technical">

--- a/src/javascript/JContent/SidePanel/ContentDetails/ContentDetails.jsx
+++ b/src/javascript/JContent/SidePanel/ContentDetails/ContentDetails.jsx
@@ -244,10 +244,7 @@ const FileLinks = () => {
     const {t} = useTranslation('jcontent');
     const {nodeData} = useSidePanelContext();
 
-    const isFile = nodeData?.primaryNodeType?.name === 'jnt:file' ||
-        (nodeData?.primaryNodeType?.supertypes || []).some(type => type.name === 'jnt:file');
-
-    if (!isFile) {
+    if (!nodeData?.isFile) {
         return null;
     }
 


### PR DESCRIPTION
### Description
Show the functional staging and live URLs for files in sidepanel's technical details and remove links for other content types. 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
