### PR TITLE
fix: hide current domain when current hostname belongs to another site

### DIFF
--- a/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/useOpenInLiveData.js
+++ b/src/javascript/JContent/ContentRoute/MainActionBar/OpenInLiveButtonGroup/useOpenInLiveData.js
@@ -59,8 +59,22 @@ export const useOpenInLiveData = path => {
         node.publicationInfo.status !== 'UNPUBLISHED';
 
     const currentHostname = globalThis.location.hostname;
-    const isHostnameInList = [serverName, ...serverNameAliases].includes(currentHostname) ||
+    const currentSitePath = node?.site?.path;
+    const allSites = data?.jcr?.allSites?.siteNodes ?? [];
+
+    // Guard 1: hostname already in this site's names (no duplicate), or site uses localhost.
+    // Jahia resolves site context from the request hostname — using localhost across different
+    // hostnames renders in the wrong site context.
+    const isHostnameInCurrentSite = [serverName, ...serverNameAliases].includes(currentHostname) ||
         [serverName, ...serverNameAliases].includes('localhost');
+
+    // Guard 2: hostname is already claimed by a different site — Jahia would resolve that other
+    // site's context instead, opening the wrong site.
+    const isHostnameClaimedByAnotherSite = allSites.some(site =>
+        site.site?.path !== currentSitePath &&
+        [site.site?.serverName, ...(site.site?.additionalServerNames?.values ?? [])].includes(currentHostname)
+    );
+
     return {
         selectedServerName,
         selectServerName,
@@ -68,7 +82,7 @@ export const useOpenInLiveData = path => {
             urlPath: node.renderUrl,
             serverName,
             serverNameAliases,
-            currentHostname: isHostnameInList ? null : currentHostname
+            currentHostname: (isHostnameInCurrentSite || isHostnameClaimedByAnotherSite) ? null : currentHostname
         } : null
     };
 };

--- a/src/javascript/JContent/JContent.utils.test.jsx
+++ b/src/javascript/JContent/JContent.utils.test.jsx
@@ -47,31 +47,31 @@ describe('resolveUrlForLiveOrPreview', () => {
     //   absolute (http://servera/cms/render/...) when j:serverName is non-localhost
 
     const relativePath = '/cms/render/live/en/sites/digitall/home.html';
-    const absoluteServera = 'http://servera/cms/render/live/en/sites/luxe/home.html';
-    const absoluteServeraWithPort = 'http://servera:8080/cms/render/live/en/sites/luxe/home.html';
-    const absoluteServerb = 'http://serverb/cms/render/live/en/sites/siteb/home.html';
+    const absoluteServera = 'https://servera/cms/render/live/en/sites/luxe/home.html';
+    const absoluteServeraWithPort = 'https://servera:8080/cms/render/live/en/sites/luxe/home.html';
+    const absoluteServerb = 'https://serverb/cms/render/live/en/sites/siteb/home.html';
 
     const setLocation = (hostname, port = '') => {
         Object.defineProperty(window, 'location', {
             configurable: true,
-            value: {hostname, port, protocol: 'http:'}
+            value: {hostname, port, protocol: 'https:'}
         });
     };
 
     describe('preview (isLive=false) or no serverName', () => {
         it('uses current domain with port for preview', () => {
             setLocation('servera', '8080');
-            expect(resolveUrlForLiveOrPreview(absoluteServera, false, 'servera')).toBe('http://servera:8080/cms/render/live/en/sites/luxe/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServera, false, 'servera')).toBe('https://servera:8080/cms/render/live/en/sites/luxe/home.html');
         });
 
         it('uses current domain with port when serverName is not provided', () => {
             setLocation('servera', '8080');
-            expect(resolveUrlForLiveOrPreview(relativePath, true, null)).toBe('http://servera:8080/cms/render/live/en/sites/digitall/home.html');
+            expect(resolveUrlForLiveOrPreview(relativePath, true, null)).toBe('https://servera:8080/cms/render/live/en/sites/digitall/home.html');
         });
 
         it('omits port when on standard port', () => {
             setLocation('servera', '');
-            expect(resolveUrlForLiveOrPreview(absoluteServera, false, 'servera')).toBe('http://servera/cms/render/live/en/sites/luxe/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServera, false, 'servera')).toBe('https://servera/cms/render/live/en/sites/luxe/home.html');
         });
     });
 
@@ -79,19 +79,19 @@ describe('resolveUrlForLiveOrPreview', () => {
         beforeEach(() => setLocation('servera', '8080'));
 
         it('luxe: select servera (current domain) → opens with port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'servera')).toBe('http://servera:8080/cms/render/live/en/sites/luxe/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'servera')).toBe('https://servera:8080/cms/render/live/en/sites/luxe/home.html');
         });
 
         it('luxe: select server2 (alias, external) → opens without port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'server2')).toBe('http://server2/cms/render/live/en/sites/luxe/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'server2')).toBe('https://server2/cms/render/live/en/sites/luxe/home.html');
         });
 
         it('digitall: select localhost → opens at localhost with port', () => {
-            expect(resolveUrlForLiveOrPreview(relativePath, true, 'localhost')).toBe('http://localhost:8080/cms/render/live/en/sites/digitall/home.html');
+            expect(resolveUrlForLiveOrPreview(relativePath, true, 'localhost')).toBe('https://localhost:8080/cms/render/live/en/sites/digitall/home.html');
         });
 
         it('siteb: select serverb (external) → opens without port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'serverb')).toBe('http://serverb/cms/render/live/en/sites/siteb/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'serverb')).toBe('https://serverb/cms/render/live/en/sites/siteb/home.html');
         });
     });
 
@@ -99,19 +99,19 @@ describe('resolveUrlForLiveOrPreview', () => {
         beforeEach(() => setLocation('localhost', '8080'));
 
         it('luxe: select servera (external) → opens without port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'servera')).toBe('http://servera/cms/render/live/en/sites/luxe/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'servera')).toBe('https://servera/cms/render/live/en/sites/luxe/home.html');
         });
 
         it('luxe: select server2 (external) → opens without port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'server2')).toBe('http://server2/cms/render/live/en/sites/luxe/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'server2')).toBe('https://server2/cms/render/live/en/sites/luxe/home.html');
         });
 
         it('digitall: select localhost (current domain) → opens with port', () => {
-            expect(resolveUrlForLiveOrPreview(relativePath, true, 'localhost')).toBe('http://localhost:8080/cms/render/live/en/sites/digitall/home.html');
+            expect(resolveUrlForLiveOrPreview(relativePath, true, 'localhost')).toBe('https://localhost:8080/cms/render/live/en/sites/digitall/home.html');
         });
 
         it('siteb: select serverb (external) → opens without port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'serverb')).toBe('http://serverb/cms/render/live/en/sites/siteb/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'serverb')).toBe('https://serverb/cms/render/live/en/sites/siteb/home.html');
         });
     });
 
