### PR TITLE
feat: allow overriding Page Builder editable roots via registry.

### DIFF
--- a/.chachalog/k2lmSvHF.md
+++ b/.chachalog/k2lmSvHF.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": minor
+---
+
+Allow overriding Page Builder editable roots via registry. (#2616)

--- a/src/javascript/JContent/JContent.utils.jsx
+++ b/src/javascript/JContent/JContent.utils.jsx
@@ -40,8 +40,25 @@ export const isDescendant = (path, ancestorPath) => {
 };
 
 export const canEditInPageBuilder = (path, nodes, site) => {
-    // Check that the node is from the same site and not e reference
-    return isDescendant(path, `/sites/${site}`) && !isFromReference(path, nodes);
+    // A reference is never editable in Page Builder, wherever it resolves to
+    if (isFromReference(path, nodes)) {
+        return false;
+    }
+
+    // By default, a node is editable when it belongs to the currently selected site
+    if (isDescendant(path, `/sites/${site}`)) {
+        return true;
+    }
+
+    // Extension point: projects can register additional editable roots so their content
+    // gets Page Builder boxes even though it lives outside the currently selected site
+    // (e.g. a shared content repository site mounted in the Contents accordion).
+    // Each entry provides either a `rootPath` string or a `matches(path, {nodes, site})`
+    // predicate returning a boolean.
+    return registry.find({type: 'pageBuilderEditableRoot'})
+        .some(entry => (typeof entry.matches === 'function' ?
+            entry.matches(path, {nodes, site}) :
+            Boolean(entry.rootPath) && isDescendant(path, entry.rootPath)));
 };
 
 // This determines if the node is included as part of content reference in which case we don't want to have a box for it.

--- a/src/javascript/JContent/JContent.utils.test.jsx
+++ b/src/javascript/JContent/JContent.utils.test.jsx
@@ -1,4 +1,17 @@
-import {getNewCounter, removeFileExtension, isDescendant, resolveUrlForLiveOrPreview} from './JContent.utils';
+import {registry} from '@jahia/ui-extender';
+import {
+    canEditInPageBuilder,
+    getNewCounter,
+    isDescendant,
+    removeFileExtension,
+    resolveUrlForLiveOrPreview
+} from './JContent.utils';
+
+jest.mock('@jahia/ui-extender', () => ({
+    registry: {
+        find: jest.fn(() => [])
+    }
+}));
 
 describe('removeFileExtension', () => {
     it('should remove file extension', () => {
@@ -199,5 +212,45 @@ describe('isDescendant', () => {
         expect(isDescendant('', '/site/test')).toBe(false);
         expect(isDescendant('/site', null)).toBe(false);
         expect(isDescendant('/site', '')).toBe(true);
+    });
+});
+
+describe('canEditInPageBuilder', () => {
+    const site = 'mySite';
+    const nodes = {
+        '/sites/otherSite/ref': {primaryNodeType: {name: 'jnt:contentReference'}}
+    };
+
+    beforeEach(() => {
+        registry.find.mockReturnValue([]);
+    });
+
+    it('should allow editing nodes from the current site', () => {
+        expect(canEditInPageBuilder('/sites/mySite/home/content', nodes, site)).toBe(true);
+    });
+
+    it('should not allow editing nodes from another site by default', () => {
+        expect(canEditInPageBuilder('/sites/otherSite/home/content', nodes, site)).toBe(false);
+    });
+
+    it('should never allow editing references, even from the current site', () => {
+        const refNodes = {'/sites/mySite/list': {primaryNodeType: {name: 'jnt:contentReference'}}};
+        expect(canEditInPageBuilder('/sites/mySite/list@/node', refNodes, site)).toBe(false);
+    });
+
+    it('should allow editing nodes under a registered editable root path', () => {
+        registry.find.mockReturnValue([{rootPath: '/sites/filesSite/contents'}]);
+        expect(canEditInPageBuilder('/sites/filesSite/contents/foo', nodes, site)).toBe(true);
+        expect(canEditInPageBuilder('/sites/filesSite/other/foo', nodes, site)).toBe(false);
+    });
+
+    it('should allow editing nodes matched by a registered predicate', () => {
+        registry.find.mockReturnValue([{matches: path => path.startsWith('/sites/filesSite/')}]);
+        expect(canEditInPageBuilder('/sites/filesSite/anything', nodes, site)).toBe(true);
+    });
+
+    it('should not allow editing a reference even if it lives under a registered editable root', () => {
+        registry.find.mockReturnValue([{rootPath: '/sites/otherSite'}]);
+        expect(canEditInPageBuilder('/sites/otherSite/ref@/node', nodes, site)).toBe(false);
     });
 });

--- a/src/javascript/JContent/actions/openInPageBuilderAction.jsx
+++ b/src/javascript/JContent/actions/openInPageBuilderAction.jsx
@@ -7,7 +7,7 @@ import JContentConstants from '~/JContent/JContent.constants';
 import {batchActions} from 'redux-batched-actions';
 import {expandTree} from '~/JContent/JContent.utils';
 import {useApolloClient} from '@apollo/client';
-import {isDefinitelyHidden} from './utils/nodeVisibilityUtils';
+
 export const OpenInPageBuilderActionComponent = ({path, node: prefetchedNode, render: Render, loading: Loading, ...others}) => {
     const client = useApolloClient();
     const dispatch = useDispatch();
@@ -16,7 +16,9 @@ export const OpenInPageBuilderActionComponent = ({path, node: prefetchedNode, re
     const isPageBuilderMode = (viewMode === JContentConstants.tableView.viewMode.PAGE_BUILDER);
 
     const showOnNodeTypes = ['jmix:mainResource'];
-    const skip = !isPageBuilderMode && isDefinitelyHidden(prefetchedNode, {showOnNodeTypes});
+    // The jmix:mainResource is a supertype-inherited mixin, so it never appears in the
+    // prefetched node's mixinTypes — the fast-path can't decide it, defer to useNodeChecks.
+    const skip = !isPageBuilderMode;
 
     const res = useNodeChecks(isPageBuilderMode ? {} : {path}, {
         skip,

--- a/src/javascript/JContent/actions/openInPageBuilderAction.jsx
+++ b/src/javascript/JContent/actions/openInPageBuilderAction.jsx
@@ -18,17 +18,16 @@ export const OpenInPageBuilderActionComponent = ({path, node: prefetchedNode, re
     const showOnNodeTypes = ['jmix:mainResource'];
     // The jmix:mainResource is a supertype-inherited mixin, so it never appears in the
     // prefetched node's mixinTypes — the fast-path can't decide it, defer to useNodeChecks.
-    const skip = !isPageBuilderMode;
 
     const res = useNodeChecks(isPageBuilderMode ? {} : {path}, {
-        skip,
+        skip: isPageBuilderMode,
         showOnNodeTypes
     });
     if (res.loading && Loading) {
         return <Loading {...others}/>;
     }
 
-    if (skip || !res.node) {
+    if (isPageBuilderMode || !res.node) {
         return (<Render {...others} isVisible={false}/>);
     }
 


### PR DESCRIPTION
### Description
canEditInPageBuilder gated area boxes on the node belonging to the                                                                                                                                                                                                                                 
  currently selected site (state.site). Content loaded from another                                                                                                                                                                                                                                  
  site (e.g. a shared /sites/files-site content repository mounted in                                                                                                                                                                                                                                
  the Contents accordion) therefore rendered without any editing                                                                                                                                                                                                                                     
  overlays, and state.site cannot be changed without triggering URL                                                                                                                                                                                                                                  
  navigation and broad refetches.                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                     
  Add a `pageBuilderEditableRoot` registry extension point so projects                                                                                                                                                                                                                               
  can declare additional editable roots (via `rootPath` or a                                                                                                                                                                                                                                         
  `matches(path, {nodes, site})` predicate) without forking. Default                                                                                                                                                                                                                                 
  behaviour is unchanged when nothing is registered; references remain                                                                                                                                                                                                                               
  non-editable everywhere as the reference check now runs first. 

### Checklist
#### Source code
- [X] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [X] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
