### PR TITLE
fix(preview): render previewed content as a static document

### DIFF
--- a/.chachalog/olUOFdB.md
+++ b/.chachalog/olUOFdB.md
@@ -3,4 +3,4 @@
 "@jahia/jcontent": patch
 ---
 
-Preview renders content as a static document: scripts embedded in previewed content no longer run in the preview frame
+Render previewed content as a static document: embedded scripts no longer run in the preview frame (#2621)

--- a/.chachalog/olUOFdB.md
+++ b/.chachalog/olUOFdB.md
@@ -1,0 +1,5 @@
+---
+jcontent: patch
+---
+
+Preview renders content as a static document: scripts embedded in previewed content no longer run in the preview frame

--- a/.chachalog/olUOFdB.md
+++ b/.chachalog/olUOFdB.md
@@ -1,5 +1,6 @@
 ---
-jcontent: patch
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": patch
 ---
 
 Preview renders content as a static document: scripts embedded in previewed content no longer run in the preview frame

--- a/src/javascript/JContent/preview/viewers/IframeViewer/IframViewer.spec.js
+++ b/src/javascript/JContent/preview/viewers/IframeViewer/IframViewer.spec.js
@@ -25,6 +25,17 @@ describe('IframeViewer', () => {
         const cmp = shallow(<IframeViewer {...props}/>);
         expect(cmp.find('LoaderOverlay').exists()).toBe(true);
     });
+
+    it('should render the rendered content as a static document, without running its scripts', () => {
+        const cmp = shallow(<IframeViewer {...props}/>);
+        const sandbox = cmp.find('iframe').prop('sandbox');
+
+        // The preview shows layout only - the framed document must not execute scripts.
+        expect(sandbox).not.toContain('allow-scripts');
+        // ...but it must stay same-origin, otherwise loadAssets and zoom can no longer reach
+        // the frame's document and the preview loses its CSS and its zoom behaviour.
+        expect(sandbox).toContain('allow-same-origin');
+    });
 });
 
 describe('Zoom test', () => {

--- a/src/javascript/JContent/preview/viewers/IframeViewer/IframeViewer.jsx
+++ b/src/javascript/JContent/preview/viewers/IframeViewer/IframeViewer.jsx
@@ -6,6 +6,18 @@ import {zoom} from '~/JContent/preview/Preview.utils';
 import {useTranslation} from 'react-i18next';
 import {LoaderOverlay} from '~/ContentEditor/DesignSystem/LoaderOverlay';
 
+/**
+ * Sandbox flags for the preview frame.
+ *
+ * The preview is a *static layout* rendering of a node: only CSS assets are collected
+ * (`staticAssets(type: "css")`) and the frame body is made non-interactive on load
+ * (`pointer-events: none`), so the framed document never needs to run scripts of its own.
+ *
+ * `allow-same-origin` IS required and must stay — `loadAssets` and `zoom` below reach into the
+ * frame's `document` from this component, which is only possible while the frame keeps our origin.
+ */
+const PREVIEW_SANDBOX = 'allow-same-origin';
+
 function loadAsset(asset, iframeHeadEl) {
     return new Promise(resolve => {
         const linkEl = document.createElement('link');
@@ -151,7 +163,7 @@ export const IframeViewer = ({previewContext, data, onContentNotFound, nodeData 
                     data-sel-role={previewContext.workspace + '-preview-frame'}
                     className={`${styles.iframe} ${loading ? styles.iframeLoading : ''}`}
                     srcDoc={displayValue}
-                    sandbox="allow-same-origin allow-scripts"
+                    sandbox={PREVIEW_SANDBOX}
                     onLoad={onLoad}
             />
         </Paper>

--- a/tests/cypress/e2e/jcontent/shard2/preview.cy.ts
+++ b/tests/cypress/e2e/jcontent/shard2/preview.cy.ts
@@ -37,6 +37,11 @@ describe('JContent preview tests', () => {
             properties: [{name: 'firstname', value: 'Preview'}, {name: 'lastname', value: 'Person'}]
         });
         addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: 'previewInlineScript',
+            primaryNodeType: 'cent:previewInlineScript'
+        });
+        addNode({
             parentPathOrId: `/sites/${siteKey}/home`,
             name: 'head-attr-test-page',
             primaryNodeType: 'jnt:page',
@@ -166,6 +171,28 @@ describe('JContent preview tests', () => {
             const head = $iframe[0].contentDocument.querySelector('head');
             expect(head, 'iframe should have a head element').to.exist;
             expect(head.getAttribute('data-stub'), '<head data-stub> attribute should be preserved from page template').to.equal('test');
+        });
+    });
+
+    it('should render content as a static document, without running scripts it contains', () => {
+        // The preview shows layout only: the frame renders the markup but must not execute the
+        // inline <script> the cent:previewInlineScript view emits. The frame must nonetheless
+        // stay readable from the app (same-origin), which the marker assertion below also proves.
+        const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+        jcontent.openPreview('previewInlineScript');
+
+        cy.get('[data-sel-role="preview-container"]').should('be.visible');
+        cy.get('iframe[data-sel-role="edit-preview-frame"]')
+            .its('0.contentDocument.body')
+            .should('be.visible')
+            .and('contain.text', 'previewInlineScript marker');
+
+        cy.get('iframe[data-sel-role="edit-preview-frame"]').should($iframe => {
+            const doc = $iframe[0].contentDocument;
+            expect(doc.querySelector('[data-testid="preview-inline-script-marker"]'),
+                'rendered markup should be displayed').to.exist;
+            expect(doc.documentElement.dataset.previewScriptRan,
+                'inline script in the rendered content should not have run').to.be.undefined;
         });
     });
 

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/META-INF/definitions.cnd
@@ -153,6 +153,10 @@
 
 [cent:previewWrapper] > jnt:content, jmix:basicContent
 
+// Renders a view containing an inline <script> — used to assert that the preview frame shows the
+// rendered markup as a static document and does not run scripts embedded in it.
+[cent:previewInlineScript] > jnt:content, jmix:basicContent
+
 // Tests for examples provided in academy
 // https://academy.jahia.com/documentation/jahia/jahia-8/developer/extending-and-customizing-jahia-ui/customizing-content-editor-forms/examples-of-content-definition-json-overrides
 

--- a/tests/jahia-module/jcontent-test-module/src/main/resources/cent_previewInlineScript/html/previewInlineScript.jsp
+++ b/tests/jahia-module/jcontent-test-module/src/main/resources/cent_previewInlineScript/html/previewInlineScript.jsp
@@ -1,0 +1,10 @@
+<%@ page language="java" contentType="text/html;charset=UTF-8" %>
+<%--
+    Renders a static marker plus an inline <script> that would stamp the document if it ran.
+    The preview frame shows rendered content as a static document, so the marker must appear
+    while the stamp must not — see the jcontent preview Cypress spec.
+--%>
+<div data-testid="preview-inline-script-marker">previewInlineScript marker</div>
+<script>
+    document.documentElement.dataset.previewScriptRan = 'yes';
+</script>


### PR DESCRIPTION
## Summary

The jContent / Content Editor preview panel renders a node's `renderedContent` output into an
iframe through `srcDoc`. The frame was declared as
`sandbox="allow-same-origin allow-scripts"`, so the previewed markup could run scripts of its own
inside the application's own origin.

That is inconsistent with what the panel is for. The preview shows **layout**: only CSS assets are
ever collected for the frame (`staticAssets(type: "css")` in the preview query), and the frame body
is made non-interactive on load (`pointer-events: none`). Scripts belonging to the previewed content
were never part of the intended rendering — `allow-scripts` was carried over unchanged when the panel
moved from `document.write` to `srcDoc`.

## Change

- `IframeViewer` now declares `sandbox="allow-same-origin"`, so the preview frame presents the
  rendered markup as a static document.
- `allow-same-origin` is deliberately kept. `loadAssets` (which adds the page's stylesheets) and
  `zoom` both reach into the frame's `document` from the component, which only works while the frame
  keeps the application's origin. Dropping it would silently cost the preview its CSS and its
  zoom/remove-siblings behaviour.
- The value moved into a named `PREVIEW_SANDBOX` constant that documents both halves of the
  decision, so neither is re-loosened by accident later.

### Behaviour change

A previewed component's own scripts no longer run inside the preview frame. Layout and CSS are
unaffected, but a template that relies on JavaScript to finish its presentation (a carousel,
JS-computed sizing, lazy-loaded media) will show its pre-script state in the preview panel.

Only the embedded preview frame is affected — how the page renders in Page Composer, in the live
site, and in the standalone preview window is unchanged. No configuration or API changes; nothing to
migrate.

## Verification

- **Unit** — `IframViewer.spec.js` asserts the frame is declared without `allow-scripts` and with
  `allow-same-origin`. The assertion fails against the previous value and passes with the new one.
- **E2E** — `cypress/e2e/jcontent/shard2/preview.cy.ts` previews a `cent:previewInlineScript` node
  whose view emits a visible marker plus an inline `<script>` that would stamp the document if it
  ran. The spec asserts the marker is rendered and the stamp is absent — which also confirms the
  frame is still readable from the app, i.e. still same-origin.
- **Regression surface** — the existing preview specs (view resolution, zoom / remove-siblings,
  page-CSS loading through `cssSourcePath`, hybrid `<head>` attribute preservation, edit-workspace
  refresh) all read `contentDocument`, so they collectively cover the same-origin requirement.