@@ -119,23 +119,23 @@ describe('resolveUrlForLiveOrPreview', () => {
         beforeEach(() => setLocation('serverb', '8080'));
 
         it('luxe: select servera (external) → opens without port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServeraWithPort, true, 'servera')).toBe('http://servera/cms/render/live/en/sites/luxe/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServeraWithPort, true, 'servera')).toBe('https://servera/cms/render/live/en/sites/luxe/home.html');
         });
 
         it('luxe: select server2 (external alias) → opens without port, not at servera', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServeraWithPort, true, 'server2')).toBe('http://server2/cms/render/live/en/sites/luxe/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServeraWithPort, true, 'server2')).toBe('https://server2/cms/render/live/en/sites/luxe/home.html');
         });
 
         it('luxe: select serverb (current domain) → opens with port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServeraWithPort, true, 'serverb')).toBe('http://serverb:8080/cms/render/live/en/sites/luxe/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServeraWithPort, true, 'serverb')).toBe('https://serverb:8080/cms/render/live/en/sites/luxe/home.html');
         });
 
         it('digitall: select localhost → opens at localhost with port, not at serverb', () => {
-            expect(resolveUrlForLiveOrPreview(relativePath, true, 'localhost')).toBe('http://localhost:8080/cms/render/live/en/sites/digitall/home.html');
+            expect(resolveUrlForLiveOrPreview(relativePath, true, 'localhost')).toBe('https://localhost:8080/cms/render/live/en/sites/digitall/home.html');
         });
 
         it('siteb: select serverb (current domain) → opens with port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'serverb')).toBe('http://serverb:8080/cms/render/live/en/sites/siteb/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'serverb')).toBe('https://serverb:8080/cms/render/live/en/sites/siteb/home.html');
         });
     });
 
