### PR TITLE
fix(preview): render previewed content as a static document (3_6_x)

### DIFF
--- a/.chachalog/KnNfP.md
+++ b/.chachalog/KnNfP.md
@@ -1,0 +1,5 @@
+---
+jcontent: patch
+---
+
+Preview renders content as a static document: scripts embedded in previewed content no longer run in the preview frames

--- a/.chachalog/KnNfP.md
+++ b/.chachalog/KnNfP.md
@@ -1,5 +1,6 @@
 ---
-jcontent: patch
+# Allowed version bumps: patch, minor, major
+"@jahia/jcontent": patch
 ---
 
 Preview renders content as a static document: scripts embedded in previewed content no longer run in the preview frames

--- a/.chachalog/KnNfP.md
+++ b/.chachalog/KnNfP.md
@@ -3,4 +3,4 @@
 "@jahia/jcontent": patch
 ---
 
-Preview renders content as a static document: scripts embedded in previewed content no longer run in the preview frames
+Render previewed content as a static document: embedded scripts no longer run in the preview frames (#2622)

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/Preview/PreviewViewers/IframeViewer/IframViewer.spec.js
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/Preview/PreviewViewers/IframeViewer/IframViewer.spec.js
@@ -28,6 +28,17 @@ describe('IframeViewer', () => {
         const cmp = shallow(<IframeViewer {...props}/>);
         expect(cmp.find('LoaderOverlay').exists()).toBe(true);
     });
+
+    it('should render the rendered content as a static document, without running its scripts', () => {
+        const cmp = shallow(<IframeViewer {...props}/>);
+        const sandbox = cmp.find('iframe').prop('sandbox');
+
+        // The preview shows layout only - the framed document must not execute scripts.
+        expect(sandbox).not.toContain('allow-scripts');
+        // ...but it must stay same-origin, otherwise loadAssets and zoom can no longer reach
+        // the frame's document and the preview loses its CSS and its zoom behaviour.
+        expect(sandbox).toContain('allow-same-origin');
+    });
 });
 
 describe('Zoom test', () => {

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/Preview/PreviewViewers/IframeViewer/IframeViewer.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/Preview/PreviewViewers/IframeViewer/IframeViewer.jsx
@@ -23,6 +23,18 @@ export function zoom(iframeDocument, onContentNotFound, editorContext) {
     }
 }
 
+/**
+ * Sandbox flags for the preview frame.
+ *
+ * The preview is a *static layout* rendering of a node: only stylesheets are added to the frame and
+ * its body is made non-interactive on load (`pointer-events: none`), so the framed document never
+ * needs to run scripts of its own.
+ *
+ * `allow-same-origin` IS required and must stay — `loadAssets` and `zoom` reach into the frame's
+ * `document` from this component, which is only possible while the frame keeps our origin.
+ */
+const PREVIEW_SANDBOX = 'allow-same-origin';
+
 function loadAsset(asset, iframeHeadEl) {
     return new Promise(resolve => {
         const linkEl = document.createElement('link');
@@ -105,7 +117,7 @@ export const IframeViewer = ({previewContext, data, onContentNotFound}) => {
                     data-sel-role={previewContext.workspace + '-preview-frame'}
                     className={`${styles.iframe} ${loading ? styles.iframeLoading : ''}`}
                     srcDoc={displayValue}
-                    sandbox="allow-same-origin allow-scripts"
+                    sandbox={PREVIEW_SANDBOX}
                     onLoad={onLoad}
             />
         </Paper>

--- a/src/javascript/ContentEditor/editorTabs/EditPanelContent/Preview/PreviewViewers/IframeViewer/IframeViewer.jsx
+++ b/src/javascript/ContentEditor/editorTabs/EditPanelContent/Preview/PreviewViewers/IframeViewer/IframeViewer.jsx
@@ -113,6 +113,7 @@ export const IframeViewer = ({previewContext, data, onContentNotFound}) => {
         <Paper elevation={1} classes={{root: styles.contentPaper}}>
             {loading && <LoaderOverlay/>}
             <iframe ref={iframeRef}
+                    title="Content preview viewer"
                     aria-labelledby="preview-tab"
                     data-sel-role={previewContext.workspace + '-preview-frame'}
                     className={`${styles.iframe} ${loading ? styles.iframeLoading : ''}`}

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PreviewComponent.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PreviewComponent.jsx
@@ -130,6 +130,7 @@ const PreviewComponentCmp = ({data, workspace, fullScreen, domLoadedCallback, iF
             <Paper elevation={1} classes={{root: styles.contentPaper}}>
                 <iframe key={data && data.nodeByPath ? data.nodeByPath.path : 'NoPreviewAvailable'}
                         ref={element => iframeLoadContent({assets, displayValue, element, domLoadedCallback, iFrameStyle})}
+                        title="Content preview viewer"
                         data-sel-role={workspace + '-preview-frame'}
                         className={styles.contentIframe}
                         {...iframeProps}

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PreviewComponent.jsx
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PreviewComponent.jsx
@@ -9,6 +9,19 @@ import ImageViewer from './ImageViewer';
 import {useTranslation} from 'react-i18next';
 import styles from './PreviewComponent.scss';
 
+/**
+ * Sandbox flags for the preview frame.
+ *
+ * The preview is a *static layout* rendering of a node: only stylesheets are added to the frame and
+ * its body is made non-interactive once written, so the framed document never needs to run scripts
+ * of its own.
+ *
+ * `allow-same-origin` IS required and must stay — `writeInIframe` and `loadAssets` reach into the
+ * frame's `document` from this component, which is only possible while the frame keeps our origin.
+ * It is applied after `iframeProps` so a caller cannot widen it by accident.
+ */
+const PREVIEW_SANDBOX = 'allow-same-origin';
+
 function writeInIframe(html, iframeWindow) {
     return new Promise((resolve, reject) => {
         iframeWindow.document.open();
@@ -120,6 +133,7 @@ const PreviewComponentCmp = ({data, workspace, fullScreen, domLoadedCallback, iF
                         data-sel-role={workspace + '-preview-frame'}
                         className={styles.contentIframe}
                         {...iframeProps}
+                        sandbox={PREVIEW_SANDBOX}
                 />
             </Paper>
         </div>

--- a/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PreviewComponent.spec.js
+++ b/src/javascript/JContent/ContentRoute/ContentLayout/PreviewDrawer/Preview/PreviewComponent/PreviewComponent.spec.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import {shallow} from '@jahia/test-framework';
+import PreviewComponent from './PreviewComponent';
+
+// The file viewers pull in react-pdf, which is not transformed for tests and is irrelevant here:
+// these cases render the content (non-file) branch of the component.
+jest.mock('./PDFViewer', () => ({PDFViewer: () => null}));
+jest.mock('./DocumentViewer', () => ({DocumentViewer: () => null}));
+jest.mock('./ImageViewer', () => ({ImageViewer: () => null}));
+
+describe('PreviewComponent', () => {
+    let props;
+    beforeEach(() => {
+        props = {
+            data: {},
+            workspace: 'edit'
+        };
+    });
+
+    it('should render the rendered content as a static document, without running its scripts', () => {
+        const cmp = shallow(<PreviewComponent {...props}/>);
+        const sandbox = cmp.find('iframe').prop('sandbox');
+
+        // The preview shows layout only - the framed document must not execute scripts.
+        expect(sandbox).not.toContain('allow-scripts');
+        // ...but it must stay same-origin, otherwise the content can no longer be written into
+        // the frame and its stylesheets can no longer be added.
+        expect(sandbox).toContain('allow-same-origin');
+    });
+
+    it('should not let a caller widen the preview frame sandbox', () => {
+        const cmp = shallow(<PreviewComponent {...props} iframeProps={{sandbox: 'allow-same-origin allow-scripts'}}/>);
+
+        expect(cmp.find('iframe').prop('sandbox')).toBe('allow-same-origin');
+    });
+});


### PR DESCRIPTION
Maintenance-line counterpart of #2621 (`main`), applied to the `3_6_x` layout.

## Summary

The preview panels render a node's `renderedContent` output into an iframe and let that markup run
scripts of its own inside the application's origin. The preview is meant to show **layout**: only
stylesheets are added to the frame and the frame body is made non-interactive once the content is in,
so scripts belonging to the previewed content were never part of the intended rendering.

On this line the preview exists in **two** places, and they had drifted apart:

| Frame | How content gets in | Sandbox before |
|---|---|---|
| Content Editor preview (`PreviewViewers/IframeViewer.jsx`) | `srcDoc` | `allow-same-origin allow-scripts` |
| jContent preview drawer (`PreviewComponent.jsx`) | `document.write` | **none declared at all** |

The second frame declared no `sandbox` attribute, so it was not merely script-enabled — it was
entirely unrestricted (forms, popups and top-level navigation included).

## Change

- Both preview frames now declare `sandbox="allow-same-origin"`, so each presents the rendered markup
  as a static document. Same value, same named `PREVIEW_SANDBOX` constant, in both files.
- `allow-same-origin` is deliberately kept in both. The component writes the content into the frame
  and adds its stylesheets by reaching into the frame's `document`, which only works while the frame
  keeps the application's origin. Dropping it would silently cost the preview its content and CSS.
- In `PreviewComponent`, `sandbox` is applied **after** the `{...iframeProps}` spread so a caller
  cannot widen it by accident. No current caller passes one.

### Behaviour change

A previewed component's own scripts no longer run inside either preview frame. Layout and CSS are
unaffected, but a template that relies on JavaScript to finish its presentation (a carousel,
JS-computed sizing, lazy-loaded media) will show its pre-script state in the preview.

Only the embedded preview frames are affected — Page Composer, the live site and the standalone
preview window are unchanged. No configuration or API changes; nothing to migrate.

## Verification

Unit tests on this line, each failing before the change and passing after:

- `PreviewViewers/IframeViewer/IframViewer.spec.js` — the Content Editor frame is declared without
  `allow-scripts` and with `allow-same-origin`.
- `PreviewComponent/PreviewComponent.spec.js` (new) — the jContent frame carries the same value
  (previously `undefined`), and a caller-supplied `iframeProps.sandbox` cannot widen it.

`yarn jest` over both preview trees: 23 tests passing, lint clean. The end-to-end coverage for this
behaviour lives on `main` (#2621), where the two frames are already unified into one component.
