### PR TITLE
test: move selenium tests to cypress

### DIFF
--- a/tests/cypress/e2e/contentEditor/shard1/visibilityScreen.cy.ts
+++ b/tests/cypress/e2e/contentEditor/shard1/visibilityScreen.cy.ts
@@ -98,6 +98,32 @@ const resetVisibilityRules = (sitekey: string) => {
 };
 
 // ---------------------------------------------------------------------------
+// resetLanguageRestriction: clears the j:invalidLanguages property that the
+// Languages section of the visibility screen stores directly on the content
+// node (NOT on the j:conditionalVisibility child node, so resetVisibilityRules
+// does not cover it). Query-then-delete avoids cy.apollo throwing when the
+// property is absent. Callers must republish afterwards to restore live state.
+// ---------------------------------------------------------------------------
+const resetLanguageRestriction = (sitekey: string) => {
+    const nodePath = `/sites/${sitekey}/home/area-main/test-content1`;
+    // The j:invalidLanguages property is multi-valued, so query `values` (not `value`,
+    // which is always null for multi-valued properties). property() returns null when
+    // absent, so the delete only runs when a restriction is actually present.
+    cy.apollo({
+        queryFile: 'jcontent/getInvalidLanguages.graphql',
+        variables: {path: nodePath}
+    }).then(({data}) => {
+        const values = data?.jcr?.nodeByPath?.invalidLanguages?.values;
+        if (Array.isArray(values) && values.length > 0) {
+            cy.apollo({
+                variables: {pathOrId: nodePath, property: 'j:invalidLanguages'},
+                mutationFile: 'jcontent/jcrDeleteProperty.graphql'
+            });
+        }
+    });
+};
+
+// ---------------------------------------------------------------------------
 // All inner suites share the same pair of sites. Site lifecycle (createSite /
 // deleteSite) lives in this outer describe so the sites are never prematurely
 // destroyed between suites.
@@ -476,8 +502,8 @@ describe('Visibility Screen', () => {
                 });
             });
 
