### PR TITLE
fix: Copy language does not reflect available options

### DIFF
--- a/.chachalog/PE5w5sWI.md
+++ b/.chachalog/PE5w5sWI.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Copy language dialog now always displays available source languages  (#2606)

--- a/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/CopyLanguageDialog.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/CopyLanguageDialog.jsx
@@ -16,7 +16,6 @@ export const CopyLanguageDialog = ({
     onCloseDialog,
     uuid,
     formik,
-    sideBySideContext,
     defaultLanguage
 }) => {
     const client = useApolloClient();
@@ -41,22 +40,16 @@ export const CopyLanguageDialog = ({
         onCloseDialog();
     };
 
-    // Override selected option with sbsOption from translate action if it exists and use that as source language
-    const sbsOption = availableLanguages
-        .map(e => ({value: e.language, label: e.uiLanguageDisplayName}))
-        .find(e => e.value === sideBySideContext.lang);
+    const languageOptions = useMemo(() => availableLanguages.map(element => ({
+        value: element.language,
+        label: element.uiLanguageDisplayName
+    })), [availableLanguages]);
 
     const defaultLanguageOption = useMemo(() => {
-        const availableLanguageOption = availableLanguages.find(al => al.language === defaultLanguage) || availableLanguages[0];
-        if (availableLanguageOption) {
-            return {
-                label: availableLanguageOption.uiLanguageDisplayName,
-                value: availableLanguageOption.language
-            };
-        }
-    }, [defaultLanguage, availableLanguages]);
+        return languageOptions.find(option => option.value === defaultLanguage) || languageOptions[0];
+    }, [defaultLanguage, languageOptions]);
 
-    const defaultOption = sbsOption || {
+    const defaultOption = {
         label: t('jcontent:label.contentEditor.edit.action.copyLanguage.defaultValue'),
         value: 'void'
     };
@@ -104,20 +97,16 @@ export const CopyLanguageDialog = ({
                 <Typography className={styles.copyFromLabel}>
                     {t('jcontent:label.contentEditor.edit.action.copyLanguage.listLabel')}
                 </Typography>
-                {sbsOption ?
-                    <Typography>{sbsOption.label}</Typography> :
+                {languageOptions.length === 1 ?
+                    <Typography className={styles.language} data-sel-role="from-language-label">
+                        {currentOption.label}
+                    </Typography> :
                     <Dropdown
                         className={styles.language}
                         value={currentOption.value}
                         size="medium"
                         data-sel-role="from-language-selector"
-                        isDisabled={Boolean(sbsOption)}
-                        data={sbsOption || defaultLanguageOption ? availableLanguages.map(element => {
-                            return {
-                                value: element.language,
-                                label: element.uiLanguageDisplayName
-                            };
-                        }) : [defaultOption]}
+                        data={languageOptions.length > 0 ? languageOptions : [defaultOption]}
                         onChange={handleOnChange}
                     />}
                 <Typography className={styles.label}>
@@ -157,6 +146,5 @@ CopyLanguageDialog.propTypes = {
     isOpen: PropTypes.bool.isRequired,
     uuid: PropTypes.string.isRequired,
     onCloseDialog: PropTypes.func.isRequired,
-    sideBySideContext: PropTypes.shape({lang: PropTypes.string}),
     defaultLanguage: PropTypes.string.isRequired
 };

--- a/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/CopyLanguageDialog.scss
+++ b/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/CopyLanguageDialog.scss
@@ -36,13 +36,13 @@
     color: #f6d62f;
 }
 
-.label {
+.label:global(.moonstone-typography) {
     padding: 0 10px;
 
     font-weight: bold;
 }
 
-.copyFromLabel {
+.copyFromLabel:global(.moonstone-typography) {
     margin-left: 24px;
     padding: 0 10px;
 

--- a/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/CopyLanguageDialog.spec.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/CopyLanguageDialog.spec.jsx
@@ -36,8 +36,7 @@ describe('CopyLanguageDialog', () => {
             }],
             t: jest.fn(key => 'translated_' + key),
             onCloseDialog: jest.fn(),
-            formik: {},
-            sideBySideContext: {}
+            formik: {}
         };
     });
 

--- a/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/copyLanguageAction.jsx
+++ b/src/javascript/ContentEditor/actions/contenteditor/copyLanguage/copyLanguageAction.jsx
@@ -3,13 +3,12 @@ import PropTypes from 'prop-types';
 import {CopyLanguageDialog} from './CopyLanguageDialog';
 import {getFullLanguageName} from './copyLanguage.utils';
 import {ComponentRendererContext} from '@jahia/ui-extender';
-import {useContentEditorContext, useContentEditorConfigContext} from '~/ContentEditor/contexts';
+import {useContentEditorContext} from '~/ContentEditor/contexts';
 import {useFormikContext} from 'formik';
 
 export const CopyLanguageActionComponent = ({render: Render, ...otherProps}) => {
     const {render, destroy} = useContext(ComponentRendererContext);
     const {mode, nodeData, lang, siteInfo} = useContentEditorContext();
-    const {sideBySideContext} = useContentEditorConfigContext();
     const formik = useFormikContext();
     const availableLanguages = siteInfo.languages.filter(l => l.language !== lang && nodeData.translationLanguages?.includes(l.language));
 
@@ -23,7 +22,6 @@ export const CopyLanguageActionComponent = ({render: Render, ...otherProps}) => 
                         uuid: nodeData.uuid,
                         formik,
                         language: getFullLanguageName(siteInfo.languages, lang),
-                        sideBySideContext,
                         availableLanguages,
                         defaultLanguage: siteInfo.defaultLanguage,
                         onCloseDialog: () => destroy('CopyLanguageDialog')

--- a/tests/cypress/e2e/contentEditor/shard2/copyFromLanguageAction.cy.ts
+++ b/tests/cypress/e2e/contentEditor/shard2/copyFromLanguageAction.cy.ts
@@ -46,13 +46,14 @@ describe('test Copy Language action', () => {
         });
     };
 
-    /** Open 'toLang' editor and copy from 'fromLang' language */
-    const setCopyLanguage = (path: string, toLang: string, fromLang: string, buttonRole: string) => {
+    /** Open 'toLang' editor and apply the copy when 'fromLang' is the only source language: no dropdown, it's shown pre-selected as a label */
+    const setCopyLanguageSingleOption = (path: string, toLang: string, fromLang: string, buttonRole: string) => {
         JContent.visit(ThreeLanguagesSiteKey, toLang, path).editContent();
         getComponentByRole(Button, 'copyLanguageAction').click();
 
         const copyLangDialog = getComponentByRole(BaseComponent, 'copy-language-dialog');
-        getComponentByRole(Dropdown, 'from-language-selector').select(fromLang);
+        cy.get('[data-sel-role="from-language-selector"]', {timeout: 10000}).should('not.exist');
+        getComponentByRole(BaseComponent, 'from-language-label', copyLangDialog).should('contain', fromLang);
         getComponentByRole(Button, buttonRole, copyLangDialog).click();
     };
 
@@ -64,12 +65,13 @@ describe('test Copy Language action', () => {
             .and('contain', fromLang);
     };
 
-    const checkCopyLanguageDoesNotHaveLang = (path: string, toLang: string, fromLang: string) => {
+    /** When there is a single source language available, it is shown pre-selected as a label instead of a dropdown */
+    const checkCopyLanguageSingleOption = (path: string, toLang: string, fromLang: string) => {
         JContent.visit(ThreeLanguagesSiteKey, toLang, path).editContent();
         getComponentByRole(Button, 'copyLanguageAction').click();
-        getComponentByRole(Dropdown, 'from-language-selector').get().click();
-        getComponentByRole(Dropdown, 'from-language-selector').should('be.visible')
-            .and('not.contain', fromLang);
+        cy.get('[data-sel-role="from-language-selector"]', {timeout: 10000}).should('not.exist');
+        getComponentByRole(BaseComponent, 'from-language-label').should('be.visible')
+            .and('contain', fromLang);
     };
 
     it('copies field from English to French and saves', () => {
@@ -89,11 +91,11 @@ describe('test Copy Language action', () => {
         const contentEditor = new ContentEditor();
 
         cy.log('Test cancel button works');
-        setCopyLanguage('content-folders/contents/all-fields', 'fr', 'English', 'cancel-button');
+        setCopyLanguageSingleOption('content-folders/contents/all-fields', 'fr', 'English', 'cancel-button');
         checkFields(path, '', 'fr');
 
         cy.log('Test apply button saves changes');
-        setCopyLanguage('content-folders/contents/all-fields', 'fr', 'English', 'apply-button');
+        setCopyLanguageSingleOption('content-folders/contents/all-fields', 'fr', 'English', 'apply-button');
         contentEditor.save();
         checkFields(path, 'Text in English', 'fr');
     });
@@ -115,7 +117,7 @@ describe('test Copy Language action', () => {
 
         const contentEditor = new ContentEditor();
 
-        setCopyLanguage('content-folders/contents/all-fields-empty', 'fr', 'English', 'apply-button');
+        setCopyLanguageSingleOption('content-folders/contents/all-fields-empty', 'fr', 'English', 'apply-button');
         contentEditor.save();
 
         getNodeByPath(path, ['smallText', 'textarea'], 'fr').then(result => {
@@ -145,7 +147,7 @@ describe('test Copy Language action', () => {
         const path = `/sites/${ThreeLanguagesSiteKey}/contents/all-fields-multiple`;
         const contentEditor = new ContentEditor();
 
-        setCopyLanguage('content-folders/contents/all-fields-multiple', 'fr', 'English', 'apply-button');
+        setCopyLanguageSingleOption('content-folders/contents/all-fields-multiple', 'fr', 'English', 'apply-button');
         contentEditor.save();
 
         getNodeByPath(path, ['bigtext'], 'fr').then(result => {
@@ -171,7 +173,8 @@ describe('test Copy Language action', () => {
 
         let path = 'content-folders/contents/all-fields-two-languages';
 
-        checkCopyLanguageDoesNotHaveLang(path, 'en', 'German');
+        cy.log('Only French has a translation: it is shown pre-selected as a label, German is not selectable');
+        checkCopyLanguageSingleOption(path, 'en', 'French');
 
         addNode({
             parentPathOrId: `/sites/${ThreeLanguagesSiteKey}/contents`,


### PR DESCRIPTION
### Description

Issue with Copy Language dialog due to side by side refactoring where Copy from dropdown values are not working properly. To reproduce:

1. have a content with content in multiple languages (e.g. en, de, fr)
2. Open advanced edit > copy a language

**Expected**

Dropdown for multiple languages  in Copy Language action

**Actual**

No dropdown but only static label:

<img width="867" height="403" alt="image" src="https://github.com/user-attachments/assets/98ebbbea-4ce2-4c3d-a217-ba50b380c511" />

#### Fix

For now, we ignore side by side right panel language option as it's not accessible from top-level CE context anymore. We should now always display available languages (other than target language)

<img width="881" height="427" alt="image" src="https://github.com/user-attachments/assets/e8034232-6f44-41da-92ab-993143d12082" />

We also change behavior so that we only display a label if there is only one valid copy from language.

I will create a follow-up story if we'd want to restore back the behavior of locking the Copy From language to sync with the source language in a side-by-side editor. 

Also fixed UI issues (see above); due to moonstone legacy css.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