@@ -143,19 +143,19 @@ describe('resolveUrlForLiveOrPreview', () => {
         beforeEach(() => setLocation('server2', '8080'));
 
         it('luxe: select servera (external) → opens without port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'servera')).toBe('http://servera/cms/render/live/en/sites/luxe/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'servera')).toBe('https://servera/cms/render/live/en/sites/luxe/home.html');
         });
 
         it('luxe: select server2 (current domain) → opens with port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'server2')).toBe('http://server2:8080/cms/render/live/en/sites/luxe/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'server2')).toBe('https://server2:8080/cms/render/live/en/sites/luxe/home.html');
         });
 
         it('digitall: select localhost → opens at localhost with port, not at server2', () => {
-            expect(resolveUrlForLiveOrPreview(relativePath, true, 'localhost')).toBe('http://localhost:8080/cms/render/live/en/sites/digitall/home.html');
+            expect(resolveUrlForLiveOrPreview(relativePath, true, 'localhost')).toBe('https://localhost:8080/cms/render/live/en/sites/digitall/home.html');
         });
 
         it('siteb: select serverb (external) → opens without port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'serverb')).toBe('http://serverb/cms/render/live/en/sites/siteb/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'serverb')).toBe('https://serverb/cms/render/live/en/sites/siteb/home.html');
         });
     });
 
@@ -163,27 +163,27 @@ describe('resolveUrlForLiveOrPreview', () => {
         beforeEach(() => setLocation('local1', '8080'));
 
         it('luxe: select servera (external) → opens without port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'servera')).toBe('http://servera/cms/render/live/en/sites/luxe/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'servera')).toBe('https://servera/cms/render/live/en/sites/luxe/home.html');
         });
 
         it('luxe: select server2 (external) → opens without port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'server2')).toBe('http://server2/cms/render/live/en/sites/luxe/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'server2')).toBe('https://server2/cms/render/live/en/sites/luxe/home.html');
         });
 
         it('luxe: select local1 (current domain) → opens with port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'local1')).toBe('http://local1:8080/cms/render/live/en/sites/luxe/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServera, true, 'local1')).toBe('https://local1:8080/cms/render/live/en/sites/luxe/home.html');
         });
 
         it('digitall: select localhost → opens at localhost with port, not at local1', () => {
-            expect(resolveUrlForLiveOrPreview(relativePath, true, 'localhost')).toBe('http://localhost:8080/cms/render/live/en/sites/digitall/home.html');
+            expect(resolveUrlForLiveOrPreview(relativePath, true, 'localhost')).toBe('https://localhost:8080/cms/render/live/en/sites/digitall/home.html');
         });
 
         it('siteb: select serverb (external) → opens without port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'serverb')).toBe('http://serverb/cms/render/live/en/sites/siteb/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'serverb')).toBe('https://serverb/cms/render/live/en/sites/siteb/home.html');
         });
 
         it('siteb: select local1 (current domain) → opens with port', () => {
-            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'local1')).toBe('http://local1:8080/cms/render/live/en/sites/siteb/home.html');
+            expect(resolveUrlForLiveOrPreview(absoluteServerb, true, 'local1')).toBe('https://local1:8080/cms/render/live/en/sites/siteb/home.html');
         });
     });
 });