-            // To be fixed https://github.com/Jahia/jcontent/issues/2382
-            it.skip('Publishes the rules and validates different visibility status for today vs today+2', () => {
+            // To be fixed https://github.com/Jahia/jcontent/pull/2440
+            it('Publishes the rules and validates different visibility status for today vs today+2', () => {
                 const {today, todayPlus2} = getDayNames();
                 cy.log(
                     `Verifying visibility for ${today} (today - should be visible) and ${todayPlus2} (today+2 - should be hidden)`
@@ -917,6 +943,10 @@ describe('Visibility Screen', () => {
             cy.loginAndStoreSession();
             resetVisibilityRules(sitekeyNonI18n);
             resetVisibilityRules(sitekeyI18n);
+            // The Languages restriction (j:invalidLanguages) lives on the content node and
+            // persists across tests, so clear it too and republish to restore a clean,
+            // fully-visible live state before every test.
+            resetLanguageRestriction(sitekeyI18n);
             publishAndWait(`/sites/${sitekeyNonI18n}/home`, ['en']);
             publishAndWait(`/sites/${sitekeyI18n}/home`, ['en']);
         });
@@ -1044,6 +1074,55 @@ describe('Visibility Screen', () => {
                 .getBox()
                 .getStatus('notVisible')
                 .should('be.visible');
+
+            // The badge is not enough: verify the content is actually gone from the
+            // rendered live (en) page while the other contents are still there.
+            cy.visit(`/sites/${sitekeyI18n}/home.html`);
+            cy.get('body').should('not.contain', 'test 1test 2test 3').and('contain.text', 'test 2test 3');
+        });
+
+        it('Content restricted for a language disappears from the live-rendered page (i18n site)', () => {
+            const homeLivePath = `/sites/${sitekeyI18n}/home.html`;
+            const contentPath = `/sites/${sitekeyI18n}/home/area-main/test-content1`;
+
+            // Check the content is rendered in live before any restriction
+            cy.visit(homeLivePath);
+            cy.get('body').should('contain.text', 'test 1test 2test 3');
+
+            // Remove English on test-content1
+            jcontent = JContent.visit(sitekeyI18n, 'en', 'pages/home');
+            jcontent.switchToListMode().getTable().getRowByName('test-content1').contextMenu().select('Edit');
+            getComponentByRole(Button, 'sbsVisibility').click();
+            getComponentByRole(BaseComponent, 'edit-visibility-rules-dialog').should('be.visible');
+
+            cy.get('[data-cm-role="visibilityScreen"]').within(() => {
+                cy.get(
+                    '[data-sel-content-editor-field*="invalidLanguages"], [data-sel-content-editor-field*="j:invalidLanguages"]'
+                )
+                    .contains('English')
+                    .should('be.visible')
+                    .click();
+            });
+            cy.get('[data-sel-role="languages-save-button"]').should('not.be.disabled').click();
+            cy.get('[data-sel-role="languages-save-button"]', {timeout: 10000}).should('be.disabled');
+            cy.get('[data-sel-role="edit-visibility-rules-dialog"]').within(() => {
+                cy.contains('button', 'Close').click();
+            });
+            cy.get('[data-sel-role="edit-visibility-rules-dialog"]').should('not.exist');
+
+            // Publish, then confirm the content is no longer rendered in live in English
+            publishAndWait(`/sites/${sitekeyI18n}/home`, ['en']);
+            cy.visit(homeLivePath);
+            cy.get('body').should('not.contain', 'test 1test 2test 3').and('contain.text', 'test 2test 3');
+
+            // Remove the restriction and republish — the content is rendered again in live
+            cy.apollo({
+                variables: {pathOrId: contentPath, property: 'j:invalidLanguages'},
+                mutationFile: 'jcontent/jcrDeleteProperty.graphql'
+            });
+            publishAndWait(`/sites/${sitekeyI18n}/home`, ['en']);
+            cy.visit(homeLivePath);
+            cy.get('body').should('contain.text', 'test 1test 2test 3');
         });
     }); // End describe('Visibility Live Mode Tests')
 

--- a/tests/cypress/e2e/contentEditor/shard1/visibilityScreen.cy.ts
+++ b/tests/cypress/e2e/contentEditor/shard1/visibilityScreen.cy.ts
@@ -502,8 +502,8 @@ describe('Visibility Screen', () => {
                 });
             });
 
-            // To be fixed https://github.com/Jahia/jcontent/pull/2440
-            it('Publishes the rules and validates different visibility status for today vs today+2', () => {
+            // To be fixed https://github.com/Jahia/jcontent/issues/2382
+            it.skip('Publishes the rules and validates different visibility status for today vs today+2', () => {
                 const {today, todayPlus2} = getDayNames();
                 cy.log(
                     `Verifying visibility for ${today} (today - should be visible) and ${todayPlus2} (today+2 - should be hidden)`

--- a/tests/cypress/e2e/contentEditor/shard2/permissions.cy.ts
+++ b/tests/cypress/e2e/contentEditor/shard2/permissions.cy.ts
@@ -1,39 +1,39 @@
 import {JContent} from '../../../page-object';
 import {RichTextField, SmallTextField} from '../../../page-object/fields';
-import gql from 'graphql-tag';
 import {ContentEditor} from '../../../page-object';
-import {createSite, createUser, deleteSite, deleteNode, deleteUser, getNodeByPath, grantRoles} from '@jahia/cypress';
+import {addNode, createSite, createUser, deleteSite, deleteUser, getNodeByPath, grantRoles} from '@jahia/cypress';
 
 describe('permissions', () => {
+    const siteKey = 'editorPermsSite';
+    const editorLogin = {username: 'editorUser', password: 'password'};
     let jcontent: JContent;
     let contentEditor;
 
     before(() => {
-        cy.apollo({mutation: gql`
-                mutation createContent {
-                    jcr {
-                        mutateNode(pathOrId: "/sites/digitall/contents") {
-                            addChild(name: "test", primaryNodeType: "jnt:bigText") {
-                                grantRoles(principalName: "bill", principalType:USER, roleNames: "editor")
-                                mutateChildren(names: "j:acl") {
-                                    mutateProperty(name: "j:inherit") {
-                                        setValue(value: "false")
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            `});
+        createSite(siteKey, {
+            languages: 'en',
+            templateSet: 'dx-base-demo-templates',
+            serverName: 'localhost',
+            locale: 'en'
+        });
+        createUser(editorLogin.username, editorLogin.password);
+        grantRoles(`/sites/${siteKey}`, ['editor'], editorLogin.username, 'USER');
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            primaryNodeType: 'jnt:bigText',
+            name: 'test'
+        });
     });
 
     after(() => {
-        deleteNode('/sites/digitall/contents/test');
+        cy.logout();
+        deleteSite(siteKey);
+        deleteUser(editorLogin.username);
     });
 
     it('can edit rich text with editor', function () {
-        cy.loginAndStoreSession('bill', 'password');
-        jcontent = JContent.visit('digitall', 'en', 'content-folders/contents');
+        cy.loginAndStoreSession(editorLogin.username, editorLogin.password);
+        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
         contentEditor = jcontent.editComponentByText('test');
         const richText = contentEditor.getField(RichTextField, 'jnt:bigText_text');
         richText.type('test');
@@ -44,6 +44,12 @@ describe('translator permissions', () => {
     const siteKey = 'translatorPermsSite';
     const translatorLogin = {username: 'frTranslator', password: 'password'};
 
+    // Copy translator role (with the "publication-start" permission removed) and its user
+    const grantedRole = 'translator-copy-translator-en';
+    const translatorCopyUser = {username: 'translatorCopyUser', password: 'password'};
+    const contentName = 'translatorCopyPublicationTest';
+    let contentUuid: string;
+
     before(() => {
         createSite(siteKey, {
             languages: 'en,fr',
@@ -53,10 +59,22 @@ describe('translator permissions', () => {
         });
         createUser(translatorLogin.username, translatorLogin.password);
         grantRoles(`/sites/${siteKey}`, ['translator-fr'], translatorLogin.username, 'USER');
+        createUser(translatorCopyUser.username, translatorCopyUser.password);
+
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            primaryNodeType: 'jnt:bigText',
+            name: contentName,
+            properties: [{name: 'text', value: 'Publication permission test', language: 'en'}]
+        }).then(result => {
+            contentUuid = result.data.jcr.addNode.uuid;
+        });
     });
 
     after(() => {
         cy.logout();
+        cy.executeGroovy('contentEditor/permissions/deleteTranslatorCopyRole.groovy');
+        deleteUser(translatorCopyUser.username);
         deleteSite(siteKey);
         deleteUser(translatorLogin.username);
     });
@@ -83,5 +101,32 @@ describe('translator permissions', () => {
             expect(titleProp.value).to.eq('Accueil traduit');
         });
     });
-});
 
+    it('should not allow a translator with no publication rights to publish content', () => {
+        // Copy the translator role and grant the copied English sub-role to the test user here
+        // (not in before) so the copy cannot affect the real translator-fr role used above.
+        cy.executeGroovy('contentEditor/permissions/copyTranslatorRoleWithoutPublication.groovy');
+        grantRoles(`/sites/${siteKey}`, [grantedRole], translatorCopyUser.username, 'USER');
+
+        // The copied role and its grantable English sub-role should have been created
+        getNodeByPath('/roles/translator-copy', [], undefined, ['jnt:role']).then(result => {
+            const role = result.data.jcr.nodeByPath;
+            expect(role, 'translator-copy role').to.not.be.null;
+            const subRoleNames = role.children.nodes.map((node: {name: string}) => node.name);
+            expect(subRoleNames, 'copied sub-roles').to.include(grantedRole);
+        });
+
+        // Log in as the translator-copy user
+        cy.loginAndStoreSession(translatorCopyUser.username, translatorCopyUser.password);
+        const ceParams = `(contentEditor:!((formKey:modal_0,isFullscreen:!t,lang:en,mode:edit,site:${siteKey},uilang:en,uuid:'${contentUuid}')))`;
+        cy.visit(`/jahia/jcontent/${siteKey}/en/content-folders/contents#${ceParams}`);
+        const ce = ContentEditor.getContentEditor();
+
+        // Save is visible but disabled
+        ce.checkButtonStatus('submitSave', false);
+
+        // All publication action buttons are unavailable
+        cy.get('[data-sel-role="publishAction"]').should('not.exist');
+        cy.get('[data-sel-role="startWorkflowMainButton"]').should('not.exist');
+    });
+});

--- a/tests/cypress/e2e/jcontent/shard2/createMedia.cy.ts
+++ b/tests/cypress/e2e/jcontent/shard2/createMedia.cy.ts
@@ -1,5 +1,6 @@
 import {ContentEditor, JContent} from '../../../page-object';
 import {addNode, createUser, deleteNode, deleteUser, grantRoles} from '@jahia/cypress';
+import {contentTypes} from '../../../fixtures/contentEditor/pickers/contentTypes';
 
 describe('Create media tests', () => {
     let jcontent: JContent;
@@ -127,5 +128,67 @@ describe('Create media tests', () => {
 
         // Clean up
         deleteNode(`/sites/${siteKey}/files/replaceTest`);
+    });
+
+    it('Can create an image reference (jnt:imageReferenceLink) in content-folders', function () {
+        const imageName = 'myfile.png';
+
+        cy.loginAndStoreSession();
+        jcontent = JContent.visit(siteKey, 'en', 'media/files');
+        jcontent.getMedia().open().uploadFileViaDialog(imageName, 'assets/uploadMedia');
+
+        // Create an image reference link
+        jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+        const contentEditor = jcontent.createContent(contentTypes.imageReference.typeName);
+        contentEditor.getSmallTextField('jnt:imageReferenceLink_jcr:title').addNewValue('imageRefLinkTest');
+        contentEditor.getSmallTextField('nt:base_ce:systemName').addNewValue('image-ref-link-test');
+
+        const picker = contentEditor
+            .getPickerField(contentTypes.imageReference.fieldNodeType, contentTypes.imageReference.multiple)
+            .open();
+        picker.getAccordionItem('picker-media').getTreeItem('files').click();
+        picker.getGrid().get().find(`div[data-sel-role-card="${imageName}"]`).dblclick({force: true});
+
+        contentEditor
+            .getPickerField(contentTypes.imageReference.fieldNodeType, contentTypes.imageReference.multiple)
+            .assertValue('myfile.png');
+        contentEditor.create();
+
+        // Verify the created content now appears in the content-folders listing
+        jcontent.switchToListMode();
+        jcontent.getTable().getRowByName('image-ref-link-test');
+
+        // Clean up
+        deleteNode(`/sites/${siteKey}/contents/image-ref-link-test`);
+        deleteNode(`/sites/${siteKey}/files/${imageName}`);
+    });
+
+    it('Can replace a file using the "Replace with" action', function () {
+        const fileName = 'myfile.png';
+
+        cy.loginAndStoreSession();
+        jcontent = JContent.visit(siteKey, 'en', 'media/files');
+        const media = jcontent.getMedia().open();
+
+        // Create a dedicated folder and navigate into it
+        media.createFolder('media/files', 'replaceWithTest').visitFolder();
+
+        // Upload the initial image
+        const file = media.uploadFileViaDialog(fileName, 'assets/uploadMedia');
+
+        // Replace its content with a different file via the "Replace with" action
+        file.replaceWith('cypress/fixtures/assets/uploadMedia/myfile2.png');
+
+        // The replace should complete successfully
+        cy.get('[data-cm-role="upload-status-success"]').should('be.visible');
+        cy.get('[data-cm-role="upload-close-button"]').click();
+
+        // The node keeps its original name and no new node is created
+        jcontent.getGrid().getCardByName(fileName).get().should('be.visible');
+        cy.get('[data-cm-role="grid-content-list-card"][data-sel-role-card="myfile2.png"]').should('not.exist');
+        cy.get('[data-cm-role="grid-content-list-card"]').should('have.length', 1);
+
+        // Clean up
+        deleteNode(`/sites/${siteKey}/files/replaceWithTest`);
     });
 });

--- a/tests/cypress/e2e/pageBuilder/contentViews.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/contentViews.cy.ts
@@ -24,7 +24,7 @@ describe('Page builder - content views', () => {
     const richTextB = 'richtextB';
     const newsName = 'newsA';
 
-    const linkSelector = (name: string) => `a[href$="/${name}.html"]`;
+    const linkSelector = (name: string) => `a[href*="/${name}."][href$=".html"]`;
 
     const selectView = (contentEditor: ContentEditor, fieldName: string, view: string) => {
         const field = contentEditor.getField(ChoiceListField, fieldName);
@@ -157,7 +157,7 @@ describe('Page builder - content views', () => {
 
         cy.log('Publish the page and verify the links in live');
         publishAndWaitJobEnding(pagePath, ['en']);
-        cy.visit(`${pagePath}.html`);
+        cy.visit(`/cms/render/live/en${pagePath}.html`);
         [richTextA, richTextB, newsName].forEach(name => {
             cy.get(linkSelector(name)).should('exist');
         });

--- a/tests/cypress/e2e/pageBuilder/contentViews.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/contentViews.cy.ts
@@ -23,19 +23,20 @@ describe('Page builder - content views', () => {
     const richTextA = 'richtextA';
     const richTextB = 'richtextB';
     const newsName = 'newsA';
+    const newsVanityUrl = '/news/news-a-title';
 
     const linkSelector = (name: string) => `a[href$="/${name}.html"]`;
 
-    const assertRenderedLinks = (names: string[]) => {
+    const assertRenderedLinks = (targets: string[]) => {
         cy.get('body').should($body => {
             const hrefs = [...$body.find('a[href]')].map(a => a.getAttribute('href')).join(' , ');
-            const newsDefaultView = $body.find('.newsListItem').length > 0;
-            names.forEach(name => {
-                expect(hrefs, `link to ${name} (news default view rendered: ${newsDefaultView}) among`)
-                    .to.contain(`/${name}.`);
+            targets.forEach(target => {
+                expect(hrefs, `link to ${target} among`).to.contain(target);
             });
         });
     };
+
+    const renderedLinkTargets = [`/${richTextA}.html`, `/${richTextB}.html`, newsVanityUrl];
 
     const selectView = (contentEditor: ContentEditor, fieldName: string, view: string) => {
         const field = contentEditor.getField(ChoiceListField, fieldName);
@@ -162,11 +163,11 @@ describe('Page builder - content views', () => {
     it('renders contents as links in preview and in live', () => {
         cy.log('Verify the links in preview');
         cy.visit(`/cms/render/default/en${pagePath}.html`);
-        assertRenderedLinks([richTextA, richTextB, newsName]);
+        assertRenderedLinks(renderedLinkTargets);
 
         cy.log('Publish the page and verify the links in live');
         publishAndWaitJobEnding(pagePath, ['en']);
         cy.visit(`/cms/render/live/en${pagePath}.html`);
-        assertRenderedLinks([richTextA, richTextB, newsName]);
+        assertRenderedLinks(renderedLinkTargets);
     });
 });

--- a/tests/cypress/e2e/pageBuilder/contentViews.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/contentViews.cy.ts
@@ -1,0 +1,165 @@
+import {
+    addNode,
+    createSite,
+    deleteSite,
+    Dropdown,
+    enableModule,
+    getComponent,
+    getComponentBySelector,
+    Menu,
+    publishAndWaitJobEnding
+} from '@jahia/cypress';
+import {ContentEditor, JContent, JContentPageBuilder} from '../../page-object';
+import {ChoiceListField} from '../../page-object/fields';
+
+describe('Page builder - content views', () => {
+    const siteKey = 'contentViewsSite';
+    const homePath = `/sites/${siteKey}/home`;
+    const pageName = 'contentViewsPage';
+    const pagePath = `${homePath}/${pageName}`;
+    const areaPath = `${pagePath}/area-main`;
+    const landingPath = `${pagePath}/landing`;
+
+    const richTextA = 'richtextA';
+    const richTextB = 'richtextB';
+    const newsName = 'newsA';
+
+    const linkSelector = (name: string) => `a[href$="/${name}.html"]`;
+
+    const selectView = (contentEditor: ContentEditor, fieldName: string, view: string) => {
+        const field = contentEditor.getField(ChoiceListField, fieldName);
+        field.get().scrollIntoView();
+        field.get().should('be.visible');
+
+        const dropdown = getComponent(Dropdown, field);
+        dropdown.get().click('right');
+        dropdown.get().find('.moonstone-menu').should('exist');
+        dropdown.get().find(`.moonstone-menuItem[data-value="${view}"]`).should('exist').trigger('click', {force: true});
+        field.assertSelected(view);
+    };
+
+    const visitPageBuilder = (): JContentPageBuilder => JContent
+        .visit(siteKey, 'en', `pages/home/${pageName}`)
+        .switchToPageBuilder();
+
+    const assertRenderedAsLink = (pageBuilder: JContentPageBuilder, parentPath: string, name: string) => {
+        const module = pageBuilder.getModule(`${parentPath}/${name}`);
+        module.get().scrollIntoView();
+        module.get().find(linkSelector(name)).should('exist');
+    };
+
+    before(() => {
+        createSite(siteKey, {
+            templateSet: 'dx-base-demo-templates',
+            serverName: 'localhost',
+            locale: 'en'
+        });
+        enableModule('news', siteKey);
+
+        addNode({
+            name: pageName,
+            parentPathOrId: homePath,
+            primaryNodeType: 'jnt:page',
+            properties: [
+                {name: 'jcr:title', value: 'Content views test page', language: 'en'},
+                {name: 'j:templateName', value: 'simple'}
+            ],
+            children: [
+                {
+                    name: 'landing',
+                    primaryNodeType: 'jnt:contentList',
+                    mixins: ['jmix:isAreaList'],
+                    children: [{
+                        name: richTextA,
+                        primaryNodeType: 'jnt:bigText',
+                        properties: [{name: 'text', value: 'Rich text A content', language: 'en'}]
+                    }]
+                },
+                {
+                    name: 'area-main',
+                    primaryNodeType: 'jnt:contentList',
+                    mixins: ['jmix:isAreaList'],
+                    children: [
+                        {
+                            name: richTextB,
+                            primaryNodeType: 'jnt:bigText',
+                            properties: [{name: 'text', value: 'Rich text B content', language: 'en'}]
+                        },
+                        {
+                            name: newsName,
+                            primaryNodeType: 'jnt:news',
+                            properties: [
+                                {name: 'jcr:title', value: 'News A title', language: 'en'},
+                                {name: 'desc', value: 'News A description', language: 'en'}
+                            ]
+                        }
+                    ]
+                }
+            ]
+        });
+    });
+
+    after(() => {
+        cy.logout();
+        deleteSite(siteKey);
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession();
+    });
+
+    it('renders richtextA as a link when its jmix:renderable view is set to "link"', () => {
+        let pageBuilder = visitPageBuilder();
+
+        cy.log('Open content editor for richtextA');
+        pageBuilder.getModule(`${landingPath}/${richTextA}`, false).contextMenu(true).selectByRole('edit');
+
+        cy.log('Activate the view option (jmix:renderable) in the layout section and select the link view');
+        const contentEditor = new ContentEditor();
+        contentEditor.openSection('layout');
+        contentEditor.toggleOption('jmix:renderable');
+        selectView(contentEditor, 'jmix:renderable_j:view', 'link');
+        contentEditor.save();
+
+        cy.log('Verify richtextA is rendered as a link');
+        pageBuilder = visitPageBuilder();
+        assertRenderedAsLink(pageBuilder, landingPath, richTextA);
+    });
+
+    it('renders the area sub contents as links when its sub content view is set to "link"', () => {
+        let pageBuilder = visitPageBuilder();
+
+        cy.log('Open content editor for the area');
+        const area = pageBuilder.getModule(areaPath, false);
+        area.get().scrollIntoView();
+        area.get().click('bottomLeft', {force: true});
+        area.getBox().getHeader().get().should('be.visible').rightclick({force: true});
+        getComponentBySelector(Menu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)').selectByRole('edit');
+
+        cy.log('Select the link view as sub content view (j:subNodesView) in the layout section');
+        const contentEditor = new ContentEditor();
+        contentEditor.openSection('layout');
+        selectView(contentEditor, 'jmix:renderableList_j:subNodesView', 'link');
+        contentEditor.save();
+
+        cy.log('Verify richtextB and the news are rendered as links');
+        pageBuilder = visitPageBuilder();
+        assertRenderedAsLink(pageBuilder, areaPath, richTextB);
+        assertRenderedAsLink(pageBuilder, areaPath, newsName);
+    });
+
+    it('renders contents as links in preview and in live', () => {
+        cy.log('Verify the links in preview');
+        cy.visit(`/cms/render/default/en${pagePath}.html`);
+        [richTextA, richTextB, newsName].forEach(name => {
+            cy.get(linkSelector(name)).should('exist');
+        });
+
+        cy.log('Publish the page and verify the links in live');
+        publishAndWaitJobEnding(pagePath, ['en']);
+        cy.visit(`${pagePath}.html`);
+        [richTextA, richTextB, newsName].forEach(name => {
+            cy.get(linkSelector(name)).should('exist');
+        });
+    });
+});

--- a/tests/cypress/e2e/pageBuilder/contentViews.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/contentViews.cy.ts
@@ -24,7 +24,18 @@ describe('Page builder - content views', () => {
     const richTextB = 'richtextB';
     const newsName = 'newsA';
 
-    const linkSelector = (name: string) => `a[href*="/${name}."][href$=".html"]`;
+    const linkSelector = (name: string) => `a[href$="/${name}.html"]`;
+
+    const assertRenderedLinks = (names: string[]) => {
+        cy.get('body').should($body => {
+            const hrefs = [...$body.find('a[href]')].map(a => a.getAttribute('href')).join(' , ');
+            const newsDefaultView = $body.find('.newsListItem').length > 0;
+            names.forEach(name => {
+                expect(hrefs, `link to ${name} (news default view rendered: ${newsDefaultView}) among`)
+                    .to.contain(`/${name}.`);
+            });
+        });
+    };
 
     const selectView = (contentEditor: ContentEditor, fieldName: string, view: string) => {
         const field = contentEditor.getField(ChoiceListField, fieldName);
@@ -151,15 +162,11 @@ describe('Page builder - content views', () => {
     it('renders contents as links in preview and in live', () => {
         cy.log('Verify the links in preview');
         cy.visit(`/cms/render/default/en${pagePath}.html`);
-        [richTextA, richTextB, newsName].forEach(name => {
-            cy.get(linkSelector(name)).should('exist');
-        });
+        assertRenderedLinks([richTextA, richTextB, newsName]);
 
         cy.log('Publish the page and verify the links in live');
         publishAndWaitJobEnding(pagePath, ['en']);
         cy.visit(`/cms/render/live/en${pagePath}.html`);
-        [richTextA, richTextB, newsName].forEach(name => {
-            cy.get(linkSelector(name)).should('exist');
-        });
+        assertRenderedLinks([richTextA, richTextB, newsName]);
     });
 });

--- a/tests/cypress/e2e/pageBuilder/orderingList.cy.ts
+++ b/tests/cypress/e2e/pageBuilder/orderingList.cy.ts
@@ -1,0 +1,192 @@
+import {
+    addNode,
+    createSite,
+    deleteSite,
+    Dropdown,
+    getComponent,
+    getComponentBySelector,
+    Menu
+} from '@jahia/cypress';
+import {ContentEditor, JContent, JContentPageBuilder} from '../../page-object';
+import {ChoiceListField} from '../../page-object/fields';
+
+describe('Page builder - ordering list', () => {
+    const siteKey = 'listOrderingPageSite';
+    const homePath = `/sites/${siteKey}/home`;
+    const pageName = 'listOrderingPage';
+    const pagePath = `${homePath}/${pageName}`;
+    const areaPath = `${pagePath}/area-main`;
+    const listPath = `${areaPath}/contributelist`;
+
+    const items = [
+        {name: 'bond', text: '007 is the real james bond'},
+        {name: 'dc-cool', text: 'Washington DC is cool'},
+        {name: 'dc-not-cool', text: 'Washington DC is not cool'},
+        {name: 'bleus', text: 'Allez les bleus!'},
+        {name: 'no-exist', text: '008 does not exist'},
+        {name: 'abcdefgh', text: 'abcdefgh'},
+        {name: 'punctuation', text: '!@#!@#!@#!@#'}
+    ];
+    const [bond, dcCool, dcNotCool, bleus, noExist, abcdefgh, punctuation] = items.map(item => item.name);
+
+    const creationOrder = [bond, dcCool, dcNotCool, bleus, noExist, abcdefgh, punctuation];
+    const textAscending = [punctuation, bond, noExist, abcdefgh, bleus, dcCool, dcNotCool];
+
+    const optionLabels: Record<string, string> = {
+        'jcr:created': 'Creation date',
+        text: 'Text',
+        asc: 'ascending',
+        desc: 'descending'
+    };
+
+    const visitPageBuilder = (): JContentPageBuilder => JContent
+        .visit(siteKey, 'en', `pages/home/${pageName}`)
+        .switchToPageBuilder();
+
+    const verifyOrder = (expected: string[]) => {
+        const list = visitPageBuilder().getModule(listPath, false);
+        list.get().scrollIntoView();
+        list.get().find(`[jahiatype="module"][path^="${listPath}/"]:not([type="placeholder"])`).then($modules => {
+            const names = [...$modules]
+                .map(module => module.getAttribute('path').substring(listPath.length + 1))
+                .filter(name => !name.includes('/'));
+            expect(names).to.deep.equal(expected);
+        });
+    };
+
+    const openListOrderingSection = (): ContentEditor => {
+        const list = visitPageBuilder().getModule(listPath, false);
+        list.get().scrollIntoView();
+        list.get().click('bottomLeft', {force: true});
+        list.getBox().getHeader().get().should('be.visible').rightclick({force: true});
+        getComponentBySelector(Menu, '#menuHolder .moonstone-menu:not(.moonstone-hidden)').selectByRole('edit');
+
+        const contentEditor = new ContentEditor();
+        contentEditor.switchToAdvancedMode();
+        contentEditor.openSection('listOrdering');
+        return contentEditor;
+    };
+
+    const selectChoice = (contentEditor: ContentEditor, fieldName: string, value: string) => {
+        const field = contentEditor.getField(ChoiceListField, fieldName);
+        field.get().scrollIntoView();
+        field.get().should('be.visible');
+
+        const dropdown = getComponent(Dropdown, field);
+        dropdown.get().click('right');
+        dropdown.get().find('.moonstone-menu').should('exist');
+        dropdown.get().find(`.moonstone-menuItem[data-value="${value}"]`).should('exist').trigger('click', {force: true});
+        field.assertSelected(optionLabels[value]);
+    };
+
+    const enableAutomaticOrdering = () => {
+        cy.get('[data-sel-role-automatic-ordering="jmix:orderedList"]')
+            .find('input[type="checkbox"]')
+            .then($checkbox => {
+                if (!$checkbox.is(':checked')) {
+                    cy.wrap($checkbox).click({force: true});
+                }
+            });
+    };
+
+    const moveItem = (contentEditor: ContentEditor, name: string, action: string) => {
+        const item = () => contentEditor.getSection('listOrdering').get().find(`[data-handler-id]:has(#${name})`);
+        item().scrollIntoView({offset: {left: 0, top: -100}});
+        item().should('be.visible').realHover();
+        item().find(`[data-sel-action^="${action}"]`).should('exist').click({force: true});
+    };
+
+    before(() => {
+        createSite(siteKey, {
+            templateSet: 'dx-base-demo-templates',
+            serverName: 'localhost',
+            locale: 'en'
+        });
+
+        addNode({
+            name: pageName,
+            parentPathOrId: homePath,
+            primaryNodeType: 'jnt:page',
+            properties: [
+                {name: 'jcr:title', value: 'List ordering test page', language: 'en'},
+                {name: 'j:templateName', value: 'simple'}
+            ],
+            children: [{
+                name: 'area-main',
+                primaryNodeType: 'jnt:contentList',
+                mixins: ['jmix:isAreaList'],
+                children: [{
+                    name: 'contributelist',
+                    primaryNodeType: 'jnt:contentList'
+                }]
+            }]
+        });
+
+        items.forEach(item => {
+            addNode({
+                name: item.name,
+                parentPathOrId: listPath,
+                primaryNodeType: 'jnt:bigText',
+                properties: [{name: 'text', value: item.text, language: 'en'}]
+            });
+        });
+    });
+
+    after(() => {
+        cy.logout();
+        deleteSite(siteKey);
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession();
+    });
+
+    it('renders the list in creation order when no ordering is configured', () => {
+        verifyOrder(creationOrder);
+    });
+
+    it('reorders the list manually', () => {
+        const contentEditor = openListOrderingSection();
+
+        moveItem(contentEditor, dcNotCool, 'moveToFirst');
+        moveItem(contentEditor, dcCool, 'moveToLast');
+        moveItem(contentEditor, punctuation, 'moveUp');
+        moveItem(contentEditor, bond, 'moveDown');
+        contentEditor.save();
+
+        verifyOrder([dcNotCool, bleus, bond, noExist, punctuation, abcdefgh, dcCool]);
+    });
+
+    it('orders the list automatically by creation date, descending', () => {
+        const contentEditor = openListOrderingSection();
+
+        enableAutomaticOrdering();
+        selectChoice(contentEditor, 'jmix:orderedList_firstField', 'jcr:created');
+        selectChoice(contentEditor, 'jmix:orderedList_firstDirection', 'desc');
+        contentEditor.save();
+
+        verifyOrder([...creationOrder].reverse());
+    });
+
+    it('orders the list automatically by text, ascending', () => {
+        const contentEditor = openListOrderingSection();
+
+        enableAutomaticOrdering();
+        selectChoice(contentEditor, 'jmix:orderedList_firstField', 'text');
+        selectChoice(contentEditor, 'jmix:orderedList_firstDirection', 'asc');
+        contentEditor.save();
+
+        verifyOrder(textAscending);
+    });
+
+    it('orders the list automatically by text, descending', () => {
+        const contentEditor = openListOrderingSection();
+
+        enableAutomaticOrdering();
+        selectChoice(contentEditor, 'jmix:orderedList_firstField', 'text');
+        selectChoice(contentEditor, 'jmix:orderedList_firstDirection', 'desc');
+        contentEditor.save();
+
+        verifyOrder([...textAscending].reverse());
+    });
+});

--- a/tests/cypress/fixtures/contentEditor/permissions/copyTranslatorRoleWithoutPublication.groovy
+++ b/tests/cypress/fixtures/contentEditor/permissions/copyTranslatorRoleWithoutPublication.groovy
@@ -1,0 +1,74 @@
+import org.jahia.services.content.JCRTemplate
+import javax.jcr.Node
+import javax.jcr.NodeIterator
+import javax.jcr.Property
+import javax.jcr.PropertyIterator
+
+// Copy the "translator" role to "translator-copy" and remove the "publication-start" permission
+// from the copied role and its sub-roles, so a user granted the copied role cannot publish.
+//
+// Role names are global and must stay unique. A plain deep Workspace.copy of /roles/translator
+// would momentarily persist sub-roles named exactly like the real ones (translator-en,
+// translator-fr, ...), which corrupts those real roles in Jahia's role registry. To avoid that we
+// build translator-copy explicitly and copy each sub-role DIRECTLY to its final, unique, grantable
+// name (translator-en -> translator-copy-translator-en), mirroring what the role manager UI does.
+def copyMixinsAndProperties(Node src, Node dest) {
+    src.getMixinNodeTypes().each { mixin ->
+        if (!dest.isNodeType(mixin.getName())) {
+            dest.addMixin(mixin.getName())
+        }
+    }
+    PropertyIterator props = src.getProperties()
+    while (props.hasNext()) {
+        Property p = props.nextProperty()
+        if (p.getDefinition().isProtected() || p.getName().startsWith('jcr:')) {
+            continue
+        }
+        try {
+            if (p.isMultiple()) {
+                dest.setProperty(p.getName(), p.getValues())
+            } else {
+                dest.setProperty(p.getName(), p.getValue())
+            }
+        } catch (Exception ignored) {
+            // Skip properties that cannot be copied (e.g. constrained/auto-created)
+        }
+    }
+}
+
+def stripPublicationStart(Node role) {
+    if (role.hasProperty('j:permissionNames')) {
+        List<String> perms = role.getProperty('j:permissionNames').getValues().collect { it.getString() }
+        if (perms.remove('publication-start')) {
+            role.setProperty('j:permissionNames', perms as String[])
+        }
+    }
+}
+
+JCRTemplate.getInstance().doExecuteWithSystemSession { session ->
+    Node roles = session.getNode('/roles')
+    Node translator = session.getNode('/roles/translator')
+
+    if (!session.nodeExists('/roles/translator-copy')) {
+        Node copy = roles.addNode('translator-copy', translator.getPrimaryNodeType().getName())
+        copyMixinsAndProperties(translator, copy)
+        // Persist the parent so Workspace.copy can target it below.
+        session.save()
+    }
+    stripPublicationStart(session.getNode('/roles/translator-copy'))
+
+    // Copy each sub-role straight to its unique grantable name, then strip publication-start.
+    NodeIterator subRoles = translator.getNodes()
+    while (subRoles.hasNext()) {
+        Node sub = subRoles.nextNode()
+        if (sub.isNodeType('jnt:role')) {
+            String targetPath = '/roles/translator-copy/translator-copy-' + sub.getName()
+            if (!session.nodeExists(targetPath)) {
+                session.getWorkspace().copy(sub.getPath(), targetPath)
+                session.refresh(false)
+            }
+            stripPublicationStart(session.getNode(targetPath))
+        }
+    }
+    session.save()
+}

--- a/tests/cypress/fixtures/contentEditor/permissions/deleteTranslatorCopyRole.groovy
+++ b/tests/cypress/fixtures/contentEditor/permissions/deleteTranslatorCopyRole.groovy
@@ -1,0 +1,11 @@
+import org.jahia.services.content.JCRTemplate
+
+// Remove the copied "translator-copy" role created for the test.
+// Roles live under the system /roles tree, which the JCR GraphQL API is not allowed to
+// mutate (returns 403), hence this system-session groovy script.
+JCRTemplate.getInstance().doExecuteWithSystemSession { session ->
+    if (session.nodeExists('/roles/translator-copy')) {
+        session.getNode('/roles/translator-copy').remove()
+        session.save()
+    }
+}

--- a/tests/cypress/fixtures/jcontent/getInvalidLanguages.graphql
+++ b/tests/cypress/fixtures/jcontent/getInvalidLanguages.graphql
@@ -1,0 +1,9 @@
+query getInvalidLanguages($path: String!) {
+    jcr {
+        nodeByPath(path: $path) {
+            invalidLanguages: property(name: "j:invalidLanguages") {
+                values
+            }
+        }
+    }
+}

--- a/tests/cypress/page-object/file.ts
+++ b/tests/cypress/page-object/file.ts
@@ -85,6 +85,12 @@ export class File extends BasePage {
         return this;
     }
 
+    replaceWith(fixturePath: string): File {
+        this.getGridCard().contextMenu().selectByRole('replaceFile');
+        cy.get('input#file-upload-input[type="file"]').selectFile(fixturePath, {force: true});
+        return this;
+    }
+
     markForDeletion(): File {
         this.getGridCard().contextMenu().selectByRole('delete');
         cy.get('[data-sel-role="delete-mark-button"]').click();


### PR DESCRIPTION
### Description
Move Selenium tests to Cypress.
It includes:
- testNoPublicationRight
- testLanguageRenderingOption
- testUploadImage
- testUploadNewVersionOfFile
- listOrderingTest
- testOrderByTextAscending
- testOrderByDateAscending
- testOrderByDateDescending
- testManualOrdering
- eventViewTest
- listViewTest
- listSubViewsTest

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
