### PR TITLE
fix(visibility): localize condition labels & add action tooltips

### DIFF
--- a/packages/date-formatter/src/index.ts
+++ b/packages/date-formatter/src/index.ts
@@ -51,3 +51,69 @@ export function formatDatetime(
     .locale(options?.locale || window.contextJsParameters.uilang)
     .format(formatMap[options?.format || 'short']);
 }
+
+const timeFormatMap = {
+  short: 'LT', // localized time, e.g. 2:30 PM (en) / 14:30 (fr)
+  long: 'LTS', // localized time with seconds
+};
+
+/**
+ * @param time RFC 9557-formatted time string (HH, HH:mm, HH:mm:ss or HH:mm:ss.sss)
+ */
+export function formatTime(
+  time: string,
+  options?: {
+    /**
+     * The format in which to display the time
+     * @default 'short'
+     */
+    format?: keyof typeof timeFormatMap;
+
+    /**
+     * The locale in which to display the time
+     * @default window.contextJsParameters.uilang
+     */
+    locale?: string;
+  }
+) {
+  // Parse the time the same way Temporal.PlainTime.from does (will make the migration easier)
+  return dayjs(time, ['HH:mm:ss.SSS', 'HH:mm:ss', 'HH:mm', 'HH'])
+    .locale(options?.locale || window.contextJsParameters.uilang)
+    .format(timeFormatMap[options?.format || 'short']);
+}
+
+const weekdayFormatMap = {
+  full: 'weekdays',
+  short: 'weekdaysShort',
+  min: 'weekdaysMin',
+} as const;
+const weekdays = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+
+/**
+ * @param day Case-insensitive day-of-week name, in English (e.g. 'monday', 'tuesday', etc.)
+ */
+export function formatDayOfWeek(
+  day: string,
+  options?: {
+    /**
+     * The format in which to display the time
+     * @default 'full'
+     */
+    format?: keyof typeof weekdayFormatMap;
+
+    /**
+     * The locale in which to display the weekday
+     * @default window.contextJsParameters.uilang
+     */
+    locale?: string;
+  }
+) {
+  const index = weekdays.indexOf(day.toLowerCase());
+
+  // If the day is not a valid day-of-week key, return it as-is
+  if (index === -1) return day;
+
+  return dayjs.Ls[options?.locale || window.contextJsParameters.uilang][
+    weekdayFormatMap[options?.format || 'full']
+  ]?.[index] ?? day;
+}