--- a/src/javascript/JContent/actions/openInAction/openInAction.gql-queries.js
+++ b/src/javascript/JContent/actions/openInAction/openInAction.gql-queries.js
@@ -24,6 +24,18 @@ const OpenInActionQuery = gql`
                     }
                 }
             }
+            allSites: nodesByQuery(query: "select * from [jnt:virtualsite] where ischildnode('/sites')") {
+                siteNodes: nodes {
+                    ...NodeCacheRequiredFields
+                    site {
+                        ...NodeCacheRequiredFields
+                        serverName
+                        additionalServerNames: property(name: "j:serverNameAliases") {
+                            values
+                        }
+                    }
+                }
+            }
         }
     }
     ${PredefinedFragments.nodeCacheRequiredFields.gql}

--- a/tests/cypress/e2e/menuActions/openInLive.cy.ts
+++ b/tests/cypress/e2e/menuActions/openInLive.cy.ts
@@ -2,6 +2,8 @@ import {Button, createSite, deleteSite, getComponentByRole, publishAndWaitJobEnd
 import {JContent} from '../../page-object';
 import gql from 'graphql-tag';
 
+const currentHostname = new URL(Cypress.config('baseUrl')).hostname;
+
 describe('Open in Live tests', () => {
     const siteKey = 'openInLiveSite';
     const storageKey = 'jcontent-live-servername';
@@ -105,7 +107,10 @@ describe('Open in Live tests', () => {
                 .should('have.class', 'moonstone-selected');
         });
 
-        it('does not show current domain section when localhost is in the server names list', () => {
+        it('does not show current domain section for localhost-serverName site', () => {
+            // Localhost sites are intentionally local-only — Jahia resolves sites by hostname,
+            // so opening a localhost site at a different hostname renders in the wrong site context.
+            // "Current domain" must never appear regardless of what hostname the user is browsing from.
             visitWithStub();
             getComponentByRole(Button, 'openInLiveChevron').click();
             cy.get('.moonstone-menu:not(.moonstone-hidden)').should('be.visible');
@@ -154,6 +159,79 @@ describe('Open in Live tests', () => {
                 'be.calledWith',
                 Cypress.sinon.match(f => f.includes(serverName) && !f.includes('unknown.invalid.host'))
             );
+        });
+    });
+
+    describe('current domain — cross-site hostname guard', () => {
+        // Guard 2: "Current domain" must not appear when the current hostname is already the
+        // server name of a different Jahia site (opening it would render that other site instead).
+        // Requires a site with a non-localhost serverName to bypass guard 1.
+        const extSiteKey = 'openInLiveSiteExt';
+        const extServerName = 'external.example.com';
+
+        const visitExtWithStub = () =>
+            JContent.visit(extSiteKey, 'en', 'pages/home', {
+                onBeforeLoad(win: Window) {
+                    // @ts-expect-error window definition does not have "open" for some reason
+                    cy.stub(win, 'open').as('winOpen');
+                }
+            });
+
+        before(() => {
+            createSite(extSiteKey, {templateSet: 'dx-base-demo-templates', serverName: extServerName, locale: 'en'});
+            publishAndWaitJobEnding(`/sites/${extSiteKey}/home`, ['en']);
+            cy.loginAndStoreSession();
+        });
+
+        after(() => {
+            cy.logout();
+            deleteSite(extSiteKey);
+        });
+
+        beforeEach(() => {
+            cy.clearLocalStorage();
+            cy.loginAndStoreSession();
+        });
+
+        it('shows current domain section when current hostname is not claimed by any site', () => {
+            // No site in the test environment has serverName=currentHostname → guard 2 does not fire.
+            // Guard 1 also does not fire (extServerName is not localhost, not currentHostname).
+            // "Current domain: currentHostname" must appear.
+            visitExtWithStub();
+            getComponentByRole(Button, 'openInLiveChevron').click();
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').should('be.visible');
+            cy.contains('Current domain').should('be.visible');
+            cy.get('.moonstone-menu:not(.moonstone-hidden)')
+                .contains('.moonstone-menuItem', currentHostname)
+                .should('be.visible');
+        });
+
+        it('does not show current domain section when current hostname is claimed by another site', () => {
+            // Add currentHostname as an alias on the OTHER site (openInLiveSite) so guard 2 fires
+            // when viewing openInLiveSiteExt — Jahia would resolve currentHostname to openInLiveSite.
+            const setAliases = (values: string[]) => cy.apollo({
+                mutation: gql`
+                    mutation SetServerNameAliases($pathOrId: String!, $values: [String]!) {
+                        jcr {
+                            mutateNode(pathOrId: $pathOrId) {
+                                mutateProperty(name: "j:serverNameAliases") {
+                                    setValues(values: $values)
+                                }
+                            }
+                        }
+                    }
+                `,
+                variables: {pathOrId: `/sites/${siteKey}`, values}
+            });
+
+            setAliases([alias1, alias2, currentHostname]);
+
+            visitExtWithStub();
+            getComponentByRole(Button, 'openInLiveChevron').click();
+            cy.get('.moonstone-menu:not(.moonstone-hidden)').should('be.visible');
+            cy.contains('Current domain').should('not.exist');
+
+            setAliases([alias1, alias2]);
         });
     });
 });


### PR DESCRIPTION
## Description

Selecting current domain redirects to the wrong site because it's already assigned to a different site and that  Jahia's UrlRewriteFilter resolves site context from the request hostname before the render servlet runs.

Scenario:

1. Have sites with server names:
   - luxe with servera, additional server2
   - siteb with serverb
2. Login to serverb (siteb default server name)
3. luxe: select serverb -> opens with port/context, but opens another site (siteb) - not OK

The fix then for now is to show current domain only if server name of current env is not assigned to sites (and that it doesn't get re-routed there). We fetch site info for all sites and check current env against it to decide if we hide or show current domain as a selection.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
