### PR TITLE
ci: point the Sonar reference branch at 3_6_x

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jahia/jahia-modules-action/sonar-analysis@v2
         with:
-          primary_release_branch: master
+          primary_release_branch: 3_6_x
           github_slug: jahia/jcontent
           github_pr_id: ${{github.event.number}}
           sonar_url: ${{ secrets.SONAR_URL }}


### PR DESCRIPTION
## What

This branch's Sonar step passes `primary_release_branch: master`, and **no `master` branch exists** on this repository.

## Why it matters

The action feeds that input straight into `-Dsonar.pullrequest.base`, which is what defines **new code** for a PR analysis. With a non-existent base SonarQube cannot compute a diff, so it attributes effectively the whole branch to the PR.

Measured on [#2622](https://github.com/Jahia/jcontent/pull/2622), a two-line change: **19 new reliability issues, 83 new maintainability issues, 478 min of added technical debt** — on files that PR never touched (`PreviewWrapperFilter.java`, `EditFrame.utils.jsx`, `UploadItem.jsx`, redux files, even `.github/workflows/manual-run.yml`). The Quality Gate therefore cannot pass on any PR onto this branch.

## Change

One line — `master` → `3_6_x`, so new code is measured against the branch PRs actually target. (`main` uses `primary_release_branch: main`; this line simply never got updated when `master` was renamed.)

## Note

SonarQube needs an existing analysis of branch `3_6_x` to diff against. The first PR after this merges may still be noisy until a push to `3_6_x` produces one — the `else` arm of the action covers that (`-Dsonar.branch.name=3_6_x` on a branch build).

Unrelated but noticed while here: `chachalog-prepare-changelog.yml`, `chachalog-comment-pr.yml` and `release-types-to-npm.yml` still trigger on `master` on this branch, so they never fire. Left alone — changing triggers has its own blast radius, and it may matter when 3.6.x is released.