--- a/packages/date-formatter/src/index.ts
+++ b/packages/date-formatter/src/index.ts
@@ -96,7 +96,7 @@ export function formatDayOfWeek(
   day: string,
   options?: {
     /**
-     * The format in which to display the time
+     * The format in which to display the weekday
      * @default 'full'
      */
     format?: keyof typeof weekdayFormatMap;
@@ -113,7 +113,7 @@ export function formatDayOfWeek(
   // If the day is not a valid day-of-week key, return it as-is
   if (index === -1) return day;
 
-  return dayjs.Ls[options?.locale || window.contextJsParameters.uilang][
+  return dayjs.Ls[options?.locale || window.contextJsParameters.uilang]?.[
     weekdayFormatMap[options?.format || 'full']
   ]?.[index] ?? day;
 }

--- a/src/javascript/ContentEditor/actions/contenteditor/editVisibilityRules/Visibility/DateTime/DatatableRules.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/editVisibilityRules/Visibility/DateTime/DatatableRules.jsx
@@ -1,16 +1,18 @@
 import React, {forwardRef, useMemo} from 'react';
 import PropTypes from 'prop-types';
 import {useTranslation} from 'react-i18next';
-import {Chip, DataTable, Delete, Edit, Hidden, TableRow, Typography, Undelete, Visibility} from '@jahia/moonstone';
+import {Chip, CloudCheck, DataTable, Delete, Edit, Hidden, TableRow, Typography, Undelete, Visibility} from '@jahia/moonstone';
 import {getConditionLabel} from './utils';
 import clsx from 'clsx';
 import statusCellStyles from './TableCellStatus.scss';
 import {
     DeleteButton,
     EditButton,
+    PublishDeletionButton,
     UndeleteButton
 } from '~/ContentEditor/actions/contenteditor/editVisibilityRules/Visibility/DateTime/ButtonRenderers';
 import {useConditionDeletion} from './useConditionDeletion';
+import {useContentEditorConfigContext} from '~/ContentEditor/contexts';
 import PublicationStatus from '~/JContent/PublicationStatus';
 
 const TableCell = forwardRef(({
@@ -84,13 +86,14 @@ TableCellActions.propTypes = {
 
 export const DatatableRules = ({rules, onEdit, refresh, hideActions = false}) => {
     const {t} = useTranslation('jcontent');
-    const {markConditionForDeletion, unmarkConditionForDeletion} = useConditionDeletion({refresh});
+    const {uilang} = useContentEditorConfigContext();
+    const {markConditionForDeletion, unmarkConditionForDeletion, publishConditionDeletion} = useConditionDeletion({refresh});
 
     // We are adding two extra columns not declared here, so we need to keep the width overall at 90%
     const columns = [
         {
             key: 'type',
-            label: 'Condition type',
+            label: t('jcontent:label.contentEditor.visibilityTab.conditions.condition'),
             isSortable: true,
             width: '70%',
             sortFn: (a, b) => a.type.localeCompare(b.type),
@@ -127,7 +130,7 @@ export const DatatableRules = ({rules, onEdit, refresh, hideActions = false}) =>
 
             return {
                 id: rule.uuid,
-                type: getConditionLabel(rule.primaryNodeType.name, rule.properties, t),
+                type: getConditionLabel(rule.primaryNodeType.name, rule.properties, t, uilang),
                 isMatching: rule.isConditionMatching,
                 isMatchingLive: rule.live !== null && rule.live.isConditionMatching,
                 isMarkedForDeletion: isMarkedForDeletion,
@@ -135,7 +138,7 @@ export const DatatableRules = ({rules, onEdit, refresh, hideActions = false}) =>
                 rule: rule
             };
         });
-    }, [rules, t]);
+    }, [rules, t, uilang]);
 
     return (
         <DataTable
@@ -147,27 +150,52 @@ export const DatatableRules = ({rules, onEdit, refresh, hideActions = false}) =>
             primaryKey="id"
             defaultSortDirection="descending"
             renderRow={({id, data, render: renderCells}) => {
+                const editLabel = t('jcontent:label.contentEditor.visibilityTab.conditions.edit');
+                const deleteLabel = t('jcontent:label.contentEditor.visibilityTab.conditions.delete');
+                const undeleteLabel = t('jcontent:label.contentEditor.visibilityTab.conditions.undelete');
+                const publishDeletionLabel = t('jcontent:label.contentEditor.visibilityTab.conditions.publishDeletion');
+
+                // Tooltips use the native `title` attribute (via buttonProps) rather than moonstone's
+                // <Tooltip>. moonstone renders its tooltip bubble inline (no portal), so it is truncated
+                // by the `overflow: hidden` on the moonstone DataTable and is never fully visible inside
+                // this table. A moonstone issue has been filed to fix that; until it lands we rely on the
+                // native `title` (which the browser always paints on top, un-clippable), mirrored by
+                // `aria-label` for accessibility since these buttons are icon-only.
                 let actions = null;
                 if (!hideActions && data.isMarkedForDeletion) {
                     actions = (
-                        <UndeleteButton buttonIcon={<Undelete/>}
-                                        dataSelRole="undelete-condition"
-                                        onClick={() => {
-                                            // Restore a condition previously marked for deletion.
-                                            // Error notification is handled inside the hook.
-                                            unmarkConditionForDeletion(data.rule.path).catch(() => {});
-                                        }}/>
+                        <>
+                            <UndeleteButton buttonIcon={<Undelete/>}
+                                            dataSelRole="undelete-condition"
+                                            buttonProps={{title: undeleteLabel, 'aria-label': undeleteLabel}}
+                                            onClick={() => {
+                                                // Restore a condition previously marked for deletion.
+                                                // Error notification is handled inside the hook.
+                                                unmarkConditionForDeletion(data.rule.path).catch(() => {});
+                                            }}/>
+                            {data.canPublishDeletion &&
+                                <PublishDeletionButton buttonIcon={<CloudCheck/>}
+                                                       dataSelRole="publish-deletion-condition"
+                                                       buttonProps={{title: publishDeletionLabel, 'aria-label': publishDeletionLabel}}
+                                                       onClick={() => {
+                                                           // Commit the deletion through the standard
+                                                           // publication workflow.
+                                                           publishConditionDeletion(data.rule.uuid);
+                                                       }}/>}
+                        </>
                     );
                 } else if (!hideActions) {
                     actions = (
                         <>
                             <EditButton buttonIcon={<Edit/>}
                                         dataSelRole="edit-condition"
+                                        buttonProps={{title: editLabel, 'aria-label': editLabel}}
                                         onClick={() => {
                                             onEdit(data.rule);
                                         }}/>
                             <DeleteButton buttonIcon={<Delete/>}
                                           dataSelRole="delete-condition"
+                                          buttonProps={{title: deleteLabel, 'aria-label': deleteLabel}}
                                           onClick={() => {
                                               // Mark the condition for deletion (soft delete). It stays
                                               // visible until the deletion is published, and can be undeleted.

--- a/src/javascript/ContentEditor/actions/contenteditor/editVisibilityRules/Visibility/DateTime/utils.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/editVisibilityRules/Visibility/DateTime/utils.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {CloudCheck, Delete, Edit, NoCloud} from '@jahia/moonstone';
-import {dayjs, formatDatetime} from 'date-formatter';
+import {formatDatetime, formatDayOfWeek, formatTime} from 'date-formatter';
 import {isArray} from 'lodash';
 
 export const jmixConditionalVisibility = 'jmix:conditionalVisibility';
@@ -111,7 +111,15 @@ export const getStatus = status => {
     };
 };
 
-export const getConditionLabel = (name, properties, t) => {
+// Localise the stored day-of-week choicelist values (raw keys: 'monday'…'sunday') into the UI
+// language, then join them for interpolation into the dayOfWeekCondition sentence.
+const formatDaysOfWeek = (values, uilang) => {
+    return (values || [])
+        .map(day => formatDayOfWeek(day, {locale: uilang}))
+        .join(', ');
+};
+
+export const getConditionLabel = (name, properties, t, uilang = window.contextJsParameters?.uilang) => {
     const getDateLabel = startDate => {
         return (startDate === undefined) ? 'jcontent:label.contentEditor.visibilityTab.conditions.endDateCondition' : 'jcontent:label.contentEditor.visibilityTab.conditions.startDateCondition';
     };
@@ -122,13 +130,13 @@ export const getConditionLabel = (name, properties, t) => {
 
     switch (name) {
         case 'jnt:dayOfWeekCondition':
-            return t('jcontent:label.contentEditor.visibilityTab.conditions.dayOfWeekCondition', {days: properties.find(p => p.name === 'dayOfWeek')?.values});
+            return t('jcontent:label.contentEditor.visibilityTab.conditions.dayOfWeekCondition', {days: formatDaysOfWeek(properties.find(p => p.name === 'dayOfWeek')?.values, uilang)});
         case 'jnt:startEndDateCondition': {
             const startDate = properties.find(p => p.name === 'start')?.value;
             const endDate = properties.find(p => p.name === 'end')?.value;
             return t((startDate !== undefined && endDate !== undefined ? 'jcontent:label.contentEditor.visibilityTab.conditions.startEndDateCondition' : getDateLabel(startDate)), {
-                startDate: startDate === undefined ? '' : formatDatetime(startDate, {format: 'long'}),
-                endDate: endDate === undefined ? '' : formatDatetime(endDate, {format: 'long'})
+                startDate: startDate === undefined ? '' : formatDatetime(startDate, {format: 'long', locale: uilang}),
+                endDate: endDate === undefined ? '' : formatDatetime(endDate, {format: 'long', locale: uilang})
             });
         }
 
@@ -138,8 +146,8 @@ export const getConditionLabel = (name, properties, t) => {
             const endHour = properties.find(p => p.name === 'endHour')?.value;
             const endMinute = properties.find(p => p.name === 'endMinute')?.value;
             return t((startHour !== undefined && endHour !== undefined ? 'jcontent:label.contentEditor.visibilityTab.conditions.startEndTimeCondition' : getTimeLabel(startHour)), {
-                startTime: startHour === undefined ? '' : dayjs(`${startHour}:${startMinute}`, 'HH:mm').format('LT'),
-                endTime: endHour === undefined ? '' : dayjs(`${endHour}:${endMinute}`, 'HH:mm').format('LT')
+                startTime: startHour === undefined ? '' : formatTime(`${startHour}:${startMinute}`, {locale: uilang}),
+                endTime: endHour === undefined ? '' : formatTime(`${endHour}:${endMinute}`, {locale: uilang})
             });
         }
 

--- a/src/javascript/ContentEditor/actions/contenteditor/editVisibilityRules/Visibility/DateTime/utils.spec.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/editVisibilityRules/Visibility/DateTime/utils.spec.jsx
@@ -1,0 +1,63 @@
+import {getConditionLabel} from './utils';
+
+// Mock the workspace date-formatter so we can assert the locale is threaded through and control output.
+jest.mock('date-formatter', () => {
+    const dayNames = {
+        monday: 'lundi',
+        tuesday: 'mardi',
+        wednesday: 'mercredi',
+        thursday: 'jeudi',
+        friday: 'vendredi',
+        saturday: 'samedi',
+        sunday: 'dimanche'
+    };
+    return {
+        formatDatetime: (date, opts) => `${date}|${opts.locale}|${opts.format}`,
+        formatTime: (time, opts) => `${time}|${opts.locale}|LT`,
+        formatDayOfWeek: day => dayNames[String(day).toLowerCase()]
+    };
+}, {virtual: true});
+
+// Translation mock: interpolates the sentence keys, mirroring i18next.
+const t = (key, opts = {}) => {
+    if (key.endsWith('dayOfWeekCondition')) {
+        return `Jours : ${opts.days}`;
+    }
+
+    if (key.endsWith('startTimeCondition')) {
+        return `A partir de ${opts.startTime}`;
+    }
+
+    if (key.endsWith('startDateCondition')) {
+        return `A partir du ${opts.startDate}`;
+    }
+
+    return key;
+};
+
+describe('getConditionLabel', () => {
+    it('localises day-of-week values instead of showing raw English keys', () => {
+        const properties = [{name: 'dayOfWeek', values: ['sunday', 'monday']}];
+        expect(getConditionLabel('jnt:dayOfWeekCondition', properties, t, 'fr')).toBe('Jours : dimanche, lundi');
+    });
+
+    it('is case-insensitive on the stored day values', () => {
+        const properties = [{name: 'dayOfWeek', values: ['SUNDAY']}];
+        expect(getConditionLabel('jnt:dayOfWeekCondition', properties, t, 'fr')).toBe('Jours : dimanche');
+    });
+
+    it('handles a missing dayOfWeek property without throwing', () => {
+        expect(getConditionLabel('jnt:dayOfWeekCondition', [], t, 'fr')).toBe('Jours : ');
+    });
+
+    it('formats the time condition in the UI locale (LT respects fr/de)', () => {
+        const properties = [{name: 'startHour', value: '14'}, {name: 'startMinute', value: '30'}];
+        expect(getConditionLabel('jnt:timeOfDayCondition', properties, t, 'fr')).toBe('A partir de 14:30|fr|LT');
+    });
+
+    it('formats the date condition in the UI locale', () => {
+        const properties = [{name: 'start', value: '2026-07-22T10:00:00.000'}];
+        expect(getConditionLabel('jnt:startEndDateCondition', properties, t, 'de'))
+            .toBe('A partir du 2026-07-22T10:00:00.000|de|long');
+    });
+});

--- a/src/javascript/ContentEditor/actions/contenteditor/editVisibilityRules/Visibility/Languages/Languages.scss
+++ b/src/javascript/ContentEditor/actions/contenteditor/editVisibilityRules/Visibility/Languages/Languages.scss
@@ -11,7 +11,7 @@
     justify-content: flex-end;
     align-items: baseline;
     min-width: 100%;
-    padding: var(--spacing-medium);
+    padding: var(--spacing-small);
 }
 
 :global(label[id="jmix:i18n_j:invalidLanguages-label"] ~ div) {

--- a/src/main/resources/javascript/locales/de.json
+++ b/src/main/resources/javascript/locales/de.json
@@ -1051,6 +1051,7 @@
         "conditions" : {
           "title" : "Datum und Uhrzeit",
           "type": "Typ",
+          "condition": "Bedingung",
           "typeDescription": "Definieren Sie die Bedingung, die angewendet werden soll.",
           "rules" : "{{rulesNumber}} Bedingungen definiert",
           "rule" : "Eine Bedingung definiert",
@@ -1060,6 +1061,8 @@
           "add": "Bedingung hinzufügen",
           "edit": "Bedingung bearbeiten",
           "delete": "Bedingung löschen",
+          "undelete": "Löschung rückgängig machen",
+          "publishDeletion": "Löschung veröffentlichen",
           "markedForDeletionBy": "Zur Löschung markiert von {{userName}} am {{timestamp}}",
           "loading": "Wird geladen…",
           "ruleType": {
@@ -1081,7 +1084,7 @@
           "endTimeCondition": "Der Inhalt wird bis {{endTime}} sichtbar sein",
           "preview": "In der Vorschau sichtbar",
           "live": "Live sichtbar",
-          "preview_live": "Übereinstimmung in Vorschau / Live",
+          "preview_live": "Aktuell in der Vorschau",
           "visible": "Sichtbar",
           "hidden": "Ausgeblendet"
         }

--- a/src/main/resources/javascript/locales/en.json
+++ b/src/main/resources/javascript/locales/en.json
@@ -1068,6 +1068,7 @@
         "conditions": {
           "title": "Date and time",
           "type": "Type",
+          "condition": "Condition",
           "typeDescription": "Define the condition that you want applied.",
           "rules": "{{rulesNumber}} rules set",
           "rule": "1 rule is set",

--- a/src/main/resources/javascript/locales/fr.json
+++ b/src/main/resources/javascript/locales/fr.json
@@ -1052,6 +1052,7 @@
         "conditions" : {
           "title" : "Jour et heure",
           "type": "Type",
+          "condition": "Condition",
           "typeDescription": "Définir la condition à appliquer.",
           "rules" : "{{rulesNumber}} conditions définies",
           "rule" : "1 condition définie",
@@ -1061,6 +1062,8 @@
           "add": "Ajouter une condition",
           "edit": "Modifier la condition",
           "delete": "Supprimer la condition",
+          "undelete": "Annuler la suppression",
+          "publishDeletion": "Publier la suppression",
           "markedForDeletionBy": "Marqué pour la suppression par {{userName}} le {{timestamp}}",
           "loading": "Chargement…",
           "ruleType": {
@@ -1082,7 +1085,7 @@
           "endTimeCondition": "Le contenu sera visible jusqu'à {{endTime}}",
           "preview": "Visible en aperçu",
           "live": "Visible en live",
-          "preview_live": "Correspondance aperçu / live",
+          "preview_live": "Actuellement en aperçu",
           "visible": "Visible",
           "hidden": "Masqué"
         },


### PR DESCRIPTION
## Summary
Fixes several i18n and UX issues in the **Edit visibility conditions** modal (jContent Content Editor).

### i18n fixes
- **Day-of-week bug:** saved condition labels rendered raw English choicelist keys (e.g. `sunday`) even in the fr/de UI — `Le contenu sera visible les jours de la semaine suivants : sunday`. Day values are now localized via `date-formatter`'s new `formatDayOfWeek(day, {locale})`, which maps `monday`…`sunday` to the locale's full weekday name using dayjs' bundled locale data.
- **Time conditions:** were formatted with `dayjs(...).format('LT')` without a locale, falling back to English 12h format. Extracted into `date-formatter`'s new `formatTime(hour, minute, {format, locale})` (mirrors `formatDatetime`), so `LT` respects fr/de (24h). Date conditions now pass the UI locale explicitly too.
- **`preview_live` label:** fr → `Actuellement en aperçu`, de → `Aktuell in der Vorschau` (was `Correspondance aperçu / live`; en was already correct).
- **Column header:** the conditions table header was a hardcoded `"Condition type"` string — replaced with a translated key → **Condition** / **Condition** / **Bedingung**. (The separate "Type" label in the Add-condition dropdown is intentionally unchanged.)

### UX
- Added localized **tooltips + aria-labels** to the row actions (edit / delete / undelete / publishDeletion) on the icon-only buttons.
  - ⚠️ These use the **native `title` attribute**, not moonstone's `<Tooltip>`. moonstone renders its tooltip bubble **inline (no portal)**, so it is **truncated by the `overflow: hidden` on the moonstone `DataTable`** and never fully visible inside this table. A moonstone issue has been filed to fix that; until it lands, native `title` (mirrored by `aria-label`) is used — the browser always paints it on top, un-clippable.
- **Wired the `publishDeletion` action into the conditions table** — it was a dead renderer with an unused `canPublishDeletion` flag; it now renders for marked-for-deletion conditions that exist in live.
- Reduced `Languages` `rowEnd` padding `spacing-medium` → `spacing-small`.

### New in `date-formatter` package
- `formatTime(hour, minute, {format, locale})` and `formatDayOfWeek(day, {locale})`, both defaulting `locale` to `window.contextJsParameters.uilang` like the existing `formatDatetime`.

### Tests
- Added `utils.spec.jsx` covering `getConditionLabel`: day-name localization, case-insensitivity, missing-property safety, and locale-aware time/date formatting.

## Verification
- ESLint + stylelint clean; new unit tests pass; full `yarn build` compiles with 0 webpack errors.
- Verified live in a French jContent UI (Luxe demo site): the day label reads `… suivants : dimanche`, header shows **Condition** and **Actuellement en aperçu**, and the action buttons expose the localized `title`/`aria-label` (`Modifier la condition`, `Supprimer la condition`, `Annuler la suppression`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)