### PR TITLE
fix(jcontent): locale-aware datetime format in side panel

### DIFF
--- a/src/javascript/ContentEditor/ContentEditor/useEditFormDefinition.js
+++ b/src/javascript/ContentEditor/ContentEditor/useEditFormDefinition.js
@@ -1,4 +1,4 @@
-import {dayjs} from 'date-formatter';
+import {formatDatetime} from 'date-formatter';
 import {getDynamicFieldSets, getFields} from '~/ContentEditor/utils';
 import {resolveSelectorType} from '~/ContentEditor/SelectorTypes/resolveSelectorType';
 import {adaptSystemNameField} from './adaptSystemNameField';
@@ -112,7 +112,7 @@ const getDetailsValue = (sections = [], nodeData = {}, lang = 'en') => {
                     label: field.displayName,
                     value: jcrDefinition &&
                         jcrDefinition.value &&
-                        dayjs(jcrDefinition.value).locale(lang).format('L HH:mm'),
+                        formatDatetime(jcrDefinition.value, {locale: lang}),
                     copyable: false
                 };
             }

--- a/src/javascript/ContentEditor/ContentEditor/useEditFormDefinition.spec.js
+++ b/src/javascript/ContentEditor/ContentEditor/useEditFormDefinition.spec.js
@@ -17,21 +17,9 @@ jest.mock('~/ContentEditor/SelectorTypes/resolveSelectorType', () => {
     };
 });
 
-jest.mock('date-formatter', () => {
-    return {
-        dayjs: date => {
-            return {
-                locale() {
-                    return {
-                        format(format) {
-                            return `formatted date: ${date} format: ${format}`;
-                        }
-                    };
-                }
-            };
-        }
-    };
-});
+jest.mock('date-formatter', () => ({
+    formatDatetime: date => `formatted datetime: ${date}`
+}));
 
 const t = val => val;
 
@@ -201,7 +189,7 @@ describe('adaptEditFormData', () => {
         expect(adaptEditFormData(graphqlResponse, 'fr', t).details).toEqual([
             {
                 label: 'labelled',
-                value: 'formatted date: 2019-05-07T11:33:31.056 format: L HH:mm',
+                value: 'formatted datetime: 2019-05-07T11:33:31.056',
                 copyable: false
             }
         ]);

--- a/src/javascript/JContent/SidePanel/ContentHistory/HistoryList.jsx
+++ b/src/javascript/JContent/SidePanel/ContentHistory/HistoryList.jsx
@@ -4,7 +4,7 @@ import {LoaderOverlay} from '~/ContentEditor/DesignSystem/LoaderOverlay';
 import {Chip, Language, Pill, Typography} from '@jahia/moonstone';
 import styles from './ContentHistory.scss';
 import {ACTION_CONFIG} from './ContentHistory';
-import {dayjs} from 'date-formatter';
+import {formatDatetime} from 'date-formatter';
 
 const MAX_DISPLAY_NAME_LENGTH = 80;
 
@@ -50,7 +50,7 @@ const HistoryList = React.memo(({isLoading = false, error, entries, data, uiLang
             return '-';
         }
 
-        return dayjs(dateString).locale(uiLanguage).format('L HH:mm');
+        return formatDatetime(dateString, {locale: uiLanguage});
     }, [uiLanguage]);
 
     if (isLoading && !data) {


### PR DESCRIPTION
Fixes https://github.com/Jahia/jcontent/issues/2612

Use `formatDatetime` instead of `dayjs.format('L HH:mm')` in side panel (details and history)
